### PR TITLE
Improve cluster login

### DIFF
--- a/auth/cluster_test.go
+++ b/auth/cluster_test.go
@@ -9,28 +9,11 @@ import (
 
 	infrastructure "github.com/ninech/apis/infrastructure/v1alpha1"
 	"github.com/ninech/nctl/api"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 
-	runtimev1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
-
-const newKubeconfig = `
-apiVersion: v1
-kind: Config
-clusters:
-- cluster:
-    server: https://new.example.org
-  name: new
-users:
-- name: new
-current-context: new
-contexts:
-- context:
-  name: new
-`
 
 const existingKubeconfig = `
 apiVersion: v1
@@ -66,9 +49,8 @@ func TestClusterCmd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	secret := clusterSecret()
-	cluster := newCluster(secret)
-	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, cluster).Build()
+	cluster := newCluster()
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
 
 	// we run without the execPlugin, that would be something for an e2e test
 	cmd := &ClusterCmd{Name: ContextName(cluster), ExecPlugin: false}
@@ -82,37 +64,29 @@ func TestClusterCmd(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	log.Printf("%s", b)
+
 	merged, err := clientcmd.Load(b)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	checkConfig(t, merged, 2, "new")
+	checkConfig(t, merged, 2, ContextName(cluster))
 }
 
-func clusterSecret() *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Data: map[string][]byte{
-			kubeconfigSecretKey: []byte(newKubeconfig),
-		},
-	}
-}
-
-func newCluster(secret *corev1.Secret) *infrastructure.KubernetesCluster {
+func newCluster() *infrastructure.KubernetesCluster {
 	return &infrastructure.KubernetesCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "test",
 		},
-		Spec: infrastructure.KubernetesClusterSpec{
-			ResourceSpec: runtimev1.ResourceSpec{
-				WriteConnectionSecretToReference: &runtimev1.SecretReference{
-					Name:      secret.Name,
-					Namespace: secret.Namespace,
+		Spec: infrastructure.KubernetesClusterSpec{},
+		Status: infrastructure.KubernetesClusterStatus{
+			AtProvider: infrastructure.KubernetesClusterObservation{
+				ClusterObservation: infrastructure.ClusterObservation{
+					APIEndpoint:   "https://new.example.org",
+					OIDCClientID:  "some-client-id",
+					OIDCIssuerURL: "https://auth.example.org",
 				},
 			},
 		},

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"path"
@@ -45,7 +46,7 @@ var (
 	defaultAuthTimeout   = 180 * time.Second
 )
 
-func (o *OIDCCmd) Run(ctx context.Context) error {
+func (o *OIDCCmd) Run(ctx context.Context, out io.Writer) error {
 	in := credentialplugin.Input{
 		Provider: oidc.Provider{
 			IssuerURL:    o.IssuerURL,
@@ -96,7 +97,7 @@ func (o *OIDCCmd) Run(ctx context.Context) error {
 		Logger:               logger,
 		TokenCacheRepository: &repository.Repository{},
 		Writer: &writer.Writer{
-			Stdout: os.Stdout,
+			Stdout: out,
 		},
 		Mutex: &mutex.Mutex{
 			Logger: logger,

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gobuffalo/flect v0.2.3
 	github.com/int128/kubelogin v1.25.3
 	github.com/lucasepe/codename v0.2.0
-	github.com/ninech/apis v0.0.0-20230309144709-d1d14d316770
+	github.com/ninech/apis v0.0.0-20230321122757-56502c35f76e
 	github.com/posener/complete v1.2.3
 	github.com/willabides/kongplete v0.3.0
 	k8s.io/api v0.25.3

--- a/go.sum
+++ b/go.sum
@@ -795,6 +795,10 @@ github.com/ninech/apis v0.0.0-20230309090302-9ed639d8fe58 h1:e8PRpyhxlk7e6HSj2oi
 github.com/ninech/apis v0.0.0-20230309090302-9ed639d8fe58/go.mod h1:pxBEpOWISbspDHCfzDddkv9CC8X11pbHMnKfQ782t2w=
 github.com/ninech/apis v0.0.0-20230309144709-d1d14d316770 h1:Yi6HMecGyMKT4PCqT9EyxJBKeZwFi+liN7QgLArmg9A=
 github.com/ninech/apis v0.0.0-20230309144709-d1d14d316770/go.mod h1:pxBEpOWISbspDHCfzDddkv9CC8X11pbHMnKfQ782t2w=
+github.com/ninech/apis v0.0.0-20230320134722-cddcd41f19e5 h1:815LwARwMbPHL6akqNaToh5aEnFCAPJrBbYEi1ImyQ0=
+github.com/ninech/apis v0.0.0-20230320134722-cddcd41f19e5/go.mod h1:pxBEpOWISbspDHCfzDddkv9CC8X11pbHMnKfQ782t2w=
+github.com/ninech/apis v0.0.0-20230321122757-56502c35f76e h1:Xi1L2hg1hCnjv+j8SpP6wl306kIiiG3WTwLpitbNd0M=
+github.com/ninech/apis v0.0.0-20230321122757-56502c35f76e/go.mod h1:pxBEpOWISbspDHCfzDddkv9CC8X11pbHMnKfQ782t2w=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 	}
 
 	if strings.HasPrefix(kongCtx.Command(), auth.OIDCCmdName) {
-		kongCtx.FatalIfErrorf(nctl.Auth.OIDC.Run(ctx))
+		kongCtx.FatalIfErrorf(nctl.Auth.OIDC.Run(ctx, os.Stdout))
 		return
 	}
 


### PR DESCRIPTION
* Instead of calling nctl itself via exec, the auth oidc command is executed internally using kong to parse the args.
* The cluster login is now reusing the apiConfig to construct the kubeconfig without needing to access the cluster secret.