### PR TITLE
Add application create

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,9 @@ dnf install nctl
 
 * login to the API using `nctl auth login <cockpit account name>`
 * run `nctl --help` to get a list of all available commands
+
+## Deplo.io Beta
+
+Some commands in `nctl` interact with resources only available if you are part
+of the [deplo.io](https://deplo.io) beta. If you are interested you can read
+more about it and also sign up [here](https://deplo.io).

--- a/create/application.go
+++ b/create/application.go
@@ -1,0 +1,277 @@
+package create
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	runtimev1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	apps "github.com/ninech/apis/apps/v1alpha1"
+	"github.com/ninech/nctl/api"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/utils/pointer"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type applicationCmd struct {
+	Name        string            `arg:"" default:"" help:"Name of the application. A random name is generated if omitted."`
+	Wait        bool              `default:"true" help:"Wait until application is fully created."`
+	WaitTimeout time.Duration     `default:"10m" help:"Duration to wait for application getting ready. Only relevant if wait is set."`
+	GitURL      string            `required:"" help:"URL to the Git repository containing the application source. Both HTTPS and SSH formats are supported."`
+	GitSubPath  string            `help:"SubPath is a path in the git repo which contains the application code. If not given, the root directory of the git repo will be used."`
+	GitRevision string            `default:"main" help:"Revision defines the revision of the source to deploy the application to. This can be a commit, tag or branch."`
+	Size        string            `default:"micro" help:"Size of the app."`
+	Port        int32             `default:"8080" help:"Port the app is listening on."`
+	Replicas    int32             `default:"1" help:"Amount of replicas of the running app."`
+	Hosts       []string          `help:"Host names where the application can be accessed. If empty, the application will just be accessible on a generated host name on the deploio.app domain."`
+	Env         map[string]string `help:"Environment variables which are passed to the app at runtime."`
+}
+
+const (
+	applicationNameLabel = "application.apps.nine.ch/name"
+
+	buildStatusRunning = "running"
+	buildStatusSuccess = "success"
+	buildStatusError   = "error"
+	buildStatusUnknown = "unknown"
+
+	releaseStatusAvailable      = "available"
+	releaseStatusReplicaFailure = "replicaFailure"
+)
+
+func (app *applicationCmd) Run(ctx context.Context, client *api.Client) error {
+	fmt.Println("Creating a new application")
+	newApp := app.newApplication(client.Namespace)
+	c := newCreator(client, newApp, strings.ToLower(apps.ApplicationKind))
+	ctx, cancel := context.WithTimeout(ctx, app.WaitTimeout)
+	defer cancel()
+
+	if err := c.createResource(ctx); err != nil {
+		return err
+	}
+
+	if !app.Wait {
+		return nil
+	}
+
+	if err := c.wait(
+		ctx,
+		waitForBuildStart(newApp),
+		waitForBuildFinish(newApp),
+		waitForRelease(newApp),
+	); err != nil {
+		if buildErr, ok := err.(buildError); ok {
+			buildErr.printMessage()
+		}
+		if releaseErr, ok := err.(releaseError); ok {
+			releaseErr.printMessage()
+		}
+		return err
+	}
+
+	if err := client.Get(ctx, api.ObjectName(newApp), newApp); err != nil {
+		return err
+	}
+
+	fmt.Printf("\nYour application %q is now available at:\n  https://%s\n\n", newApp.Name, newApp.Status.AtProvider.CNAMETarget)
+
+	printUnverifiedHostsMessage(newApp)
+	return nil
+}
+
+func (app *applicationCmd) newApplication(namespace string) *apps.Application {
+	name := getName(app.Name)
+	size := apps.ApplicationSize(app.Size)
+	return &apps.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: apps.ApplicationSpec{
+			ResourceSpec: runtimev1.ResourceSpec{
+				WriteConnectionSecretToReference: &runtimev1.SecretReference{
+					Name:      name,
+					Namespace: namespace,
+				},
+			},
+			ForProvider: apps.ApplicationParameters{
+				Git: apps.ApplicationGitConfig{
+					GitTarget: apps.GitTarget{
+						URL:      app.GitURL,
+						SubPath:  app.GitSubPath,
+						Revision: app.GitRevision,
+					},
+				},
+				Hosts: app.Hosts,
+				Config: apps.Config{
+					Size:     &size,
+					Replicas: pointer.Int32Ptr(app.Replicas),
+					Port:     pointer.Int32Ptr(app.Port),
+					Env:      toEnvVars(app.Env),
+				},
+			},
+		},
+	}
+}
+
+func toEnvVars(env map[string]string) apps.EnvVars {
+	vars := apps.EnvVars{}
+	for k, v := range env {
+		vars = append(vars, apps.EnvVar{Name: k, Value: v})
+	}
+	return vars
+}
+
+type buildError struct {
+	build *apps.Build
+}
+
+func (b buildError) Error() string {
+	return fmt.Sprintf("build failed with status %s", b.build.Status.AtProvider.BuildStatus)
+}
+
+func (b buildError) printMessage() {
+	fmt.Printf("\nYour build has failed with status %q. To view the build logs run the command:\n",
+		b.build.Status.AtProvider.BuildStatus)
+	fmt.Printf("  nctl logs build %s\n\n", b.build.Name)
+}
+
+func waitForBuildStart(app *apps.Application) waitStage {
+	return waitStage{
+		kind:       strings.ToLower(apps.BuildKind),
+		objectList: &apps.BuildList{},
+		listOpts: []runtimeclient.ListOption{
+			runtimeclient.InNamespace(app.GetNamespace()),
+			runtimeclient.MatchingLabels{applicationNameLabel: app.GetName()},
+		},
+		waitMessage: &message{
+			text: "waiting for build to start",
+			icon: "⏳",
+		},
+		doneMessage: &message{
+			disabled: true,
+		},
+		onResult: func(e watch.Event) (bool, error) {
+			build, ok := e.Object.(*apps.Build)
+			if !ok {
+				return false, nil
+			}
+
+			switch build.Status.AtProvider.BuildStatus {
+			case buildStatusRunning:
+				return true, nil
+			case buildStatusError:
+				fallthrough
+			case buildStatusUnknown:
+				return false, buildError{build: build}
+			}
+
+			return false, nil
+		},
+	}
+}
+
+func waitForBuildFinish(app *apps.Application) waitStage {
+	return waitStage{
+		kind:       strings.ToLower(apps.BuildKind),
+		objectList: &apps.BuildList{},
+		listOpts: []runtimeclient.ListOption{
+			runtimeclient.InNamespace(app.GetNamespace()),
+			runtimeclient.MatchingLabels{applicationNameLabel: app.GetName()},
+		},
+		waitMessage: &message{
+			text: "building application",
+			icon: "📦",
+		},
+		doneMessage: &message{
+			disabled: true,
+		},
+		onResult: func(e watch.Event) (bool, error) {
+			build, ok := e.Object.(*apps.Build)
+			if !ok {
+				return false, nil
+			}
+
+			switch build.Status.AtProvider.BuildStatus {
+			case buildStatusSuccess:
+				return true, nil
+			case buildStatusError:
+				fallthrough
+			case buildStatusUnknown:
+				return false, buildError{build: build}
+			}
+
+			return false, nil
+		},
+	}
+}
+
+type releaseError struct {
+	release *apps.Release
+}
+
+func (r releaseError) Error() string {
+	return fmt.Sprintf("release failed with status %s", r.release.Status.AtProvider.ReleaseStatus)
+}
+
+func (r releaseError) printMessage() {
+	fmt.Printf("\nYour release has failed with status %q. To view the release logs run the command:\n",
+		r.release.Status.AtProvider.ReleaseStatus)
+	fmt.Printf("  nctl logs release %s\n\n", r.release.Name)
+}
+
+func waitForRelease(app *apps.Application) waitStage {
+	return waitStage{
+		kind:       strings.ToLower(apps.ReleaseKind),
+		objectList: &apps.ReleaseList{},
+		listOpts: []runtimeclient.ListOption{
+			runtimeclient.InNamespace(app.GetNamespace()),
+			runtimeclient.MatchingLabels{applicationNameLabel: app.GetName()},
+		},
+		waitMessage: &message{
+			text: "releasing application",
+			icon: "🚦",
+		},
+		doneMessage: &message{
+			text: "release available",
+			icon: "⛺",
+		},
+		onResult: func(e watch.Event) (bool, error) {
+			release, ok := e.Object.(*apps.Release)
+			if !ok {
+				return false, nil
+			}
+
+			switch release.Status.AtProvider.ReleaseStatus {
+			case releaseStatusAvailable:
+				return true, nil
+			case releaseStatusReplicaFailure:
+				return false, releaseError{release: release}
+			}
+
+			return false, nil
+		},
+	}
+}
+
+func printUnverifiedHostsMessage(app *apps.Application) {
+	unverifiedHosts := []string{}
+	for _, host := range app.Status.AtProvider.Hosts {
+		if host.LatestSuccess == nil {
+			unverifiedHosts = append(unverifiedHosts, host.Name)
+		}
+	}
+
+	if len(unverifiedHosts) != 0 {
+		fmt.Println("You configured the following hosts:")
+
+		for _, name := range unverifiedHosts {
+			fmt.Printf("  %s\n", name)
+		}
+
+		fmt.Printf("\nTo make your app available on them, make sure they have a CNAME record targeting %q.\n",
+			app.Status.AtProvider.CNAMETarget)
+	}
+}

