### PR TITLE
Add generic crud of resources

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/ninech/apis"
-	iam "github.com/ninech/apis/iam/v1alpha1"
-	infrastructure "github.com/ninech/apis/infrastructure/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -45,13 +43,13 @@ func New(apiClusterContext, namespace string) (*Client, error) {
 		return nil, err
 	}
 
-	// we statically define a RESTMapper in order to avoid slow discovery
-	mapper := meta.NewDefaultRESTMapper(scheme.PrioritizedVersionsAllGroups())
-	mapper.Add(infrastructure.KubernetesClusterGroupVersionKind, meta.RESTScopeNamespace)
-	mapper.Add(iam.APIServiceAccountGroupVersionKind, meta.RESTScopeNamespace)
+	mapper := apis.StaticRESTMapper(scheme)
 	mapper.Add(corev1.SchemeGroupVersion.WithKind("Secret"), meta.RESTScopeNamespace)
 
-	c, err := runtimeclient.NewWithWatch(client.Config, runtimeclient.Options{Scheme: scheme, Mapper: mapper})
+	c, err := runtimeclient.NewWithWatch(client.Config, runtimeclient.Options{
+		Scheme: scheme,
+		Mapper: mapper,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/api/client.go
+++ b/api/client.go
@@ -147,3 +147,7 @@ func loadConfigWithContext(apiServerURL string, loader clientcmd.ClientConfigLoa
 	cfg, err := clientConfig.ClientConfig()
 	return cfg, ns, err
 }
+
+func ObjectName(obj runtimeclient.Object) types.NamespacedName {
+	return types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+}

--- a/apply/apply.go
+++ b/apply/apply.go
@@ -1,0 +1,6 @@
+package apply
+
+type Cmd struct {
+	Filename string   `short:"f" predictor:"file"`
+	FromFile fromFile `cmd:"" default:"1" name:"-f <file>" help:"Apply any resource from a yaml or json file."`
+}

--- a/apply/file.go
+++ b/apply/file.go
@@ -1,0 +1,115 @@
+package apply
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/ninech/nctl/api"
+	"golang.org/x/exp/maps"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type fromFile struct {
+}
+
+func (cmd *Cmd) Run(ctx context.Context, client *api.Client, apply *Cmd) error {
+	return File(ctx, client, apply.Filename, UpdateOnExists())
+}
+
+type Option func(*config)
+
+type config struct {
+	updateOnExists bool
+	delete         bool
+}
+
+func UpdateOnExists() Option {
+	return func(c *config) {
+		c.updateOnExists = true
+	}
+}
+
+func Delete() Option {
+	return func(c *config) {
+		c.delete = true
+	}
+}
+
+func File(ctx context.Context, client *api.Client, filename string, opts ...Option) error {
+	if len(filename) == 0 {
+		return fmt.Errorf("missing flag -f, --filename=STRING")
+	}
+
+	cfg := &config{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+
+	obj := &unstructured.Unstructured{}
+	if err := yaml.NewYAMLOrJSONDecoder(f, 4096).Decode(obj); err != nil {
+		return err
+	}
+
+	if cfg.delete {
+		if err := client.Delete(ctx, obj); err != nil {
+			return err
+		}
+		printSuccessMessage("deleted", obj)
+
+		return nil
+	}
+
+	if err := client.Create(ctx, obj); err != nil {
+		if errors.IsAlreadyExists(err) && cfg.updateOnExists {
+			return update(ctx, client, obj)
+		}
+		return err
+	}
+
+	printSuccessMessage("created", obj)
+	return nil
+}
+
+func update(ctx context.Context, client *api.Client, obj *unstructured.Unstructured) error {
+	oldObj := &unstructured.Unstructured{}
+	oldObj.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
+	if err := client.Get(ctx, api.ObjectName(obj), oldObj); err != nil {
+		return err
+	}
+
+	// merge annotations/labels
+	annotations, labels := oldObj.GetAnnotations(), oldObj.GetLabels()
+	maps.Copy(annotations, obj.GetAnnotations())
+	maps.Copy(labels, obj.GetLabels())
+	obj.SetAnnotations(annotations)
+	obj.SetLabels(labels)
+
+	// preserve finalizers
+	obj.SetFinalizers(append(obj.GetFinalizers(), oldObj.GetFinalizers()...))
+	// ensure resource version is up to date
+	obj.SetResourceVersion(oldObj.GetResourceVersion())
+
+	if err := client.Update(ctx, obj); err != nil {
+		return err
+	}
+
+	printSuccessMessage("applied", obj)
+	return nil
+}
+
+func printSuccessMessage(message string, obj client.Object) {
+	fmt.Printf(
+		" ✓ %s %s %s/%s\n", message,
+		obj.GetObjectKind().GroupVersionKind().Kind,
+		obj.GetName(), obj.GetNamespace(),
+	)
+}

--- a/apply/file_test.go
+++ b/apply/file_test.go
@@ -1,0 +1,190 @@
+package apply
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	runtimev1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	iam "github.com/ninech/apis/iam/v1alpha1"
+	"github.com/ninech/nctl/api"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	apiServiceAccountYAML = `kind: APIServiceAccount
+apiVersion: iam.nine.ch/v1alpha1
+metadata:
+  name: %s
+  namespace: default
+  annotations:
+    key: %s
+spec:
+  deletionPolicy: "%s"
+`
+	apiServiceAccountJSON = `{
+    "apiVersion": "iam.nine.ch/v1alpha1",
+    "kind": "APIServiceAccount",
+    "metadata": {
+        "name": "%s",
+        "namespace": "default",
+        "annotations": {
+            "key": "%s"
+        }
+    },
+    "spec": {
+      "deletionPolicy": "%s"
+    }
+}
+`
+	missingKindResourceYAML = `
+apiVersion: nope.nine.ch/v1alpha1
+metadata:
+  name: %s
+  namespace: default
+  annotations:
+    key: %s
+spec: {}
+`
+
+	invalidResourceJSON = `
+{wat}
+`
+)
+
+func TestFile(t *testing.T) {
+	scheme, err := api.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	apiClient := &api.Client{WithWatch: client, Namespace: "default"}
+
+	ctx := context.Background()
+
+	tests := map[string]struct {
+		name              string
+		file              string
+		update            bool
+		updatedAnnotation string
+		updatedSpecValue  string
+		expectedErr       bool
+		delete            bool
+	}{
+		"create from yaml": {
+			file: apiServiceAccountYAML,
+		},
+		"create from json": {
+			file: apiServiceAccountJSON,
+		},
+		"apply from yaml": {
+			file:              apiServiceAccountYAML,
+			update:            true,
+			updatedAnnotation: "updated",
+			updatedSpecValue:  "Delete",
+		},
+		"apply from json": {
+			file:              apiServiceAccountJSON,
+			update:            true,
+			updatedAnnotation: "updated",
+			updatedSpecValue:  "Delete",
+		},
+		"create invalid yaml": {
+			file:        missingKindResourceYAML,
+			expectedErr: true,
+		},
+		"create invalid json": {
+			file:        invalidResourceJSON,
+			expectedErr: true,
+		},
+		"delete from yaml": {
+			name:   "delete-yaml",
+			file:   apiServiceAccountYAML,
+			delete: true,
+		},
+		"delete from json": {
+			name:   "delete-json",
+			file:   apiServiceAccountJSON,
+			delete: true,
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			f, err := os.CreateTemp("", "nctl-filetest*")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(f.Name())
+
+			if _, err := f.WriteString(fmt.Sprintf(tc.file, name, "value", runtimev1.DeletionOrphan)); err != nil {
+				t.Fatal(err)
+			}
+
+			opts := []Option{}
+
+			if tc.delete {
+				// we need to ensure that the resource exists before we can delete it
+				if err := File(ctx, apiClient, f.Name()); err != nil {
+					t.Fatal(err)
+				}
+				opts = append(opts, Delete())
+			}
+
+			if tc.update {
+				// we need to ensure that the resource exists before we can update
+				if err := File(ctx, apiClient, f.Name()); err != nil {
+					t.Fatal(err)
+				}
+
+				if err := f.Truncate(0); err != nil {
+					t.Fatal(err)
+				}
+
+				if _, err := f.Seek(0, 0); err != nil {
+					t.Fatal(err)
+				}
+
+				if _, err := f.WriteString(fmt.Sprintf(tc.file, name, tc.updatedAnnotation, tc.updatedSpecValue)); err != nil {
+					t.Fatal(err)
+				}
+
+				opts = append(opts, UpdateOnExists())
+			}
+
+			if err := File(ctx, apiClient, f.Name(), opts...); err != nil {
+				if tc.expectedErr {
+					return
+				}
+				t.Fatal(err)
+			} else if tc.expectedErr {
+				t.Fatalf("expected error, got nil")
+			}
+
+			asa := &iam.APIServiceAccount{}
+			if err := apiClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, asa); err != nil {
+				if tc.delete {
+					if !errors.IsNotFound(err) {
+						t.Fatalf("expected resource to not exist after delete, got %s", err)
+					}
+					return
+				}
+				t.Fatalf("expected asa %s to exist, got: %s", tc.name, err)
+			}
+
+			if tc.update && asa.GetAnnotations()["key"] != tc.updatedAnnotation {
+				t.Fatalf("expected annotation to be updated to %q, got %q",
+					tc.updatedAnnotation, asa.GetAnnotations()["key"])
+			}
+
+			if tc.update && asa.GetDeletionPolicy() != runtimev1.DeletionDelete {
+				t.Fatalf("expected spec.deletionPolicy to be updated to %q, got %q", "Delete", asa.GetDeletionPolicy())
+			}
+		})
+	}
+}

