### PR TITLE
login: Do not switch the CurrentContext on auth login

### DIFF
--- a/auth/cluster.go
+++ b/auth/cluster.go
@@ -62,7 +62,7 @@ func (a *ClusterCmd) Run(ctx context.Context, client *api.Client) error {
 		return fmt.Errorf("unable to create kubeconfig: %w", err)
 	}
 
-	if err := login(cfg, client.KubeconfigPath, runExecPlugin(a.ExecPlugin)); err != nil {
+	if err := login(cfg, client.KubeconfigPath, runExecPlugin(a.ExecPlugin), switchCurrentContext()); err != nil {
 		return fmt.Errorf("error logging in to cluster %s: %w", name, err)
 	}
 

--- a/auth/cluster_test.go
+++ b/auth/cluster_test.go
@@ -64,8 +64,6 @@ func TestClusterCmd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	log.Printf("%s", b)
-
 	merged, err := clientcmd.Load(b)
 	if err != nil {
 		t.Fatal(err)

--- a/auth/config.go
+++ b/auth/config.go
@@ -20,8 +20,6 @@ func mergeConfig(from, to *clientcmdapi.Config) {
 	for k, v := range from.Contexts {
 		to.Contexts[k] = v
 	}
-
-	to.CurrentContext = from.CurrentContext
 }
 
 func RemoveClusterFromConfig(client *api.Client, clusterContext string) error {

--- a/auth/login_test.go
+++ b/auth/login_test.go
@@ -42,7 +42,7 @@ func TestLoginCmd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	checkConfig(t, merged, 2, apiHost)
+	checkConfig(t, merged, 2, "existing")
 }
 
 func checkConfig(t *testing.T, cfg *clientcmdapi.Config, expectedLen int, expectedContext string) {


### PR DESCRIPTION
When just logging into nctl with auth login, we don't want to change the CurrentContext of the existing kubeconfig as this is probably more confusing to the user than anything. When logging into a cluster, we keep the current behaviour and switch the CurrentContext.