--- a/create/application_test.go
+++ b/create/application_test.go
@@ -1,0 +1,186 @@
+package create
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	runtimev1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	apps "github.com/ninech/apis/apps/v1alpha1"
+	"github.com/ninech/nctl/api"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestApplication(t *testing.T) {
+	scheme, err := api.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := applicationCmd{
+		Wait:        false,
+		Name:        "custom-name",
+		GitURL:      "https://github.com/ninech/doesnotexist.git",
+		GitSubPath:  "/my/app",
+		GitRevision: "superbug",
+		Size:        "mini",
+		Hosts:       []string{"custom.example.org", "custom2.example.org"},
+		Port:        1337,
+		Replicas:    42,
+		Env:         map[string]string{"hello": "world"},
+	}
+
+	app := cmd.newApplication("default")
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	apiClient := &api.Client{WithWatch: client, Namespace: "default"}
+
+	ctx := context.Background()
+	if err := cmd.Run(ctx, apiClient); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := apiClient.Get(ctx, api.ObjectName(app), app); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, cmd.Name, app.Name)
+	assert.Equal(t, cmd.GitURL, app.Spec.ForProvider.Git.URL)
+	assert.Equal(t, cmd.GitSubPath, app.Spec.ForProvider.Git.SubPath)
+	assert.Equal(t, cmd.GitRevision, app.Spec.ForProvider.Git.Revision)
+	assert.Equal(t, cmd.Hosts, app.Spec.ForProvider.Hosts)
+	assert.Equal(t, apps.ApplicationSize(cmd.Size), *app.Spec.ForProvider.Config.Size)
+	assert.Equal(t, int32(cmd.Port), *app.Spec.ForProvider.Config.Port)
+	assert.Equal(t, int32(cmd.Replicas), *app.Spec.ForProvider.Config.Replicas)
+	assert.Equal(t, toEnvVars(cmd.Env), app.Spec.ForProvider.Config.Env)
+}
+
+func TestApplicationWait(t *testing.T) {
+	scheme, err := api.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := applicationCmd{
+		Wait:        true,
+		WaitTimeout: time.Second * 5,
+		Name:        "some-name",
+	}
+	namespace := "default"
+
+	build := &apps.Build{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "any-name",
+			Namespace: namespace,
+			Labels: map[string]string{
+				applicationNameLabel: cmd.Name,
+			},
+		},
+	}
+
+	release := &apps.Release{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "another-name",
+			Namespace: namespace,
+			Labels: map[string]string{
+				applicationNameLabel: cmd.Name,
+			},
+		},
+	}
+
+	// throw in a second build/release to ensure it can handle it
+	build2 := *build
+	build2.Name = build2.Name + "-1"
+	release2 := *release
+	release2.Name = release2.Name + "-1"
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(build, &build2, release, &release2).Build()
+	apiClient := &api.Client{WithWatch: client, Namespace: namespace}
+
+	ctx := context.Background()
+
+	// to test the wait we create a ticker that continously updates our
+	// resources in a goroutine to simulate a controller doing the same
+	ticker := time.NewTicker(100 * time.Millisecond)
+	done := make(chan bool)
+	errors := make(chan error, 1)
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				close(errors)
+				return
+			case <-ticker.C:
+				app := &apps.Application{}
+				if err := apiClient.Get(ctx, types.NamespacedName{Name: cmd.Name, Namespace: namespace}, app); err != nil {
+					errors <- err
+				}
+
+				if err := setResourceCondition(ctx, apiClient, app, runtimev1.ReconcileSuccess()); err != nil {
+					errors <- err
+				}
+
+				app.Status.AtProvider.Hosts = []apps.VerificationStatus{{Name: "host.example.org"}}
+				app.Status.AtProvider.CNAMETarget = "some.target.example.org"
+				if err := apiClient.Status().Update(ctx, app); err != nil {
+					errors <- err
+				}
+
+				if err := setResourceCondition(ctx, apiClient, build, runtimev1.Available()); err != nil {
+					errors <- err
+				}
+
+				if err := setResourceCondition(ctx, apiClient, &build2, runtimev1.Available()); err != nil {
+					errors <- err
+				}
+
+				if err := apiClient.Get(ctx, api.ObjectName(build), build); err != nil {
+					errors <- err
+				}
+
+				build.Status.AtProvider.BuildStatus = buildStatusRunning
+				if err := apiClient.Status().Update(ctx, build); err != nil {
+					errors <- err
+				}
+
+				build.Status.AtProvider.BuildStatus = buildStatusSuccess
+				if err := apiClient.Status().Update(ctx, build); err != nil {
+					errors <- err
+				}
+
+				if err := setResourceCondition(ctx, apiClient, &release2, runtimev1.Available()); err != nil {
+					errors <- err
+				}
+
+				release.Status.AtProvider.ReleaseStatus = releaseStatusAvailable
+				if err := apiClient.Status().Update(ctx, release); err != nil {
+					errors <- err
+				}
+			}
+		}
+	}()
+
+	if err := cmd.Run(ctx, apiClient); err != nil {
+		t.Fatal(err)
+	}
+
+	ticker.Stop()
+	done <- true
+
+	for err := range errors {
+		t.Fatal(err)
+	}
+}
+
+func setResourceCondition(ctx context.Context, apiClient *api.Client, mg resource.Managed, condition runtimev1.Condition) error {
+	if err := apiClient.Get(ctx, api.ObjectName(mg), mg); err != nil {
+		return err
+	}
+
+	mg.SetConditions(condition)
+	return apiClient.Status().Update(ctx, mg)
+}