--- a/create/apiserviceaccount.go
+++ b/create/apiserviceaccount.go
@@ -21,7 +21,7 @@ func (asa *apiServiceAccountCmd) Run(ctx context.Context, client *api.Client) er
 	ctx, cancel := context.WithTimeout(ctx, asa.WaitTimeout)
 	defer cancel()
 
-	if err := c.createResource(ctx, asa.WaitTimeout, client); err != nil {
+	if err := c.createResource(ctx, client); err != nil {
 		return err
 	}
 

--- a/create/apiserviceaccount_test.go
+++ b/create/apiserviceaccount_test.go
@@ -1,0 +1,35 @@
+package create
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ninech/nctl/api"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestAPIServiceAccount(t *testing.T) {
+	scheme, err := api.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := apiServiceAccountCmd{
+		Wait:        false,
+		WaitTimeout: time.Second,
+	}
+
+	asa := cmd.newAPIServiceAccount("default")
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(asa).Build()
+	apiClient := &api.Client{WithWatch: client, Namespace: "default"}
+	ctx := context.Background()
+
+	if err := cmd.Run(ctx, apiClient); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := apiClient.Get(ctx, api.ObjectName(asa), asa); err != nil {
+		t.Fatalf("expected asa to exist, got: %s", err)
+	}
+}