--- a/create/create.go
+++ b/create/create.go
@@ -22,6 +22,7 @@ type Cmd struct {
 	FromFile          fromFile             `cmd:"" default:"1" name:"-f <file>" help:"Create any resource from a yaml or json file."`
 	VCluster          vclusterCmd          `cmd:"" name:"vcluster" help:"Create a new vcluster."`
 	APIServiceAccount apiServiceAccountCmd `cmd:"" name:"apiserviceaccount" aliases:"asa" help:"Create a new API Service Account."`
+	Application       applicationCmd       `cmd:"" name:"application" aliases:"app" help:"Create a new deplo.io Application. (Beta - requires access)"`
 }
 
 // resultFunc is the function called on a watch event during creation. It
@@ -174,7 +175,7 @@ func (w *waitStage) wait(ctx context.Context, client *api.Client) error {
 			}
 		case <-ctx.Done():
 			msg := "timeout waiting for %s"
-			spinner.StopFailMessage(fmt.Sprintf(msg, w.kind))
+			spinner.StopFailMessage(format.ProgressMessagef("", msg, w.kind))
 			_ = spinner.StopFail()
 
 			return fmt.Errorf(msg, w.kind)

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	k8s.io/api v0.25.3
 	k8s.io/apimachinery v0.25.3
 	k8s.io/client-go v0.25.3