--- a/create/create.go
+++ b/create/create.go
@@ -19,6 +19,8 @@ import (
 )
 
 type Cmd struct {
+	Filename          string               `short:"f" predictor:"file"`
+	FromFile          fromFile             `cmd:"" default:"1" name:"-f <file>" help:"Create any resource from a yaml or json file."`
 	VCluster          vclusterCmd          `cmd:"" name:"vcluster" help:"Create a new vcluster."`
 	APIServiceAccount apiServiceAccountCmd `cmd:"" name:"apiserviceaccount" aliases:"asa" help:"Create a new API Service Account."`
 }

--- a/create/create.go
+++ b/create/create.go
@@ -37,10 +37,7 @@ func newCreator(mg resource.Managed, resourceName string, objectList runtimeclie
 	return &creator{mg: mg, kind: resourceName, objectList: objectList}
 }
 
-func (c *creator) createResource(ctx context.Context, waitTimeout time.Duration, client *api.Client) error {
-	ctx, cancel := context.WithTimeout(ctx, waitTimeout)
-	defer cancel()
-
+func (c *creator) createResource(ctx context.Context, client *api.Client) error {
 	if err := client.Create(ctx, c.mg); err != nil {
 		return fmt.Errorf("unable to create %s %q: %w", c.kind, c.mg.GetName(), err)
 	}

--- a/create/create_test.go
+++ b/create/create_test.go
@@ -1,0 +1,83 @@
+package create
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	runtimev1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	iam "github.com/ninech/apis/iam/v1alpha1"
+	"github.com/ninech/nctl/api"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCreate(t *testing.T) {
+	scheme, err := api.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	asa := &iam.APIServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: iam.APIServiceAccountSpec{
+			ResourceSpec: runtimev1.ResourceSpec{
+				WriteConnectionSecretToReference: &runtimev1.SecretReference{
+					Name:      "test",
+					Namespace: "default",
+				},
+			},
+		},
+	}
+
+	c := newCreator(asa, "apiserviceaccount", &iam.APIServiceAccountList{})
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	apiClient := &api.Client{WithWatch: client, Namespace: "default"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	if err := c.createResource(ctx, apiClient); err != nil {
+		t.Fatal(err)
+	}
+
+	// to test the wait we create a ticker that continously updates our
+	// resource in a goroutine to simulate a controller doing the same
+	ticker := time.NewTicker(100 * time.Millisecond)
+	done := make(chan bool)
+	errChan := make(chan error, 1)
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				close(errChan)
+				return
+			case <-ticker.C:
+				if err := apiClient.Get(ctx, types.NamespacedName{Name: asa.Name, Namespace: asa.Namespace}, asa); err != nil {
+					errChan <- err
+				}
+
+				asa.SetConditions(runtimev1.Available())
+				if err := apiClient.Status().Update(ctx, asa); err != nil {
+					errChan <- err
+				}
+			}
+		}
+	}()
+
+	if err := c.wait(ctx, apiClient, resourceAvailable); err != nil {
+		t.Fatal(err)
+	}
+
+	ticker.Stop()
+	done <- true
+
+	for err := range errChan {
+		t.Fatal(err)
+	}
+}

--- a/create/file.go
+++ b/create/file.go
@@ -1,0 +1,15 @@
+package create
+
+import (
+	"context"
+
+	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/apply"
+)
+
+type fromFile struct {
+}
+
+func (cmd *fromFile) Run(ctx context.Context, client *api.Client, create *Cmd) error {
+	return apply.File(ctx, client, create.Filename)
+}

--- a/create/vcluster.go
+++ b/create/vcluster.go
@@ -30,7 +30,7 @@ func (vc *vclusterCmd) Run(ctx context.Context, client *api.Client) error {
 	ctx, cancel := context.WithTimeout(ctx, vc.WaitTimeout)
 	defer cancel()
 
-	if err := c.createResource(ctx, vc.WaitTimeout, client); err != nil {
+	if err := c.createResource(ctx, client); err != nil {
 		return err
 	}
 

--- a/create/vcluster_test.go
+++ b/create/vcluster_test.go
@@ -1,0 +1,35 @@
+package create
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ninech/nctl/api"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestVCluster(t *testing.T) {
+	scheme, err := api.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := vclusterCmd{
+		Wait:        false,
+		WaitTimeout: time.Second,
+	}
+
+	cluster := cmd.newCluster("default")
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+	apiClient := &api.Client{WithWatch: client, Namespace: "default"}
+	ctx := context.Background()
+
+	if err := cmd.Run(ctx, apiClient); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := apiClient.Get(ctx, api.ObjectName(cluster), cluster); err != nil {
+		t.Fatalf("expected vcluster to exist, got: %s", err)
+	}
+}

--- a/delete/delete.go
+++ b/delete/delete.go
@@ -15,6 +15,8 @@ import (
 )
 
 type Cmd struct {
+	Filename          string               `short:"f" predictor:"file"`
+	FromFile          fromFile             `cmd:"" default:"1" name:"-f <file>" help:"Delete any resource from a yaml or json file."`
 	VCluster          vclusterCmd          `cmd:"" name:"vcluster" help:"Delete a vcluster."`
 	APIServiceAccount apiServiceAccountCmd `cmd:"" name:"apiserviceaccount" aliases:"asa" help:"Delete a new API Service Account."`
 }

--- a/delete/file.go
+++ b/delete/file.go
@@ -1,0 +1,15 @@
+package delete
+
+import (
+	"context"
+
+	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/apply"
+)
+
+type fromFile struct {
+}
+
+func (cmd *fromFile) Run(ctx context.Context, client *api.Client, delete *Cmd) error {
+	return apply.File(ctx, client, delete.Filename, apply.Delete())
+}

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,10 @@ require (
 	github.com/int128/kubelogin v1.25.3
 	github.com/lucasepe/codename v0.2.0
 	github.com/mattn/go-isatty v0.0.18
-	github.com/ninech/apis v0.0.0-20230321122757-56502c35f76e
+	github.com/ninech/apis v0.0.0-20230405094104-05c6ac3c53c8
 	github.com/posener/complete v1.2.3
 	github.com/willabides/kongplete v0.3.0
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 	k8s.io/api v0.25.3
 	k8s.io/apimachinery v0.25.3
 	k8s.io/client-go v0.25.3

--- a/go.sum
+++ b/go.sum
@@ -792,8 +792,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/ninech/apis v0.0.0-20230321122757-56502c35f76e h1:Xi1L2hg1hCnjv+j8SpP6wl306kIiiG3WTwLpitbNd0M=
-github.com/ninech/apis v0.0.0-20230321122757-56502c35f76e/go.mod h1:pxBEpOWISbspDHCfzDddkv9CC8X11pbHMnKfQ782t2w=
+github.com/ninech/apis v0.0.0-20230405094104-05c6ac3c53c8 h1:bw/V45lioRL+XV7lsJnxMwxgsjrGp+uSYi6P1Tr7RA0=
+github.com/ninech/apis v0.0.0-20230405094104-05c6ac3c53c8/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -1139,6 +1139,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/alecthomas/kong"
 	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/apply"
 	"github.com/ninech/nctl/auth"
 	"github.com/ninech/nctl/create"
 	"github.com/ninech/nctl/delete"
@@ -29,6 +30,7 @@ type rootCommand struct {
 	Auth        auth.Cmd                     `cmd:"" help:"Authenticate with resource."`
 	Completions kongplete.InstallCompletions `cmd:"" help:"Print shell completions."`
 	Create      create.Cmd                   `cmd:"" help:"Create resource."`
+	Apply       apply.Cmd                    `cmd:"" help:"Apply resource."`
 	Delete      delete.Cmd                   `cmd:"" help:"Delete resource."`
 }
 


### PR DESCRIPTION
This adds a few new commands to enable CRUD of any resource on the API from a yaml or json file.

```bash
# create a resource
$ nctl create -f asa.yaml
# create or update a resource
$ nctl apply -f asa.yaml
# delete a resource
$ nctl delete -f asa.yaml
```