+	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 	sigs.k8s.io/controller-runtime v0.13.0
 )
 
@@ -83,7 +84,6 @@ require (
 	helm.sh/helm/v3 v3.6.3 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
-	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gobuffalo/flect v0.2.3
 	github.com/int128/kubelogin v1.25.3
 	github.com/lucasepe/codename v0.2.0
-	github.com/ninech/apis v0.0.0-20230405094104-05c6ac3c53c8
+	github.com/ninech/apis v0.0.0-20230510151919-2b04a7af4f60
 	github.com/posener/complete v1.2.3
 	github.com/theckman/yacspin v0.13.12
 	github.com/willabides/kongplete v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -796,8 +796,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/ninech/apis v0.0.0-20230405094104-05c6ac3c53c8 h1:bw/V45lioRL+XV7lsJnxMwxgsjrGp+uSYi6P1Tr7RA0=
-github.com/ninech/apis v0.0.0-20230405094104-05c6ac3c53c8/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
+github.com/ninech/apis v0.0.0-20230510151919-2b04a7af4f60 h1:Us1Jn9ciObUw5sLQ2LnfSWgKxzuXYwAekVYjV/cYs6o=
+github.com/ninech/apis v0.0.0-20230510151919-2b04a7af4f60/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/main.go
+++ b/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
+
 	"os"
 	"os/signal"
 	"strings"
 
 	"github.com/alecthomas/kong"
+
 	"github.com/ninech/nctl/api"
 	"github.com/ninech/nctl/apply"
 	"github.com/ninech/nctl/auth"


### PR DESCRIPTION
This adds the full app creation flow. By default it will wait until the application is fully built and released.

The args allow to configure all the settings that are currently available on the API.

The second commit retries the watch on failure. I noticed this during testing with the new API, whenever our staging env kills the watch (for whatever reason) it would fail silently and the wait would just timeout.

Note to the reviewer: Please install this branch locally and try it out against staging `nctl --api-cluster staging.nineapis.ch create app ...`.