### PR TITLE
Add project management

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -22,11 +22,12 @@ import (
 
 type Client struct {
 	runtimeclient.WithWatch
-	Config         *rest.Config
-	KubeconfigPath string
-	Namespace      string
-	Log            *log.Client
-	Token          string
+	Config            *rest.Config
+	KubeconfigPath    string
+	Namespace         string
+	Log               *log.Client
+	Token             string
+	KubeconfigContext string
 }
 
 type ClientOpt func(c *Client) error
@@ -37,7 +38,8 @@ type ClientOpt func(c *Client) error
 // * $HOME/.kube/config if exists
 func New(ctx context.Context, apiClusterContext, namespace string, opts ...ClientOpt) (*Client, error) {
 	client := &Client{
-		Namespace: namespace,
+		Namespace:         namespace,
+		KubeconfigContext: apiClusterContext,
 	}
 	if err := client.loadConfig(apiClusterContext); err != nil {
 		return nil, err
@@ -177,4 +179,8 @@ func loadConfigWithContext(apiServerURL string, loader clientcmd.ClientConfigLoa
 
 func ObjectName(obj runtimeclient.Object) types.NamespacedName {
 	return types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+}
+
+func NamespacedName(name, namespace string) types.NamespacedName {
+	return types.NamespacedName{Name: name, Namespace: namespace}
 }

--- a/api/util/apps.go
+++ b/api/util/apps.go
@@ -63,7 +63,7 @@ type GitAuth struct {
 	SSHPrivateKey *string
 }
 
-func (git GitAuth) Secret(name, namespace string) *corev1.Secret {
+func (git GitAuth) Secret(name, project string) *corev1.Secret {
 	data := map[string][]byte{}
 
 	if git.SSHPrivateKey != nil {
@@ -76,7 +76,7 @@ func (git GitAuth) Secret(name, namespace string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: project,
 		},
 		Data: data,
 	}

--- a/apply/file_test.go
+++ b/apply/file_test.go
@@ -62,7 +62,7 @@ func TestFile(t *testing.T) {
 	}
 
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
-	apiClient := &api.Client{WithWatch: client, Namespace: "default"}
+	apiClient := &api.Client{WithWatch: client, Project: "default"}
 
 	ctx := context.Background()
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,7 +1,8 @@
 package auth
 
 type Cmd struct {
-	Login   LoginCmd   `cmd:"" help:"Login to nineapis.ch."`
-	Cluster ClusterCmd `cmd:"" help:"Authenticate with Kubernetes Cluster."`
-	OIDC    OIDCCmd    `cmd:"" help:"Perform interactive OIDC login." hidden:""`
+	Login      LoginCmd      `cmd:"" help:"Login to nineapis.ch."`
+	Cluster    ClusterCmd    `cmd:"" help:"Authenticate with Kubernetes Cluster."`
+	OIDC       OIDCCmd       `cmd:"" help:"Perform interactive OIDC login." hidden:""`
+	SetProject SetProjectCmd `cmd:"" help:"Set the default project to be used."`
 }

--- a/auth/cluster.go
+++ b/auth/cluster.go
@@ -14,12 +14,12 @@ import (
 )
 
 type ClusterCmd struct {
-	Name       string `arg:"" help:"Name of the cluster to authenticate with. Also accepts 'name/namespace' format."`
+	Name       string `arg:"" help:"Name of the cluster to authenticate with. Also accepts 'name/project' format."`
 	ExecPlugin bool   `help:"Automatically run exec plugin after writing the kubeconfig."`
 }
 
 func (a *ClusterCmd) Run(ctx context.Context, client *api.Client) error {
-	name, err := clusterName(a.Name, client.Namespace)
+	name, err := clusterName(a.Name, client.Project)
 	if err != nil {
 		return err
 	}
@@ -69,18 +69,18 @@ func (a *ClusterCmd) Run(ctx context.Context, client *api.Client) error {
 	return nil
 }
 
-func clusterName(name, namespace string) (types.NamespacedName, error) {
+func clusterName(name, project string) (types.NamespacedName, error) {
 	parts := strings.Split(name, "/")
 	if len(parts) == 2 {
 		name = parts[0]
-		namespace = parts[1]
+		project = parts[1]
 	}
 
-	if namespace == "" {
-		return types.NamespacedName{}, fmt.Errorf("namespace cannot be empty")
+	if project == "" {
+		return types.NamespacedName{}, fmt.Errorf("project cannot be empty")
 	}
 
-	return types.NamespacedName{Name: name, Namespace: namespace}, nil
+	return types.NamespacedName{Name: name, Namespace: project}, nil
 }
 
 func ContextName(cluster *infrastructure.KubernetesCluster) string {

--- a/auth/config.go
+++ b/auth/config.go
@@ -131,6 +131,20 @@ func RemoveClusterFromKubeConfig(client *api.Client, clusterContext string) erro
 	return clientcmd.WriteToFile(*kubeconfig, client.KubeconfigPath)
 }
 
+// SetContextProject sets the given project in the given context of the kubeconfig
+func SetContextProject(kubeconfigPath string, contextName string, project string) error {
+	kubeconfig, err := clientcmd.LoadFromFile(kubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("kubeconfig not found: %w", err)
+	}
+	context, exists := kubeconfig.Contexts[contextName]
+	if !exists {
+		return fmt.Errorf("could not find cluster %q in kubeconfig", contextName)
+	}
+	context.Namespace = project
+	return clientcmd.WriteToFile(*kubeconfig, kubeconfigPath)
+}
+
 func readConfig(kubeconfigContent []byte, contextName string) (*Config, error) {
 	kubeconfig, err := clientcmd.Load(kubeconfigContent)
 	if err != nil {

--- a/auth/config.go
+++ b/auth/config.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 
@@ -56,7 +55,7 @@ func groupVersion() string {
 	return fmt.Sprintf("%s/%s", extensionGroup, extensionVersion)
 }
 
-func newConfig(organization string) *Config {
+func NewConfig(organization string) *Config {
 	return &Config{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       extensionKind,
@@ -66,9 +65,9 @@ func newConfig(organization string) *Config {
 	}
 }
 
-// toObject wraps a Config in a runtime.Unknown object which implements
+// ToObject wraps a Config in a runtime.Unknown object which implements
 // runtime.Object.
-func (e *Config) toObject() (runtime.Object, error) {
+func (e *Config) ToObject() (runtime.Object, error) {
 	raw, err := json.Marshal(e)
 	if err != nil {
 		return nil, err
@@ -141,9 +140,9 @@ func readConfig(kubeconfigContent []byte, contextName string) (*Config, error) {
 	if !exists {
 		return nil, fmt.Errorf("could not find context %q in kubeconfig", contextName)
 	}
-	extension, exists := context.Extensions[nctlExtensionName]
+	extension, exists := context.Extensions[NctlExtensionName]
 	if !exists {
-		return nil, errors.New("could not find config extension in kubeconfig")
+		return nil, ErrConfigNotFound
 	}
 	cfg, err := parseConfig(extension)
 	if err != nil {

--- a/auth/config.go
+++ b/auth/config.go
@@ -1,14 +1,105 @@
 package auth
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/ninech/nctl/api"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-func mergeConfig(from, to *clientcmdapi.Config) {
+const (
+	extensionKind    = "Config"
+	extensionGroup   = "nctl.nine.ch"
+	extensionVersion = "v1alpha1"
+)
+
+var (
+	// ErrConfigNotFound describes a missing nctl config in the kubeconfig
+	ErrConfigNotFound configError = "nctl config not found"
+)
+
+type configError string
+
+func (c configError) Error() string {
+	return string(c)
+}
+
+// IsConfigNotFoundError returns true if the nctl config could not be found in
+// the kubconfig context
+func IsConfigNotFoundError(err error) bool {
+	return err == ErrConfigNotFound
+}
+
+// ReloginNeeded returns an error which outputs the given err with a message
+// saying that a re-login is needed.
+func ReloginNeeded(err error) error {
+	return fmt.Errorf(
+		"%w, please re-login by executing %q",
+		err,
+		fmt.Sprintf("%s %s", os.Args[0], LoginCmdName),
+	)
+}
+
+// Config is used to store information in the kubeconfig context created
+type Config struct {
+	metav1.TypeMeta `json:",inline"`
+	Organization    string `json:"organization"`
+}
+
+func groupVersion() string {
+	return fmt.Sprintf("%s/%s", extensionGroup, extensionVersion)
+}
+
+func newConfig(organization string) *Config {
+	return &Config{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       extensionKind,
+			APIVersion: groupVersion(),
+		},
+		Organization: organization,
+	}
+}
+
+// toObject wraps a Config in a runtime.Unknown object which implements
+// runtime.Object.
+func (e *Config) toObject() (runtime.Object, error) {
+	raw, err := json.Marshal(e)
+	if err != nil {
+		return nil, err
+	}
+	u := runtime.Unknown{
+		Raw:         raw,
+		ContentType: runtime.ContentTypeJSON,
+	}
+
+	return &u, nil
+}
+
+func parseConfig(o runtime.Object) (*Config, error) {
+	u, is := o.(*runtime.Unknown)
+	if !is {
+		return nil, fmt.Errorf("can not handle underlying type %T", o)
+	}
+
+	m := &metav1.TypeMeta{}
+	if err := json.Unmarshal(u.Raw, m); err != nil {
+		return nil, fmt.Errorf("can not parse type meta of extension: %w", err)
+	}
+	if m.Kind != extensionKind || m.APIVersion != groupVersion() {
+		return nil, fmt.Errorf("can not parse extension with type meta %q", u.TypeMeta.String())
+	}
+
+	e := &Config{}
+	return e, json.Unmarshal(u.Raw, e)
+}
+
+func mergeKubeConfig(from, to *clientcmdapi.Config) {
 	for k, v := range from.Clusters {
 		to.Clusters[k] = v
 	}
@@ -22,7 +113,7 @@ func mergeConfig(from, to *clientcmdapi.Config) {
 	}
 }
 
-func RemoveClusterFromConfig(client *api.Client, clusterContext string) error {
+func RemoveClusterFromKubeConfig(client *api.Client, clusterContext string) error {
 	kubeconfig, err := clientcmd.LoadFromFile(client.KubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("kubeconfig not found: %w", err)
@@ -39,4 +130,33 @@ func RemoveClusterFromConfig(client *api.Client, clusterContext string) error {
 	kubeconfig.CurrentContext = ""
 
 	return clientcmd.WriteToFile(*kubeconfig, client.KubeconfigPath)
+}
+
+func readConfig(kubeconfigContent []byte, contextName string) (*Config, error) {
+	kubeconfig, err := clientcmd.Load(kubeconfigContent)
+	if err != nil {
+		return nil, fmt.Errorf("kubeconfig not found: %w", err)
+	}
+	context, exists := kubeconfig.Contexts[contextName]
+	if !exists {
+		return nil, fmt.Errorf("could not find context %q in kubeconfig", contextName)
+	}
+	extension, exists := context.Extensions[nctlExtensionName]
+	if !exists {
+		return nil, errors.New("could not find config extension in kubeconfig")
+	}
+	cfg, err := parseConfig(extension)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+func ReadConfig(kubeconfigPath string, contextName string) (*Config, error) {
+	content, err := os.ReadFile(kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+	return readConfig(content, contextName)
 }

--- a/auth/config_test.go
+++ b/auth/config_test.go
@@ -1,0 +1,46 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestConfigParsing(t *testing.T) {
+	cfg := newConfig("evilcorp")
+	objectCfg, err := cfg.toObject()
+	require.NoError(t, err)
+	kubeconfig := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"test": {
+				Server: "not.so.important",
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"test": {
+				Token: "blablubb",
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"test": {
+				Cluster:   "test",
+				AuthInfo:  "test",
+				Namespace: "whatever",
+				Extensions: map[string]runtime.Object{
+					nctlExtensionName: objectCfg,
+				},
+			},
+		},
+		CurrentContext: "test",
+	}
+
+	content, err := clientcmd.Write(kubeconfig)
+	require.NoError(t, err)
+
+	parsedCfg, err := readConfig(content, "test")
+	require.NoError(t, err)
+	require.Equal(t, parsedCfg.Organization, cfg.Organization)
+}

--- a/auth/login.go
+++ b/auth/login.go
@@ -25,7 +25,7 @@ type LoginCmd struct {
 
 const (
 	LoginCmdName      = "auth login"
-	nctlExtensionName = "nctl"
+	NctlExtensionName = "nctl"
 )
 
 func (l *LoginCmd) Run(ctx context.Context, command string) error {
@@ -100,7 +100,7 @@ func newAPIConfig(apiURL, issuerURL *url.URL, command, clientID string, opts ...
 		opt(cfg)
 	}
 
-	extension, err := newConfig(cfg.organization).toObject()
+	extension, err := NewConfig(cfg.organization).ToObject()
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func newAPIConfig(apiURL, issuerURL *url.URL, command, clientID string, opts ...
 				Cluster:  cfg.name,
 				AuthInfo: cfg.name,
 				Extensions: map[string]runtime.Object{
-					nctlExtensionName: extension,
+					NctlExtensionName: extension,
 				},
 			},
 		},

--- a/auth/login.go
+++ b/auth/login.go
@@ -55,7 +55,7 @@ func (l *LoginCmd) Run(ctx context.Context, command string) error {
 		return err
 	}
 
-	return login(ctx, cfg, loadingRules.GetDefaultFilename(), runExecPlugin(l.ExecPlugin), namespace(l.Organization))
+	return login(ctx, cfg, loadingRules.GetDefaultFilename(), runExecPlugin(l.ExecPlugin), project(l.Organization))
 }
 
 type apiConfig struct {
@@ -146,7 +146,7 @@ func newAPIConfig(apiURL, issuerURL *url.URL, command, clientID string, opts ...
 
 type loginConfig struct {
 	execPlugin           bool
-	namespace            string
+	project              string
 	switchCurrentContext bool
 }
 
@@ -159,10 +159,10 @@ func runExecPlugin(enabled bool) loginOption {
 	}
 }
 
-// namespace overrides the namespace in the new config
-func namespace(context string) loginOption {
+// project overrides the project in the new config
+func project(project string) loginOption {
 	return func(l *loginConfig) {
-		l.namespace = context
+		l.project = project
 	}
 }
 
@@ -180,8 +180,8 @@ func login(ctx context.Context, newConfig *clientcmdapi.Config, kubeconfigPath s
 		opt(loginConfig)
 	}
 
-	if loginConfig.namespace != "" && newConfig.Contexts[newConfig.CurrentContext] != nil {
-		newConfig.Contexts[newConfig.CurrentContext].Namespace = loginConfig.namespace
+	if loginConfig.project != "" && newConfig.Contexts[newConfig.CurrentContext] != nil {
+		newConfig.Contexts[newConfig.CurrentContext].Namespace = loginConfig.project
 	}
 
 	kubeconfig, err := clientcmd.LoadFromFile(kubeconfigPath)

--- a/auth/set_project.go
+++ b/auth/set_project.go
@@ -1,0 +1,15 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/ninech/nctl/api"
+)
+
+type SetProjectCmd struct {
+	Name string `arg:"" help:"Name of the default project to be used."`
+}
+
+func (s *SetProjectCmd) Run(ctx context.Context, client *api.Client) error {
+	return SetContextProject(client.KubeconfigPath, client.KubeconfigContext, s.Name)
+}

--- a/create/apiserviceaccount.go
+++ b/create/apiserviceaccount.go
@@ -17,7 +17,7 @@ type apiServiceAccountCmd struct {
 }
 
 func (asa *apiServiceAccountCmd) Run(ctx context.Context, client *api.Client) error {
-	c := newCreator(client, asa.newAPIServiceAccount(client.Namespace), iam.APIServiceAccountKind)
+	c := newCreator(client, asa.newAPIServiceAccount(client.Project), iam.APIServiceAccountKind)
 	ctx, cancel := context.WithTimeout(ctx, asa.WaitTimeout)
 	defer cancel()
 
@@ -35,18 +35,18 @@ func (asa *apiServiceAccountCmd) Run(ctx context.Context, client *api.Client) er
 	})
 }
 
-func (asa *apiServiceAccountCmd) newAPIServiceAccount(namespace string) *iam.APIServiceAccount {
+func (asa *apiServiceAccountCmd) newAPIServiceAccount(project string) *iam.APIServiceAccount {
 	name := getName(asa.Name)
 	return &iam.APIServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: project,
 		},
 		Spec: iam.APIServiceAccountSpec{
 			ResourceSpec: runtimev1.ResourceSpec{
 				WriteConnectionSecretToReference: &runtimev1.SecretReference{
 					Name:      name,
-					Namespace: namespace,
+					Namespace: project,
 				},
 			},
 		},

--- a/create/apiserviceaccount_test.go
+++ b/create/apiserviceaccount_test.go
@@ -25,7 +25,7 @@ func TestAPIServiceAccount(t *testing.T) {
 	asa.Name = "test"
 
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
-	apiClient := &api.Client{WithWatch: client, Namespace: "default"}
+	apiClient := &api.Client{WithWatch: client, Project: "default"}
 	ctx := context.Background()
 
 	if err := cmd.Run(ctx, apiClient); err != nil {

--- a/create/apiserviceaccount_test.go
+++ b/create/apiserviceaccount_test.go
@@ -16,12 +16,15 @@ func TestAPIServiceAccount(t *testing.T) {
 	}
 
 	cmd := apiServiceAccountCmd{
+		Name:        "test",
 		Wait:        false,
 		WaitTimeout: time.Second,
 	}
 
 	asa := cmd.newAPIServiceAccount("default")
-	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(asa).Build()
+	asa.Name = "test"
+
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 	apiClient := &api.Client{WithWatch: client, Namespace: "default"}
 	ctx := context.Background()
 

--- a/create/application.go
+++ b/create/application.go
@@ -54,7 +54,7 @@ const (
 
 func (app *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 	fmt.Println("Creating a new application")
-	newApp := app.newApplication(client.Namespace)
+	newApp := app.newApplication(client.Project)
 
 	auth := util.GitAuth{
 		Username:      app.Git.Username,
@@ -64,7 +64,7 @@ func (app *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 
 	if auth.Enabled() {
 		// for git auth we create a separate secret and then reference it in the app.
-		secret := auth.Secret(newApp.Name, client.Namespace)
+		secret := auth.Secret(newApp.Name, client.Project)
 		if err := client.Create(ctx, secret); err != nil {
 			return fmt.Errorf("unable to create git auth secret: %w", err)
 		}
@@ -117,14 +117,14 @@ func (app *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 	return nil
 }
 
-func (app *applicationCmd) newApplication(namespace string) *apps.Application {
+func (app *applicationCmd) newApplication(project string) *apps.Application {
 	name := getName(app.Name)
 	size := apps.ApplicationSize(app.Size)
 
 	return &apps.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: project,
 		},
 		Spec: apps.ApplicationSpec{
 			ForProvider: apps.ApplicationParameters{

--- a/create/application_test.go
+++ b/create/application_test.go
@@ -127,12 +127,12 @@ func TestApplicationWait(t *testing.T) {
 		WaitTimeout: time.Second * 5,
 		Name:        "some-name",
 	}
-	namespace := "default"
+	project := "default"
 
 	build := &apps.Build{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "any-name",
-			Namespace: namespace,
+			Namespace: project,
 			Labels: map[string]string{
 				util.ApplicationNameLabel: cmd.Name,
 			},
@@ -142,7 +142,7 @@ func TestApplicationWait(t *testing.T) {
 	release := &apps.Release{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "another-name",
-			Namespace: namespace,
+			Namespace: project,
 			Labels: map[string]string{
 				util.ApplicationNameLabel: cmd.Name,
 			},
@@ -176,7 +176,7 @@ func TestApplicationWait(t *testing.T) {
 				return
 			case <-ticker.C:
 				app := &apps.Application{}
-				if err := apiClient.Get(ctx, types.NamespacedName{Name: cmd.Name, Namespace: namespace}, app); err != nil {
+				if err := apiClient.Get(ctx, types.NamespacedName{Name: cmd.Name, Namespace: project}, app); err != nil {
 					errors <- err
 				}
 
@@ -242,12 +242,12 @@ func TestApplicationBuildFail(t *testing.T) {
 		WaitTimeout: time.Second * 5,
 		Name:        "some-name",
 	}
-	namespace := "default"
+	project := "default"
 
 	build := &apps.Build{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "any-name",
-			Namespace: namespace,
+			Namespace: project,
 			Labels: map[string]string{
 				util.ApplicationNameLabel: cmd.Name,
 			},
@@ -292,7 +292,7 @@ func TestApplicationBuildFail(t *testing.T) {
 			case <-ticker.C:
 				app := &apps.Application{ObjectMeta: metav1.ObjectMeta{
 					Name:      cmd.Name,
-					Namespace: namespace,
+					Namespace: project,
 				}}
 
 				if err := setResourceCondition(ctx, client, app, runtimev1.ReconcileSuccess()); err != nil {

--- a/create/create.go
+++ b/create/create.go
@@ -22,9 +22,9 @@ type Cmd struct {
 	FromFile          fromFile             `cmd:"" default:"1" name:"-f <file>" help:"Create any resource from a yaml or json file."`
 	VCluster          vclusterCmd          `cmd:"" group:"infrastructure.nine.ch" name:"vcluster" help:"Create a new vcluster."`
 	APIServiceAccount apiServiceAccountCmd `cmd:"" group:"iam.nine.ch" name:"apiserviceaccount" aliases:"asa" help:"Create a new API Service Account."`
-	Application       applicationCmd       `cmd:"" group:"deplo.io" name:"application" aliases:"app" help:"Create a new deplo.io Application. (Beta - requires access)"`
-	Config            configCmd            `cmd:"" group:"deplo.io" name:"config"  help:"Create a new deplo.io Project Configuration. (Beta - requires access)"`
 	Project           projectCmd           `cmd:"" group:"management.nine.ch" name:"project" help:"Create a new project."`
+	Config            configCmd            `cmd:"" group:"deplo.io" name:"config"  help:"Create a new deplo.io Project Configuration. (Beta - requires access)"`
+	Application       applicationCmd       `cmd:"" group:"deplo.io" name:"application" aliases:"app" help:"Create a new deplo.io Application. (Beta - requires access)"`
 }
 
 // resultFunc is the function called on a watch event during creation. It

--- a/create/create.go
+++ b/create/create.go
@@ -24,6 +24,7 @@ type Cmd struct {
 	APIServiceAccount apiServiceAccountCmd `cmd:"" group:"iam.nine.ch" name:"apiserviceaccount" aliases:"asa" help:"Create a new API Service Account."`
 	Application       applicationCmd       `cmd:"" group:"deplo.io" name:"application" aliases:"app" help:"Create a new deplo.io Application. (Beta - requires access)"`
 	Config            configCmd            `cmd:"" group:"deplo.io" name:"config"  help:"Create a new deplo.io Project Configuration. (Beta - requires access)"`
+	Project           projectCmd           `cmd:"" group:"management.nine.ch" name:"project" help:"Create a new project."`
 }
 
 // resultFunc is the function called on a watch event during creation. It

--- a/create/create_test.go
+++ b/create/create_test.go
@@ -36,7 +36,7 @@ func TestCreate(t *testing.T) {
 	}
 
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
-	apiClient := &api.Client{WithWatch: client, Namespace: "default"}
+	apiClient := &api.Client{WithWatch: client, Project: "default"}
 	c := newCreator(apiClient, asa, "apiserviceaccount")
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)

--- a/create/project.go
+++ b/create/project.go
@@ -47,11 +47,11 @@ func (proj *projectCmd) Run(ctx context.Context, client *api.Client) error {
 	})
 }
 
-func newProject(name, namespace string) *management.Project {
+func newProject(name, project string) *management.Project {
 	return &management.Project{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      getName(name),
-			Namespace: namespace,
+			Namespace: project,
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       management.ProjectKind,

--- a/create/project.go
+++ b/create/project.go
@@ -1,0 +1,61 @@
+package create
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	management "github.com/ninech/apis/management/v1alpha1"
+	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/auth"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type projectCmd struct {
+	Name        string        `arg:"" default:"" help:"Name of the project. A random name is generated if omitted."`
+	Wait        bool          `default:"true" help:"Wait until the project was fully created."`
+	WaitTimeout time.Duration `default:"10m" help:"Duration to wait for project getting ready. Only relevant if wait is set."`
+}
+
+func (app *projectCmd) Run(ctx context.Context, client *api.Client) error {
+	fmt.Println("Creating new project")
+	cfg, err := auth.ReadConfig(client.KubeconfigPath, client.KubeconfigContext)
+	if err != nil {
+		if auth.IsConfigNotFoundError(err) {
+			fmt.Println("necessary nctl config not found, please run 'nctl auth login' to re-login")
+			return err
+		}
+		return err
+	}
+	c := newCreator(client, newProject(app.Name, cfg.Organization), strings.ToLower(management.ProjectKind))
+	ctx, cancel := context.WithTimeout(ctx, app.WaitTimeout)
+	defer cancel()
+
+	if err := c.createResource(ctx); err != nil {
+		return err
+	}
+
+	if !app.Wait {
+		return nil
+	}
+
+	return c.wait(ctx, waitStage{
+		objectList: &management.ProjectList{},
+		onResult:   resourceAvailable,
+	})
+}
+
+func newProject(name, namespace string) *management.Project {
+	return &management.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getName(name),
+			Namespace: namespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       management.ProjectKind,
+			APIVersion: management.SchemeGroupVersion.String(),
+		},
+		Spec: management.ProjectSpec{},
+	}
+}

--- a/create/project_config.go
+++ b/create/project_config.go
@@ -19,7 +19,7 @@ type configCmd struct {
 }
 
 func (cmd *configCmd) Run(ctx context.Context, client *api.Client) error {
-	c := newCreator(client, cmd.newProjectConfig(client.Namespace), apps.ProjectConfigGroupKind)
+	c := newCreator(client, cmd.newProjectConfig(client.Project), apps.ProjectConfigGroupKind)
 
 	return c.createResource(ctx)
 }

--- a/create/project_config_test.go
+++ b/create/project_config_test.go
@@ -22,7 +22,7 @@ func TestProjectConfig(t *testing.T) {
 
 	cases := map[string]struct {
 		cmd         configCmd
-		namespace   string
+		project     string
 		checkConfig func(t *testing.T, cmd configCmd, cfg *apps.ProjectConfig)
 	}{
 		"all fields set": {
@@ -32,9 +32,9 @@ func TestProjectConfig(t *testing.T) {
 				Replicas: pointer.Int32(42),
 				Env:      &map[string]string{"key1": "val1"},
 			},
-			namespace: "namespace-1",
+			project: "namespace-1",
 			checkConfig: func(t *testing.T, cmd configCmd, cfg *apps.ProjectConfig) {
-				assert.Equal(t, apiClient.Namespace, cfg.Name)
+				assert.Equal(t, apiClient.Project, cfg.Name)
 				assert.Equal(t, apps.ApplicationSize(*cmd.Size), *cfg.Spec.ForProvider.Config.Size)
 				assert.Equal(t, *cmd.Port, *cfg.Spec.ForProvider.Config.Port)
 				assert.Equal(t, *cmd.Replicas, *cfg.Spec.ForProvider.Config.Replicas)
@@ -46,9 +46,9 @@ func TestProjectConfig(t *testing.T) {
 				Size:     pointer.String(string(test.AppMicro)),
 				Replicas: pointer.Int32(1),
 			},
-			namespace: "namespace-2",
+			project: "namespace-2",
 			checkConfig: func(t *testing.T, cmd configCmd, cfg *apps.ProjectConfig) {
-				assert.Equal(t, apiClient.Namespace, cfg.Name)
+				assert.Equal(t, apiClient.Project, cfg.Name)
 				assert.Equal(t, apps.ApplicationSize(*cmd.Size), *cfg.Spec.ForProvider.Config.Size)
 				assert.Nil(t, cfg.Spec.ForProvider.Config.Port)
 				assert.Equal(t, *cmd.Replicas, *cfg.Spec.ForProvider.Config.Replicas)
@@ -56,10 +56,10 @@ func TestProjectConfig(t *testing.T) {
 			},
 		},
 		"all fields not set": {
-			cmd:       configCmd{},
-			namespace: "namespace-3",
+			cmd:     configCmd{},
+			project: "namespace-3",
 			checkConfig: func(t *testing.T, cmd configCmd, cfg *apps.ProjectConfig) {
-				assert.Equal(t, apiClient.Namespace, cfg.Name)
+				assert.Equal(t, apiClient.Project, cfg.Name)
 				assert.Nil(t, cfg.Spec.ForProvider.Config.Size)
 				assert.Nil(t, cfg.Spec.ForProvider.Config.Port)
 				assert.Nil(t, cfg.Spec.ForProvider.Config.Replicas)
@@ -71,8 +71,8 @@ func TestProjectConfig(t *testing.T) {
 	for name, tc := range cases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			apiClient.Namespace = tc.namespace
-			cfg := tc.cmd.newProjectConfig(tc.namespace)
+			apiClient.Project = tc.project
+			cfg := tc.cmd.newProjectConfig(tc.project)
 
 			if err := tc.cmd.Run(ctx, apiClient); err != nil {
 				t.Fatal(err)

--- a/create/project_test.go
+++ b/create/project_test.go
@@ -1,0 +1,97 @@
+package create
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	management "github.com/ninech/apis/management/v1alpha1"
+	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/auth"
+	"github.com/ninech/nctl/internal/test"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestProjects(t *testing.T) {
+	ctx := context.Background()
+	projectName, contextName, organization := "testproject", "test", "evilcorp"
+	apiClient, err := test.SetupClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	kubeconfigPath, err := createTempKubeconfig(contextName, organization)
+	require.NoError(t, err)
+	defer os.Remove(kubeconfigPath)
+	apiClient.KubeconfigPath = kubeconfigPath
+	apiClient.KubeconfigContext = contextName
+
+	cmd := projectCmd{
+		Name:        projectName,
+		Wait:        false,
+		WaitTimeout: time.Second,
+	}
+
+	if err := cmd.Run(ctx, apiClient); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := apiClient.Get(
+		ctx,
+		api.NamespacedName(projectName, organization),
+		&management.Project{},
+	); err != nil {
+		t.Fatalf("expected project %q to exist, got: %s", "testproject", err)
+	}
+}
+
+func createTempKubeconfig(contextName, organization string) (string, error) {
+	cfg := auth.NewConfig(organization)
+	cfgObject, err := cfg.ToObject()
+	if err != nil {
+		return "", err
+	}
+	// create and open a temporary file
+	f, err := os.CreateTemp("", "kubeconfig-")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	kubeconfig := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			contextName: {
+				Server: "not.so.important",
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			contextName: {
+				Token: "not-valid",
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			contextName: {
+				Cluster:   contextName,
+				AuthInfo:  contextName,
+				Namespace: "default",
+				Extensions: map[string]runtime.Object{
+					auth.NctlExtensionName: cfgObject,
+				},
+			},
+		},
+		CurrentContext: contextName,
+	}
+
+	content, err := clientcmd.Write(kubeconfig)
+	if err != nil {
+		return "", err
+	}
+	if _, err = f.Write(content); err != nil {
+		return "", err
+	}
+
+	return f.Name(), nil
+}

--- a/create/project_test.go
+++ b/create/project_test.go
@@ -8,6 +8,7 @@ import (
 
 	management "github.com/ninech/apis/management/v1alpha1"
 	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/auth"
 	"github.com/ninech/nctl/internal/test"
 	"github.com/stretchr/testify/require"
 )
@@ -40,4 +41,26 @@ func TestProjects(t *testing.T) {
 	); err != nil {
 		t.Fatalf("expected project %q to exist, got: %s", "testproject", err)
 	}
+}
+
+func TestProjectsConfigErrors(t *testing.T) {
+	ctx := context.Background()
+	apiClient, err := test.SetupClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := projectCmd{
+		Name:        "testproject",
+		Wait:        false,
+		WaitTimeout: time.Second,
+	}
+	// there is no kubeconfig so we expect to fail
+	require.Error(t, cmd.Run(ctx, apiClient))
+
+	// we create a kubeconfig which does not contain a nctl config
+	// extension
+	kubeconfig, err := test.CreateTestKubeconfig(apiClient, "")
+	require.NoError(t, err)
+	defer os.Remove(kubeconfig)
+	require.ErrorIs(t, cmd.Run(ctx, apiClient), auth.ErrConfigNotFound)
 }

--- a/create/project_test.go
+++ b/create/project_test.go
@@ -8,26 +8,20 @@ import (
 
 	management "github.com/ninech/apis/management/v1alpha1"
 	"github.com/ninech/nctl/api"
-	"github.com/ninech/nctl/auth"
 	"github.com/ninech/nctl/internal/test"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 func TestProjects(t *testing.T) {
 	ctx := context.Background()
-	projectName, contextName, organization := "testproject", "test", "evilcorp"
+	projectName, organization := "testproject", "evilcorp"
 	apiClient, err := test.SetupClient()
 	if err != nil {
 		t.Fatal(err)
 	}
-	kubeconfigPath, err := createTempKubeconfig(contextName, organization)
+	kubeconfig, err := test.CreateTestKubeconfig(apiClient, organization)
 	require.NoError(t, err)
-	defer os.Remove(kubeconfigPath)
-	apiClient.KubeconfigPath = kubeconfigPath
-	apiClient.KubeconfigContext = contextName
+	defer os.Remove(kubeconfig)
 
 	cmd := projectCmd{
 		Name:        projectName,
@@ -46,52 +40,4 @@ func TestProjects(t *testing.T) {
 	); err != nil {
 		t.Fatalf("expected project %q to exist, got: %s", "testproject", err)
 	}
-}
-
-func createTempKubeconfig(contextName, organization string) (string, error) {
-	cfg := auth.NewConfig(organization)
-	cfgObject, err := cfg.ToObject()
-	if err != nil {
-		return "", err
-	}
-	// create and open a temporary file
-	f, err := os.CreateTemp("", "kubeconfig-")
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-
-	kubeconfig := clientcmdapi.Config{
-		Clusters: map[string]*clientcmdapi.Cluster{
-			contextName: {
-				Server: "not.so.important",
-			},
-		},
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			contextName: {
-				Token: "not-valid",
-			},
-		},
-		Contexts: map[string]*clientcmdapi.Context{
-			contextName: {
-				Cluster:   contextName,
-				AuthInfo:  contextName,
-				Namespace: "default",
-				Extensions: map[string]runtime.Object{
-					auth.NctlExtensionName: cfgObject,
-				},
-			},
-		},
-		CurrentContext: contextName,
-	}
-
-	content, err := clientcmd.Write(kubeconfig)
-	if err != nil {
-		return "", err
-	}
-	if _, err = f.Write(content); err != nil {
-		return "", err
-	}
-
-	return f.Name(), nil
 }

--- a/create/vcluster.go
+++ b/create/vcluster.go
@@ -26,7 +26,7 @@ type vclusterCmd struct {
 }
 
 func (vc *vclusterCmd) Run(ctx context.Context, client *api.Client) error {
-	cluster := vc.newCluster(client.Namespace)
+	cluster := vc.newCluster(client.Project)
 	c := newCreator(client, cluster, "vcluster")
 	ctx, cancel := context.WithTimeout(ctx, vc.WaitTimeout)
 	defer cancel()
@@ -59,18 +59,18 @@ func (vc *vclusterCmd) isAvailable(cluster *infrastructure.KubernetesCluster) bo
 	return isAvailable(cluster) && len(cluster.Status.AtProvider.APIEndpoint) != 0
 }
 
-func (vc *vclusterCmd) newCluster(namespace string) *infrastructure.KubernetesCluster {
+func (vc *vclusterCmd) newCluster(project string) *infrastructure.KubernetesCluster {
 	name := getName(vc.Name)
 	return &infrastructure.KubernetesCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: project,
 		},
 		Spec: infrastructure.KubernetesClusterSpec{
 			ResourceSpec: runtimev1.ResourceSpec{
 				WriteConnectionSecretToReference: &runtimev1.SecretReference{
 					Name:      name,
-					Namespace: namespace,
+					Namespace: project,
 				},
 			},
 			ForProvider: infrastructure.KubernetesClusterParameters{

--- a/create/vcluster_test.go
+++ b/create/vcluster_test.go
@@ -22,7 +22,7 @@ func TestVCluster(t *testing.T) {
 
 	cluster := cmd.newCluster("default")
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
-	apiClient := &api.Client{WithWatch: client, Namespace: "default"}
+	apiClient := &api.Client{WithWatch: client, Project: "default"}
 	ctx := context.Background()
 
 	if err := cmd.Run(ctx, apiClient); err != nil {

--- a/delete/apiserviceaccount.go
+++ b/delete/apiserviceaccount.go
@@ -26,7 +26,7 @@ func (asa *apiServiceAccountCmd) Run(ctx context.Context, client *api.Client) er
 		Namespace: client.Namespace,
 	}}
 
-	d := newDeleter(sa, iam.APIServiceAccountKind, noCleanup)
+	d := newDeleter(sa, iam.APIServiceAccountKind)
 
 	if err := d.deleteResource(ctx, client, asa.WaitTimeout, asa.Wait, asa.Force); err != nil {
 		return fmt.Errorf("error while deleting %s: %w", iam.APIServiceAccountKind, err)

--- a/delete/apiserviceaccount.go
+++ b/delete/apiserviceaccount.go
@@ -23,7 +23,7 @@ func (asa *apiServiceAccountCmd) Run(ctx context.Context, client *api.Client) er
 
 	sa := &iam.APIServiceAccount{ObjectMeta: metav1.ObjectMeta{
 		Name:      asa.Name,
-		Namespace: client.Namespace,
+		Namespace: client.Project,
 	}}
 
 	d := newDeleter(sa, iam.APIServiceAccountKind)

--- a/delete/application.go
+++ b/delete/application.go
@@ -24,7 +24,7 @@ func (app *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 	a := &apps.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      app.Name,
-			Namespace: client.Namespace,
+			Namespace: client.Project,
 		},
 	}
 

--- a/delete/application.go
+++ b/delete/application.go
@@ -28,7 +28,7 @@ func (app *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 		},
 	}
 
-	d := newDeleter(a, apps.ApplicationKind, noCleanup)
+	d := newDeleter(a, apps.ApplicationKind)
 
 	if err := d.deleteResource(ctx, client, app.WaitTimeout, app.Wait, app.Force); err != nil {
 		return fmt.Errorf("error while deleting %s: %w", apps.ApplicationKind, err)

--- a/delete/application_test.go
+++ b/delete/application_test.go
@@ -32,7 +32,7 @@ func TestApplication(t *testing.T) {
 	}
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).Build()
-	apiClient := &api.Client{WithWatch: client, Namespace: "default"}
+	apiClient := &api.Client{WithWatch: client, Project: "default"}
 
 	ctx := context.Background()
 	if err := cmd.Run(ctx, apiClient); err != nil {

--- a/delete/delete.go
+++ b/delete/delete.go
@@ -16,9 +16,9 @@ type Cmd struct {
 	FromFile          fromFile             `cmd:"" default:"1" name:"-f <file>" help:"Delete any resource from a yaml or json file."`
 	VCluster          vclusterCmd          `cmd:"" group:"infrastructure.nine.ch" name:"vcluster" help:"Delete a vcluster."`
 	APIServiceAccount apiServiceAccountCmd `cmd:"" group:"iam.nine.ch" name:"apiserviceaccount" aliases:"asa" help:"Delete an API Service Account."`
-	Application       applicationCmd       `cmd:"" group:"deplo.io" name:"application" aliases:"app" help:"Delete a deplo.io Application. (Beta - requires access)"`
-	Config            configCmd            `cmd:"" group:"deplo.io" name:"config" help:"Delete a deplo.io Project Configuration. (Beta - requires access)"`
 	Project           projectCmd           `cmd:"" group:"management.nine.ch" name:"project" aliases:"proj" help:"Delete a Project."`
+	Config            configCmd            `cmd:"" group:"deplo.io" name:"config" help:"Delete a deplo.io Project Configuration. (Beta - requires access)"`
+	Application       applicationCmd       `cmd:"" group:"deplo.io" name:"application" aliases:"app" help:"Delete a deplo.io Application. (Beta - requires access)"`
 }
 
 // cleanupFunc is called after the resource has been deleted in order to do

--- a/delete/delete.go
+++ b/delete/delete.go
@@ -18,28 +18,60 @@ type Cmd struct {
 	APIServiceAccount apiServiceAccountCmd `cmd:"" group:"iam.nine.ch" name:"apiserviceaccount" aliases:"asa" help:"Delete an API Service Account."`
 	Application       applicationCmd       `cmd:"" group:"deplo.io" name:"application" aliases:"app" help:"Delete a deplo.io Application. (Beta - requires access)"`
 	Config            configCmd            `cmd:"" group:"deplo.io" name:"config" help:"Delete a deplo.io Project Configuration. (Beta - requires access)"`
+	Project           projectCmd           `cmd:"" group:"management.nine.ch" name:"project" aliases:"proj" help:"Delete a Project."`
 }
 
 // cleanupFunc is called after the resource has been deleted in order to do
 // any sort of cleanups.
 type cleanupFunc func(client *api.Client) error
 
+// promptFunc can be used to create a special prompt when asking for deletion
+type promptFunc func(kind, name string) string
+
 type deleter struct {
 	kind    string
 	mg      resource.Managed
 	cleanup cleanupFunc
+	prompt  promptFunc
 }
 
-func newDeleter(mg resource.Managed, kind string, cleanup cleanupFunc) *deleter {
-	return &deleter{
+// deleterOption allows to set options for the deletion
+type deleterOption func(*deleter)
+
+func newDeleter(mg resource.Managed, kind string, opts ...deleterOption) *deleter {
+	d := &deleter{
 		kind:    kind,
 		mg:      mg,
-		cleanup: cleanup,
+		cleanup: noCleanup,
+		prompt:  defaultPrompt,
+	}
+	for _, opt := range opts {
+		opt(d)
+	}
+
+	return d
+}
+
+// cleanup allows to set a cleanup function
+func cleanup(cleanup cleanupFunc) deleterOption {
+	return func(d *deleter) {
+		d.cleanup = cleanup
+	}
+}
+
+// prompt allows to alter the deletion prompt
+func prompt(prompt promptFunc) deleterOption {
+	return func(d *deleter) {
+		d.prompt = prompt
 	}
 }
 
 func noCleanup(client *api.Client) error {
 	return nil
+}
+
+func defaultPrompt(kind, name string) string {
+	return fmt.Sprintf("do you really want to delete the %s %q?", kind, name)
 }
 
 func (d *deleter) deleteResource(ctx context.Context, client *api.Client, waitTimeout time.Duration, wait, force bool) error {
@@ -52,7 +84,7 @@ func (d *deleter) deleteResource(ctx context.Context, client *api.Client, waitTi
 	}
 
 	if !force {
-		ok, err := format.Confirmf("do you really want to delete the %s %q?", d.kind, d.mg.GetName())
+		ok, err := format.Confirmf(d.prompt(d.kind, d.mg.GetName()))
 		if err != nil {
 			return err
 		}

--- a/delete/delete_test.go
+++ b/delete/delete_test.go
@@ -29,7 +29,7 @@ func TestDeleter(t *testing.T) {
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(asa).Build()
 	apiClient := &api.Client{WithWatch: client, Namespace: "default"}
 	ctx := context.Background()
-	d := newDeleter(asa, iam.APIServiceAccountKind, noCleanup)
+	d := newDeleter(asa, iam.APIServiceAccountKind)
 
 	if err := d.deleteResource(ctx, apiClient, 0, false, true); err != nil {
 		t.Fatalf("error while deleting %s: %s", apps.ApplicationKind, err)

--- a/delete/delete_test.go
+++ b/delete/delete_test.go
@@ -27,7 +27,7 @@ func TestDeleter(t *testing.T) {
 	}
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(asa).Build()
-	apiClient := &api.Client{WithWatch: client, Namespace: "default"}
+	apiClient := &api.Client{WithWatch: client, Project: "default"}
 	ctx := context.Background()
 	d := newDeleter(asa, iam.APIServiceAccountKind)
 

--- a/delete/project.go
+++ b/delete/project.go
@@ -43,7 +43,7 @@ func (proj *projectCmd) Run(ctx context.Context, client *api.Client) error {
 
 	// we need to overwrite the namespace as projects are always in the
 	// main organization namespace
-	client.Namespace = cfg.Organization
+	client.Project = cfg.Organization
 
 	if err := d.deleteResource(ctx, client, proj.WaitTimeout, proj.Wait, proj.Force); err != nil {
 		return fmt.Errorf("error while deleting %s: %w", management.ProjectKind, err)

--- a/delete/project.go
+++ b/delete/project.go
@@ -1,0 +1,67 @@
+package delete
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	management "github.com/ninech/apis/management/v1alpha1"
+	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/auth"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type projectCmd struct {
+	Name        string        `arg:"" help:"Name of the Project."`
+	Force       bool          `default:"false" help:"Do not ask for confirmation of deletion."`
+	Wait        bool          `default:"true" help:"Wait until Project is fully deleted"`
+	WaitTimeout time.Duration `default:"60s" help:"Duration to wait for the deletion. Only relevant if wait is set."`
+}
+
+func (proj *projectCmd) Run(ctx context.Context, client *api.Client) error {
+	ctx, cancel := context.WithTimeout(ctx, proj.WaitTimeout)
+	defer cancel()
+
+	cfg, err := auth.ReadConfig(client.KubeconfigPath, client.KubeconfigContext)
+	if err != nil {
+		if auth.IsConfigNotFoundError(err) {
+			fmt.Println("necessary nctl config not found, please run 'nctl auth login' to re-login")
+			return err
+		}
+		return err
+	}
+
+	d := newDeleter(
+		&management.Project{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      proj.Name,
+				Namespace: cfg.Organization,
+			},
+		},
+		management.ProjectKind,
+		prompt(projectDeletePrompt(cfg.Organization)),
+	)
+
+	// we need to overwrite the namespace as projects are always in the
+	// main organization namespace
+	client.Namespace = cfg.Organization
+
+	if err := d.deleteResource(ctx, client, proj.WaitTimeout, proj.Wait, proj.Force); err != nil {
+		return fmt.Errorf("error while deleting %s: %w", management.ProjectKind, err)
+	}
+
+	return nil
+}
+
+func projectDeletePrompt(organization string) promptFunc {
+	return func(kind, name string) string {
+		return fmt.Sprintf("Deleting %s %q of organization %q will also destroy all resources within this %s."+
+			"\n\n !!! This can not be recovered !!! \n\n"+
+			"Do you really want to continue?",
+			kind,
+			name,
+			organization,
+			kind,
+		)
+	}
+}

--- a/delete/project.go
+++ b/delete/project.go
@@ -25,8 +25,7 @@ func (proj *projectCmd) Run(ctx context.Context, client *api.Client) error {
 	cfg, err := auth.ReadConfig(client.KubeconfigPath, client.KubeconfigContext)
 	if err != nil {
 		if auth.IsConfigNotFoundError(err) {
-			fmt.Println("necessary nctl config not found, please run 'nctl auth login' to re-login")
-			return err
+			return auth.ReloginNeeded(err)
 		}
 		return err
 	}

--- a/delete/project_config.go
+++ b/delete/project_config.go
@@ -22,12 +22,12 @@ func (cmd *configCmd) Run(ctx context.Context, client *api.Client) error {
 
 	c := &apps.ProjectConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      client.Namespace,
-			Namespace: client.Namespace,
+			Name:      client.Project,
+			Namespace: client.Project,
 		},
 	}
 
-	d := newDeleter(c, apps.ProjectConfigKind, noCleanup)
+	d := newDeleter(c, apps.ProjectConfigKind)
 
 	if err := d.deleteResource(ctx, client, cmd.WaitTimeout, cmd.Wait, cmd.Force); err != nil {
 		return fmt.Errorf("error while deleting %s: %w", apps.ProjectConfigKind, err)

--- a/delete/project_config_test.go
+++ b/delete/project_config_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 func TestProjectConfig(t *testing.T) {
-	namespace := "some-namespace"
+	project := "some-project"
 
 	cfg := &apps.ProjectConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      namespace,
-			Namespace: namespace,
+			Name:      project,
+			Namespace: project,
 		},
 		Spec: apps.ProjectConfigSpec{},
 	}
@@ -32,7 +32,7 @@ func TestProjectConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	apiClient.Namespace = namespace
+	apiClient.Project = project
 
 	ctx := context.Background()
 

--- a/delete/vcluster.go
+++ b/delete/vcluster.go
@@ -33,7 +33,7 @@ func (vc *vclusterCmd) Run(ctx context.Context, client *api.Client) error {
 	}
 
 	d := newDeleter(cluster, "vcluster", func(client *api.Client) error {
-		return auth.RemoveClusterFromConfig(client, auth.ContextName(cluster))
+		return auth.RemoveClusterFromKubeConfig(client, auth.ContextName(cluster))
 	})
 
 	if err := d.deleteResource(ctx, client, vc.WaitTimeout, vc.Wait, vc.Force); err != nil {

--- a/delete/vcluster.go
+++ b/delete/vcluster.go
@@ -32,9 +32,10 @@ func (vc *vclusterCmd) Run(ctx context.Context, client *api.Client) error {
 		return fmt.Errorf("supplied cluster %q is not a vcluster", auth.ContextName(cluster))
 	}
 
-	d := newDeleter(cluster, "vcluster", func(client *api.Client) error {
-		return auth.RemoveClusterFromKubeConfig(client, auth.ContextName(cluster))
-	})
+	d := newDeleter(cluster, "vcluster", cleanup(
+		func(client *api.Client) error {
+			return auth.RemoveClusterFromKubeConfig(client, auth.ContextName(cluster))
+		}))
 
 	if err := d.deleteResource(ctx, client, vc.WaitTimeout, vc.Wait, vc.Force); err != nil {
 		return fmt.Errorf("unable to delete vcluster: %w", err)

--- a/delete/vcluster.go
+++ b/delete/vcluster.go
@@ -23,7 +23,7 @@ func (vc *vclusterCmd) Run(ctx context.Context, client *api.Client) error {
 	defer cancel()
 
 	cluster := &infrastructure.KubernetesCluster{}
-	clusterName := types.NamespacedName{Name: vc.Name, Namespace: client.Namespace}
+	clusterName := types.NamespacedName{Name: vc.Name, Namespace: client.Project}
 	if err := client.Get(ctx, clusterName, cluster); err != nil {
 		return fmt.Errorf("unable to get vcluster %q: %w", cluster.Name, err)
 	}

--- a/get/apiserviceaccount.go
+++ b/get/apiserviceaccount.go
@@ -30,7 +30,7 @@ func (asa *apiServiceAccountsCmd) Run(ctx context.Context, client *api.Client, g
 	}
 
 	if len(asaList.Items) == 0 {
-		printEmptyMessage(iam.APIServiceAccountKind, client.Namespace)
+		printEmptyMessage(os.Stdout, iam.APIServiceAccountKind, client.Namespace)
 		return nil
 	}
 

--- a/get/apiserviceaccount.go
+++ b/get/apiserviceaccount.go
@@ -12,7 +12,7 @@ import (
 )
 
 type apiServiceAccountsCmd struct {
-	Name            string `arg:"" help:"Name of the API Service Account to get. If omitted all in the namespace will be listed." default:""`
+	Name            string `arg:"" help:"Name of the API Service Account to get. If omitted all in the project will be listed." default:""`
 	PrintToken      bool   `help:"Print the bearer token of the Account. Requires name to be set." default:"false"`
 	PrintKubeconfig bool   `help:"Print the kubeconfig of the Account. Requires name to be set." default:"false"`
 }
@@ -30,7 +30,7 @@ func (asa *apiServiceAccountsCmd) Run(ctx context.Context, client *api.Client, g
 	}
 
 	if len(asaList.Items) == 0 {
-		printEmptyMessage(os.Stdout, iam.APIServiceAccountKind, client.Namespace)
+		printEmptyMessage(os.Stdout, iam.APIServiceAccountKind, client.Project)
 		return nil
 	}
 

--- a/get/application.go
+++ b/get/application.go
@@ -13,7 +13,7 @@ import (
 )
 
 type applicationsCmd struct {
-	Name string `arg:"" help:"Name of the Application to get. If omitted all in the namespace will be listed." default:""`
+	Name string `arg:"" help:"Name of the Application to get. If omitted all in the project will be listed." default:""`
 	out  io.Writer
 }
 
@@ -25,7 +25,7 @@ func (cmd *applicationsCmd) Run(ctx context.Context, client *api.Client, get *Cm
 	}
 
 	if len(appList.Items) == 0 {
-		printEmptyMessage(cmd.out, apps.ApplicationKind, client.Namespace)
+		printEmptyMessage(cmd.out, apps.ApplicationKind, client.Project)
 		return nil
 	}
 

--- a/get/application.go
+++ b/get/application.go
@@ -25,7 +25,7 @@ func (cmd *applicationsCmd) Run(ctx context.Context, client *api.Client, get *Cm
 	}
 
 	if len(appList.Items) == 0 {
-		printEmptyMessage(apps.ApplicationKind, client.Namespace)
+		printEmptyMessage(cmd.out, apps.ApplicationKind, client.Namespace)
 		return nil
 	}
 

--- a/get/application_test.go
+++ b/get/application_test.go
@@ -40,7 +40,7 @@ func TestApplication(t *testing.T) {
 			return []string{o.GetName()}
 		}).
 		WithObjects(&app, &app2).Build()
-	apiClient := &api.Client{WithWatch: client, Namespace: "default"}
+	apiClient := &api.Client{WithWatch: client, Project: "default"}
 	ctx := context.Background()
 
 	buf := &bytes.Buffer{}

--- a/get/build.go
+++ b/get/build.go
@@ -23,8 +23,8 @@ import (
 )
 
 type buildCmd struct {
-	Name            string `arg:"" help:"Name of the Build to get. If omitted all in the namespace will be listed." default:""`
-	ApplicationName string `short:"a" help:"Name of the Application to get builds for. If omitted all in the namespace will be listed."`
+	Name            string `arg:"" help:"Name of the Build to get. If omitted all in the project will be listed." default:""`
+	ApplicationName string `short:"a" help:"Name of the Application to get builds for. If omitted all in the project will be listed."`
 	PullImage       bool   `help:"Pull the image of the build. Uses the local docker socket at the env DOCKER_HOST if set."`
 	out             io.Writer
 }
@@ -42,7 +42,7 @@ func (cmd *buildCmd) Run(ctx context.Context, client *api.Client, get *Cmd) erro
 	}
 
 	if len(buildList.Items) == 0 {
-		printEmptyMessage(cmd.out, apps.BuildKind, client.Namespace)
+		printEmptyMessage(cmd.out, apps.BuildKind, client.Project)
 		return nil
 	}
 

--- a/get/build.go
+++ b/get/build.go
@@ -42,7 +42,7 @@ func (cmd *buildCmd) Run(ctx context.Context, client *api.Client, get *Cmd) erro
 	}
 
 	if len(buildList.Items) == 0 {
-		printEmptyMessage(apps.BuildKind, client.Namespace)
+		printEmptyMessage(cmd.out, apps.BuildKind, client.Namespace)
 		return nil
 	}
 

--- a/get/build_test.go
+++ b/get/build_test.go
@@ -44,7 +44,7 @@ func TestBuild(t *testing.T) {
 			return []string{o.GetName()}
 		}).
 		WithObjects(&build, &build2).Build()
-	apiClient := &api.Client{WithWatch: client, Namespace: "default"}
+	apiClient := &api.Client{WithWatch: client, Project: "default"}
 	ctx := context.Background()
 
 	buf := &bytes.Buffer{}

--- a/get/clusters.go
+++ b/get/clusters.go
@@ -23,7 +23,7 @@ func (l *clustersCmd) Run(ctx context.Context, client *api.Client, get *Cmd) err
 	}
 
 	if len(clusterList.Items) == 0 {
-		printEmptyMessage(os.Stdout, infrastructure.KubernetesClusterKind, client.Namespace)
+		printEmptyMessage(os.Stdout, infrastructure.KubernetesClusterKind, client.Project)
 		return nil
 	}
 

--- a/get/clusters.go
+++ b/get/clusters.go
@@ -23,7 +23,7 @@ func (l *clustersCmd) Run(ctx context.Context, client *api.Client, get *Cmd) err
 	}
 
 	if len(clusterList.Items) == 0 {
-		printEmptyMessage(infrastructure.KubernetesClusterKind, client.Namespace)
+		printEmptyMessage(os.Stdout, infrastructure.KubernetesClusterKind, client.Namespace)
 		return nil
 	}
 

--- a/get/get.go
+++ b/get/get.go
@@ -20,6 +20,7 @@ type Cmd struct {
 	Builds             buildCmd              `cmd:"" group:"deplo.io" name:"builds" aliases:"build" help:"Get deplo.io Builds. (Beta - requires access)"`
 	Releases           releasesCmd           `cmd:"" group:"deplo.io" name:"releases" aliases:"release" help:"Get deplo.io Releases. (Beta - requires access)"`
 	Configs            configsCmd            `cmd:"" group:"deplo.io" name:"configs" aliases:"config" help:"Get deplo.io Project Configuration. (Beta - requires access)"`
+	Projects           projectCmd            `cmd:"" group:"management.nine.ch" name:"projects" aliases:"proj" help:"Get Projects."`
 
 	opts []runtimeclient.ListOption
 }

--- a/get/get.go
+++ b/get/get.go
@@ -16,11 +16,11 @@ type Cmd struct {
 	AllProjects        bool                  `help:"apply the get over all projects." short:"A"`
 	Clusters           clustersCmd           `cmd:"" group:"infrastructure.nine.ch" help:"Get Kubernetes Clusters."`
 	APIServiceAccounts apiServiceAccountsCmd `cmd:"" group:"iam.nine.ch" name:"apiserviceaccounts" aliases:"asa" help:"Get API Service Accounts."`
+	Projects           projectCmd            `cmd:"" group:"management.nine.ch" name:"projects" aliases:"proj" help:"Get Projects."`
 	Applications       applicationsCmd       `cmd:"" group:"deplo.io" name:"applications" aliases:"app,apps" help:"Get deplo.io Applications. (Beta - requires access)"`
 	Builds             buildCmd              `cmd:"" group:"deplo.io" name:"builds" aliases:"build" help:"Get deplo.io Builds. (Beta - requires access)"`
 	Releases           releasesCmd           `cmd:"" group:"deplo.io" name:"releases" aliases:"release" help:"Get deplo.io Releases. (Beta - requires access)"`
 	Configs            configsCmd            `cmd:"" group:"deplo.io" name:"configs" aliases:"config" help:"Get deplo.io Project Configuration. (Beta - requires access)"`
-	Projects           projectCmd            `cmd:"" group:"management.nine.ch" name:"projects" aliases:"proj" help:"Get Projects."`
 
 	opts []runtimeclient.ListOption
 }

--- a/get/get.go
+++ b/get/get.go
@@ -77,15 +77,21 @@ func (cmd *Cmd) writeTabRow(w io.Writer, namespace string, row ...string) {
 		fmt.Fprintf(w, "%s\t", namespace)
 	}
 
+	format := "%s\t"
+	// if there is just one element to be printed, we do not need a tab
+	// separator
+	if len(row) == 1 {
+		format = "%s"
+	}
 	for _, r := range row {
-		fmt.Fprintf(w, "%s\t", r)
+		fmt.Fprintf(w, format, r)
 	}
 	fmt.Fprintf(w, "\n")
 }
 
-func printEmptyMessage(kind, namespace string) {
+func printEmptyMessage(out io.Writer, kind, namespace string) {
 	if namespace == "" {
-		fmt.Printf("no %s found\n", flect.Pluralize(kind))
+		fmt.Fprintf(defaultOut(out), "no %s found\n", flect.Pluralize(kind))
 		return
 	}
 

--- a/get/get.go
+++ b/get/get.go
@@ -13,7 +13,7 @@ import (
 
 type Cmd struct {
 	Output             output                `help:"Configures list output. ${enum}" short:"o" enum:"full,no-header,contexts,yaml" default:"full"`
-	AllNamespaces      bool                  `help:"apply the get over all namespaces." short:"A"`
+	AllProjects        bool                  `help:"apply the get over all projects." short:"A"`
 	Clusters           clustersCmd           `cmd:"" group:"infrastructure.nine.ch" help:"Get Kubernetes Clusters."`
 	APIServiceAccounts apiServiceAccountsCmd `cmd:"" group:"iam.nine.ch" name:"apiserviceaccounts" aliases:"asa" help:"Get API Service Accounts."`
 	Applications       applicationsCmd       `cmd:"" group:"deplo.io" name:"applications" aliases:"app,apps" help:"Get deplo.io Applications. (Beta - requires access)"`
@@ -55,27 +55,27 @@ func (cmd *Cmd) list(ctx context.Context, client *api.Client, list runtimeclient
 		opt(cmd)
 	}
 
-	if !cmd.AllNamespaces {
-		cmd.opts = append(cmd.opts, runtimeclient.InNamespace(client.Namespace))
+	if !cmd.AllProjects {
+		cmd.opts = append(cmd.opts, runtimeclient.InNamespace(client.Project))
 	}
 
 	return client.List(ctx, list, cmd.opts...)
 }
 
-// writeHeader writes the header row, prepending the namespace row if
-// cmd.AllNamespaces is set.
+// writeHeader writes the header row, prepending the project row if
+// cmd.AllProjects is set.
 func (cmd *Cmd) writeHeader(w io.Writer, headings ...string) {
-	if cmd.AllNamespaces {
-		headings = append([]string{"NAMESPACE"}, headings...)
+	if cmd.AllProjects {
+		headings = append([]string{"PROJECT"}, headings...)
 	}
 	cmd.writeTabRow(w, "", headings...)
 }
 
-// writeTabRow writes a row to w, prepending the namespace if
-// cmd.AllNamespaces is set and the namespace is not empty.
-func (cmd *Cmd) writeTabRow(w io.Writer, namespace string, row ...string) {
-	if cmd.AllNamespaces && len(namespace) != 0 {
-		fmt.Fprintf(w, "%s\t", namespace)
+// writeTabRow writes a row to w, prepending the project if
+// cmd.AllProjects is set and the project is not empty.
+func (cmd *Cmd) writeTabRow(w io.Writer, project string, row ...string) {
+	if cmd.AllProjects && len(project) != 0 {
+		fmt.Fprintf(w, "%s\t", project)
 	}
 
 	format := "%s\t"
@@ -90,13 +90,13 @@ func (cmd *Cmd) writeTabRow(w io.Writer, namespace string, row ...string) {
 	fmt.Fprintf(w, "\n")
 }
 
-func printEmptyMessage(out io.Writer, kind, namespace string) {
-	if namespace == "" {
+func printEmptyMessage(out io.Writer, kind, project string) {
+	if project == "" {
 		fmt.Fprintf(defaultOut(out), "no %s found\n", flect.Pluralize(kind))
 		return
 	}
 
-	fmt.Printf("no %s found in namespace %s\n", flect.Pluralize(kind), namespace)
+	fmt.Printf("no %s found in project %s\n", flect.Pluralize(kind), project)
 }
 
 func defaultOut(out io.Writer) io.Writer {

--- a/get/project.go
+++ b/get/project.go
@@ -28,8 +28,8 @@ func (proj *projectCmd) Run(ctx context.Context, client *api.Client, get *Cmd) e
 
 	// projects can only be created in the main organization project so we
 	// only need to search there
-	client.Namespace = cfg.Organization
-	get.AllNamespaces = false
+	client.Project = cfg.Organization
+	get.AllProjects = false
 
 	projectList := &management.ProjectList{}
 	if err := get.list(ctx, client, projectList, matchName(proj.Name)); err != nil {

--- a/get/project.go
+++ b/get/project.go
@@ -2,7 +2,6 @@ package get
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"sort"
 	"text/tabwriter"
@@ -22,8 +21,7 @@ func (proj *projectCmd) Run(ctx context.Context, client *api.Client, get *Cmd) e
 	cfg, err := auth.ReadConfig(client.KubeconfigPath, client.KubeconfigContext)
 	if err != nil {
 		if auth.IsConfigNotFoundError(err) {
-			fmt.Println("necessary nctl config not found, please run 'nctl auth login' to re-login")
-			return err
+			return auth.ReloginNeeded(err)
 		}
 		return err
 	}

--- a/get/project.go
+++ b/get/project.go
@@ -1,0 +1,91 @@
+package get
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"text/tabwriter"
+
+	management "github.com/ninech/apis/management/v1alpha1"
+	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/auth"
+	"github.com/ninech/nctl/internal/format"
+)
+
+type projectCmd struct {
+	Name string `arg:"" help:"Name of the project to get. If omitted all projects will be listed." default:""`
+	out  io.Writer
+}
+
+func (proj *projectCmd) Run(ctx context.Context, client *api.Client, get *Cmd) error {
+	cfg, err := auth.ReadConfig(client.KubeconfigPath, client.KubeconfigContext)
+	if err != nil {
+		if auth.IsConfigNotFoundError(err) {
+			fmt.Println("necessary nctl config not found, please run 'nctl auth login' to re-login")
+			return err
+		}
+		return err
+	}
+
+	// projects can only be created in the main organization project so we
+	// only need to search there
+	client.Namespace = cfg.Organization
+	get.AllNamespaces = false
+
+	projectList := &management.ProjectList{}
+	if err := get.list(ctx, client, projectList, matchName(proj.Name)); err != nil {
+		return err
+	}
+
+	if len(projectList.Items) == 0 {
+		printEmptyMessage(proj.out, management.ProjectKind, "")
+		return nil
+	}
+
+	// we sort alphabetically to have a deterministic output
+	sort.Slice(
+		projectList.Items,
+		func(i, j int) bool {
+			return projectList.Items[i].Name < projectList.Items[j].Name
+		},
+	)
+
+	switch get.Output {
+	case full:
+		return printProject(projectList.Items, get, defaultOut(proj.out), true)
+	case noHeader:
+		return printProject(projectList.Items, get, defaultOut(proj.out), false)
+	case yamlOut:
+		return format.PrettyPrintObjects(
+			projectList.GetItems(),
+			format.PrintOpts{
+				Out:               proj.out,
+				ExcludeAdditional: projectYamlExcludes(),
+			},
+		)
+	}
+
+	return nil
+}
+
+func printProject(projects []management.Project, get *Cmd, out io.Writer, header bool) error {
+	w := tabwriter.NewWriter(out, 0, 0, 4, ' ', 0)
+
+	if header {
+		get.writeHeader(w, "NAME")
+	}
+
+	for _, proj := range projects {
+		get.writeTabRow(w, "", proj.Name)
+	}
+
+	return w.Flush()
+}
+
+func projectYamlExcludes() [][]string {
+	return [][]string{
+		{"spec"},
+		{"status"},
+	}
+}

--- a/get/project_config.go
+++ b/get/project_config.go
@@ -23,8 +23,8 @@ func (cmd *configsCmd) Run(ctx context.Context, client *api.Client, get *Cmd) er
 
 	var opts []listOpt
 
-	if !get.AllNamespaces {
-		opts = []listOpt{matchName(client.Namespace)}
+	if !get.AllProjects {
+		opts = []listOpt{matchName(client.Project)}
 	}
 
 	if err := get.list(ctx, client, projectConfigList, opts...); err != nil {
@@ -32,7 +32,7 @@ func (cmd *configsCmd) Run(ctx context.Context, client *api.Client, get *Cmd) er
 	}
 
 	if len(projectConfigList.Items) == 0 {
-		printEmptyMessage(apps.ProjectConfigKind, client.Namespace)
+		printEmptyMessage(cmd.out, apps.ProjectConfigKind, client.Project)
 		return nil
 	}
 

--- a/get/project_config_test.go
+++ b/get/project_config_test.go
@@ -29,17 +29,17 @@ func TestConfigs(t *testing.T) {
 	cases := map[string]struct {
 		cmd          configsCmd
 		get          *Cmd
-		namespace    string
+		project      string
 		configs      *apps.ProjectConfigList
 		otherConfigs *apps.ProjectConfigList
 	}{
 		"get configs for all projects": {
 			cmd: configsCmd{},
 			get: &Cmd{
-				Output:        full,
-				AllNamespaces: true,
+				Output:      full,
+				AllProjects: true,
 			},
-			namespace: "ns-1",
+			project: "ns-1",
 			configs: &apps.ProjectConfigList{
 				Items: []apps.ProjectConfig{
 					*fakeProjectConfig(time.Second*10, "ns-1", "ns-1"),
@@ -64,7 +64,7 @@ func TestConfigs(t *testing.T) {
 			get: &Cmd{
 				Output: full,
 			},
-			namespace: "ns-2",
+			project: "ns-2",
 			configs: &apps.ProjectConfigList{
 				Items: []apps.ProjectConfig{
 					*fakeProjectConfig(time.Second*10, "ns-2", "ns-2"),
@@ -82,7 +82,7 @@ func TestConfigs(t *testing.T) {
 			get: &Cmd{
 				Output: full,
 			},
-			namespace: "ns-3",
+			project: "ns-3",
 			configs: &apps.ProjectConfigList{
 				Items: []apps.ProjectConfig{},
 			},
@@ -109,13 +109,13 @@ func TestConfigs(t *testing.T) {
 				}).
 				WithLists(tc.configs, tc.otherConfigs).
 				Build()
-			apiClient := &api.Client{WithWatch: client, Namespace: tc.namespace}
+			apiClient := &api.Client{WithWatch: client, Project: tc.project}
 
 			configList := &apps.ProjectConfigList{}
 
 			var opts []listOpt
-			if !tc.get.AllNamespaces {
-				opts = []listOpt{matchName(tc.namespace)}
+			if !tc.get.AllProjects {
+				opts = []listOpt{matchName(tc.project)}
 			}
 
 			if err := tc.get.list(ctx, apiClient, configList, opts...); err != nil {

--- a/get/project_test.go
+++ b/get/project_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ninech/nctl/internal/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -29,7 +28,7 @@ func TestProject(t *testing.T) {
 		output        string
 	}{
 		"projects exist, full format": {
-			projects:     testProjects(organization, "dev", "staging", "prod"),
+			projects:     test.Projects(organization, "dev", "staging", "prod"),
 			outputFormat: full,
 			output: `NAME
 dev
@@ -38,7 +37,7 @@ staging
 `,
 		},
 		"projects exist, no header format": {
-			projects:     testProjects(organization, "dev", "staging", "prod"),
+			projects:     test.Projects(organization, "dev", "staging", "prod"),
 			outputFormat: noHeader,
 			output: `dev
 prod
@@ -46,7 +45,7 @@ staging
 `,
 		},
 		"projects exist and all namespaces set": {
-			projects:      testProjects(organization, "dev", "staging", "prod"),
+			projects:      test.Projects(organization, "dev", "staging", "prod"),
 			outputFormat:  full,
 			allNamespaces: true,
 			output: `NAME
@@ -66,7 +65,7 @@ staging
 			output:       "no Projects found\n",
 		},
 		"specific project requested": {
-			projects:     testProjects(organization, "dev", "staging"),
+			projects:     test.Projects(organization, "dev", "staging"),
 			name:         "dev",
 			outputFormat: full,
 			output: `NAME
@@ -74,13 +73,13 @@ dev
 `,
 		},
 		"specific project requested, but does not exist": {
-			projects:     testProjects(organization, "staging"),
+			projects:     test.Projects(organization, "staging"),
 			name:         "dev",
 			outputFormat: full,
 			output:       "no Projects found\n",
 		},
 		"specific project requested, yaml output": {
-			projects:     testProjects(organization, "dev", "staging"),
+			projects:     test.Projects(organization, "dev", "staging"),
 			name:         "dev",
 			outputFormat: yamlOut,
 			output:       "\x1b[96mapiVersion\x1b[0m:\x1b[92m management.nine.ch/v1alpha1\x1b[0m\n\x1b[92m\x1b[0m\x1b[96mkind\x1b[0m:\x1b[92m Project\x1b[0m\n\x1b[92m\x1b[0m\x1b[96mmetadata\x1b[0m:\x1b[96m\x1b[0m\n\x1b[96m  name\x1b[0m:\x1b[92m dev\x1b[0m\n\x1b[92m  \x1b[0m\x1b[96mnamespace\x1b[0m:\x1b[92m evilcorp\x1b[0m\n",
@@ -126,22 +125,4 @@ dev
 			assert.Equal(t, testCase.output, buf.String())
 		})
 	}
-}
-
-func testProjects(organization string, names ...string) []client.Object {
-	var projects []client.Object
-	for _, name := range names {
-		projects = append(projects, &management.Project{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: organization,
-			},
-			TypeMeta: metav1.TypeMeta{
-				Kind:       management.ProjectKind,
-				APIVersion: management.SchemeGroupVersion.String(),
-			},
-			Spec: management.ProjectSpec{},
-		})
-	}
-	return projects
 }

--- a/get/project_test.go
+++ b/get/project_test.go
@@ -8,6 +8,7 @@ import (
 
 	management "github.com/ninech/apis/management/v1alpha1"
 	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/auth"
 	"github.com/ninech/nctl/internal/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -125,4 +126,27 @@ dev
 			assert.Equal(t, testCase.output, buf.String())
 		})
 	}
+}
+
+func TestProjectsConfigErrors(t *testing.T) {
+	ctx := context.Background()
+	apiClient, err := test.SetupClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := projectCmd{
+		Name: "testproject",
+	}
+	get := &Cmd{
+		Output: full,
+	}
+	// there is no kubeconfig so we expect to fail
+	require.Error(t, cmd.Run(ctx, apiClient, get))
+
+	// we create a kubeconfig which does not contain a nctl config
+	// extension
+	kubeconfig, err := test.CreateTestKubeconfig(apiClient, "")
+	require.NoError(t, err)
+	defer os.Remove(kubeconfig)
+	require.ErrorIs(t, cmd.Run(ctx, apiClient, get), auth.ErrConfigNotFound)
 }

--- a/get/project_test.go
+++ b/get/project_test.go
@@ -1,0 +1,147 @@
+package get
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	management "github.com/ninech/apis/management/v1alpha1"
+	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/internal/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestProject(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	organization := "evilcorp"
+
+	for name, testCase := range map[string]struct {
+		projects      []client.Object
+		name          string
+		outputFormat  output
+		allNamespaces bool
+		output        string
+	}{
+		"projects exist, full format": {
+			projects:     testProjects(organization, "dev", "staging", "prod"),
+			outputFormat: full,
+			output: `NAME
+dev
+prod
+staging
+`,
+		},
+		"projects exist, no header format": {
+			projects:     testProjects(organization, "dev", "staging", "prod"),
+			outputFormat: noHeader,
+			output: `dev
+prod
+staging
+`,
+		},
+		"projects exist and all namespaces set": {
+			projects:      testProjects(organization, "dev", "staging", "prod"),
+			outputFormat:  full,
+			allNamespaces: true,
+			output: `NAME
+dev
+prod
+staging
+`,
+		},
+		"no projects exist": {
+			projects:     []client.Object{},
+			outputFormat: full,
+			output:       "no Projects found\n",
+		},
+		"no projects exist, no header format": {
+			projects:     []client.Object{},
+			outputFormat: noHeader,
+			output:       "no Projects found\n",
+		},
+		"specific project requested": {
+			projects:     testProjects(organization, "dev", "staging"),
+			name:         "dev",
+			outputFormat: full,
+			output: `NAME
+dev
+`,
+		},
+		"specific project requested, but does not exist": {
+			projects:     testProjects(organization, "staging"),
+			name:         "dev",
+			outputFormat: full,
+			output:       "no Projects found\n",
+		},
+		"specific project requested, yaml output": {
+			projects:     testProjects(organization, "dev", "staging"),
+			name:         "dev",
+			outputFormat: yamlOut,
+			output:       "\x1b[96mapiVersion\x1b[0m:\x1b[92m management.nine.ch/v1alpha1\x1b[0m\n\x1b[92m\x1b[0m\x1b[96mkind\x1b[0m:\x1b[92m Project\x1b[0m\n\x1b[92m\x1b[0m\x1b[96mmetadata\x1b[0m:\x1b[96m\x1b[0m\n\x1b[96m  name\x1b[0m:\x1b[92m dev\x1b[0m\n\x1b[92m  \x1b[0m\x1b[96mnamespace\x1b[0m:\x1b[92m evilcorp\x1b[0m\n",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			testCase := testCase
+
+			get := &Cmd{
+				Output:        testCase.outputFormat,
+				AllNamespaces: testCase.allNamespaces,
+			}
+
+			scheme, err := api.NewScheme()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			client := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithIndex(&management.Project{}, "metadata.name", func(o client.Object) []string {
+					return []string{o.GetName()}
+				}).
+				WithObjects(testCase.projects...).Build()
+
+			// we set the namespace in the client to show that it
+			// doesn't affect projects listing
+			apiClient := &api.Client{WithWatch: client, Namespace: "default"}
+			kubeconfig, err := test.CreateTestKubeconfig(apiClient, organization)
+			require.NoError(t, err)
+			defer os.Remove(kubeconfig)
+
+			buf := &bytes.Buffer{}
+			cmd := projectCmd{
+				out:  buf,
+				Name: testCase.name,
+			}
+
+			if err := cmd.Run(ctx, apiClient, get); err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, testCase.output, buf.String())
+		})
+	}
+}
+
+func testProjects(organization string, names ...string) []client.Object {
+	var projects []client.Object
+	for _, name := range names {
+		projects = append(projects, &management.Project{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: organization,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       management.ProjectKind,
+				APIVersion: management.SchemeGroupVersion.String(),
+			},
+			Spec: management.ProjectSpec{},
+		})
+	}
+	return projects
+}

--- a/get/project_test.go
+++ b/get/project_test.go
@@ -22,11 +22,11 @@ func TestProject(t *testing.T) {
 	organization := "evilcorp"
 
 	for name, testCase := range map[string]struct {
-		projects      []client.Object
-		name          string
-		outputFormat  output
-		allNamespaces bool
-		output        string
+		projects     []client.Object
+		name         string
+		outputFormat output
+		allProjects  bool
+		output       string
 	}{
 		"projects exist, full format": {
 			projects:     test.Projects(organization, "dev", "staging", "prod"),
@@ -45,10 +45,10 @@ prod
 staging
 `,
 		},
-		"projects exist and all namespaces set": {
-			projects:      test.Projects(organization, "dev", "staging", "prod"),
-			outputFormat:  full,
-			allNamespaces: true,
+		"projects exist and allProjects is set": {
+			projects:     test.Projects(organization, "dev", "staging", "prod"),
+			outputFormat: full,
+			allProjects:  true,
 			output: `NAME
 dev
 prod
@@ -90,8 +90,8 @@ dev
 			testCase := testCase
 
 			get := &Cmd{
-				Output:        testCase.outputFormat,
-				AllNamespaces: testCase.allNamespaces,
+				Output:      testCase.outputFormat,
+				AllProjects: testCase.allProjects,
 			}
 
 			scheme, err := api.NewScheme()
@@ -106,9 +106,9 @@ dev
 				}).
 				WithObjects(testCase.projects...).Build()
 
-			// we set the namespace in the client to show that it
-			// doesn't affect projects listing
-			apiClient := &api.Client{WithWatch: client, Namespace: "default"}
+			// we set the project in the client to show that setting it
+			// doesn't affect listing of projects
+			apiClient := &api.Client{WithWatch: client, Project: "default"}
 			kubeconfig, err := test.CreateTestKubeconfig(apiClient, organization)
 			require.NoError(t, err)
 			defer os.Remove(kubeconfig)

--- a/get/releases.go
+++ b/get/releases.go
@@ -17,8 +17,8 @@ import (
 )
 
 type releasesCmd struct {
-	Name            string `arg:"" help:"Name of the Release to get. If omitted all in the namespace will be listed." default:""`
-	ApplicationName string `help:"Name of the Application to get releases for. If omitted all in the namespace will be listed."`
+	Name            string `arg:"" help:"Name of the Release to get. If omitted all in the projects will be listed." default:""`
+	ApplicationName string `help:"Name of the Application to get releases for. If omitted all applications in the project will be listed."`
 	out             io.Writer
 }
 
@@ -35,7 +35,7 @@ func (cmd *releasesCmd) Run(ctx context.Context, client *api.Client, get *Cmd) e
 	}
 
 	if len(releaseList.Items) == 0 {
-		printEmptyMessage(cmd.out, apps.ReleaseKind, client.Namespace)
+		printEmptyMessage(cmd.out, apps.ReleaseKind, client.Project)
 		return nil
 	}
 

--- a/get/releases.go
+++ b/get/releases.go
@@ -35,7 +35,7 @@ func (cmd *releasesCmd) Run(ctx context.Context, client *api.Client, get *Cmd) e
 	}
 
 	if len(releaseList.Items) == 0 {
-		printEmptyMessage(apps.ReleaseKind, client.Namespace)
+		printEmptyMessage(cmd.out, apps.ReleaseKind, client.Namespace)
 		return nil
 	}
 

--- a/get/releases_test.go
+++ b/get/releases_test.go
@@ -31,7 +31,7 @@ var (
 )
 
 func TestReleases(t *testing.T) {
-	const namespace = "some-namespace"
+	const project = "some-project"
 
 	scheme, err := api.NewScheme()
 	if err != nil {
@@ -51,17 +51,17 @@ func TestReleases(t *testing.T) {
 			},
 			releases: &apps.ReleaseList{
 				Items: []apps.Release{
-					newRelease(time.Second*10, 10, "a1", namespace, "app1", "pc", test.StatusAvailable),
+					newRelease(time.Second*10, 10, "a1", project, "app1", "pc", test.StatusAvailable),
 				},
 			},
 			otherAppReleases: &apps.ReleaseList{
 				Items: []apps.Release{
-					newRelease(time.Second*13, 10, "o-a1", namespace, "other-app1", "pc", test.StatusSuperseded),
-					newRelease(time.Second*10, 20, "o-b1", namespace, "other-app1", "pc", test.StatusSuperseded),
-					newRelease(time.Second*11, 30, "o-c1", namespace, "other-app1", "pc", test.StatusAvailable),
+					newRelease(time.Second*13, 10, "o-a1", project, "other-app1", "pc", test.StatusSuperseded),
+					newRelease(time.Second*10, 20, "o-b1", project, "other-app1", "pc", test.StatusSuperseded),
+					newRelease(time.Second*11, 30, "o-c1", project, "other-app1", "pc", test.StatusAvailable),
 
-					newRelease(time.Second*15, 10, "o-a2", namespace, "other-app2", "pc", test.StatusSuperseded),
-					newRelease(time.Second*10, 20, "o-b2", namespace, "other-app2", "pc", test.StatusAvailable),
+					newRelease(time.Second*15, 10, "o-a2", project, "other-app2", "pc", test.StatusSuperseded),
+					newRelease(time.Second*10, 20, "o-b2", project, "other-app2", "pc", test.StatusAvailable),
 				},
 			},
 		},
@@ -72,17 +72,17 @@ func TestReleases(t *testing.T) {
 			},
 			releases: &apps.ReleaseList{
 				Items: []apps.Release{
-					newRelease(time.Second*16, 10, "a2", namespace, "app2", "pc", test.StatusSuperseded),
-					newRelease(time.Second*12, 20, "b2", namespace, "app2", "pc", test.StatusSuperseded),
-					newRelease(time.Second*17, 30, "c2", namespace, "app2", "pc", test.StatusAvailable),
+					newRelease(time.Second*16, 10, "a2", project, "app2", "pc", test.StatusSuperseded),
+					newRelease(time.Second*12, 20, "b2", project, "app2", "pc", test.StatusSuperseded),
+					newRelease(time.Second*17, 30, "c2", project, "app2", "pc", test.StatusAvailable),
 				},
 			},
 			otherAppReleases: &apps.ReleaseList{
 				Items: []apps.Release{
-					newRelease(time.Second*10, 10, "o-a1", namespace, "other-app1", "pc", test.StatusAvailable),
+					newRelease(time.Second*10, 10, "o-a1", project, "other-app1", "pc", test.StatusAvailable),
 
-					newRelease(time.Second*11, 10, "o-a2", namespace, "other-app2", "pc", test.StatusSuperseded),
-					newRelease(time.Second*12, 20, "o-b2", namespace, "other-app2", "pc", test.StatusAvailable),
+					newRelease(time.Second*11, 10, "o-a2", project, "other-app2", "pc", test.StatusSuperseded),
+					newRelease(time.Second*12, 20, "o-b2", project, "other-app2", "pc", test.StatusAvailable),
 				},
 			},
 		},
@@ -96,10 +96,10 @@ func TestReleases(t *testing.T) {
 			},
 			otherAppReleases: &apps.ReleaseList{
 				Items: []apps.Release{
-					newRelease(time.Second*10, 10, "o-a1", namespace, "other-app1", "pc", test.StatusAvailable),
+					newRelease(time.Second*10, 10, "o-a1", project, "other-app1", "pc", test.StatusAvailable),
 
-					newRelease(time.Second*11, 10, "o-a2", namespace, "other-app2", "pc", test.StatusSuperseded),
-					newRelease(time.Second*12, 20, "o-b2", namespace, "other-app2", "pc", test.StatusAvailable),
+					newRelease(time.Second*11, 10, "o-a2", project, "other-app2", "pc", test.StatusSuperseded),
+					newRelease(time.Second*12, 20, "o-b2", project, "other-app2", "pc", test.StatusAvailable),
 				},
 			},
 		},
@@ -110,17 +110,17 @@ func TestReleases(t *testing.T) {
 			},
 			releases: &apps.ReleaseList{
 				Items: []apps.Release{
-					newRelease(time.Second*12, 10, "a3", namespace, "app3", "pc", test.StatusSuperseded),
-					newRelease(time.Second*11, 20, "b3", namespace, "app3", "pc", test.StatusSuperseded),
-					newRelease(time.Second*10, 30, "c3", namespace, "app3", "pc", test.StatusAvailable),
+					newRelease(time.Second*12, 10, "a3", project, "app3", "pc", test.StatusSuperseded),
+					newRelease(time.Second*11, 20, "b3", project, "app3", "pc", test.StatusSuperseded),
+					newRelease(time.Second*10, 30, "c3", project, "app3", "pc", test.StatusAvailable),
 
-					newRelease(time.Second*10, 10, "a4", namespace, "app4", "pc", test.StatusSuperseded),
-					newRelease(time.Second*10, 20, "b4", namespace, "app4", "pc", test.StatusAvailable),
+					newRelease(time.Second*10, 10, "a4", project, "app4", "pc", test.StatusSuperseded),
+					newRelease(time.Second*10, 20, "b4", project, "app4", "pc", test.StatusAvailable),
 
-					newRelease(time.Second*15, 10, "a5", namespace, "app5", "pc", test.StatusSuperseded),
-					newRelease(time.Second*10, 20, "b5", namespace, "app5", "pc", test.StatusSuperseded),
-					newRelease(time.Second*16, 30, "c5", namespace, "app5", "pc", test.StatusSuperseded),
-					newRelease(time.Second*11, 40, "d5", namespace, "app5", "pc", test.StatusAvailable),
+					newRelease(time.Second*15, 10, "a5", project, "app5", "pc", test.StatusSuperseded),
+					newRelease(time.Second*10, 20, "b5", project, "app5", "pc", test.StatusSuperseded),
+					newRelease(time.Second*16, 30, "c5", project, "app5", "pc", test.StatusSuperseded),
+					newRelease(time.Second*11, 40, "d5", project, "app5", "pc", test.StatusAvailable),
 				},
 			},
 			otherAppReleases: &apps.ReleaseList{
@@ -135,21 +135,21 @@ func TestReleases(t *testing.T) {
 			},
 			releases: &apps.ReleaseList{
 				Items: []apps.Release{
-					newRelease(time.Second*10, 10, "a4", namespace, "app4", "pc", test.StatusSuperseded),
+					newRelease(time.Second*10, 10, "a4", project, "app4", "pc", test.StatusSuperseded),
 				},
 			},
 			otherAppReleases: &apps.ReleaseList{
 				Items: []apps.Release{
-					newRelease(time.Second*12, 10, "a3", namespace, "app3", "pc", test.StatusSuperseded),
-					newRelease(time.Second*11, 20, "b3", namespace, "app3", "pc", test.StatusSuperseded),
-					newRelease(time.Second*10, 30, "c3", namespace, "app3", "pc", test.StatusAvailable),
+					newRelease(time.Second*12, 10, "a3", project, "app3", "pc", test.StatusSuperseded),
+					newRelease(time.Second*11, 20, "b3", project, "app3", "pc", test.StatusSuperseded),
+					newRelease(time.Second*10, 30, "c3", project, "app3", "pc", test.StatusAvailable),
 
-					newRelease(time.Second*10, 20, "b4", namespace, "app4", "pc", test.StatusAvailable),
+					newRelease(time.Second*10, 20, "b4", project, "app4", "pc", test.StatusAvailable),
 
-					newRelease(time.Second*15, 10, "a5", namespace, "app5", "pc", test.StatusSuperseded),
-					newRelease(time.Second*10, 20, "b5", namespace, "app5", "pc", test.StatusSuperseded),
-					newRelease(time.Second*16, 30, "c5", namespace, "app5", "pc", test.StatusSuperseded),
-					newRelease(time.Second*11, 40, "d5", namespace, "app5", "pc", test.StatusAvailable),
+					newRelease(time.Second*15, 10, "a5", project, "app5", "pc", test.StatusSuperseded),
+					newRelease(time.Second*10, 20, "b5", project, "app5", "pc", test.StatusSuperseded),
+					newRelease(time.Second*16, 30, "c5", project, "app5", "pc", test.StatusSuperseded),
+					newRelease(time.Second*11, 40, "d5", project, "app5", "pc", test.StatusAvailable),
 				},
 			},
 		},
@@ -161,21 +161,21 @@ func TestReleases(t *testing.T) {
 			},
 			releases: &apps.ReleaseList{
 				Items: []apps.Release{
-					newRelease(time.Second*10, 20, "b5", namespace, "app5", "pc", test.StatusSuperseded),
+					newRelease(time.Second*10, 20, "b5", project, "app5", "pc", test.StatusSuperseded),
 				},
 			},
 			otherAppReleases: &apps.ReleaseList{
 				Items: []apps.Release{
-					newRelease(time.Second*12, 10, "a3", namespace, "app3", "pc", test.StatusSuperseded),
-					newRelease(time.Second*11, 20, "b3", namespace, "app3", "pc", test.StatusSuperseded),
-					newRelease(time.Second*10, 30, "c3", namespace, "app3", "pc", test.StatusAvailable),
+					newRelease(time.Second*12, 10, "a3", project, "app3", "pc", test.StatusSuperseded),
+					newRelease(time.Second*11, 20, "b3", project, "app3", "pc", test.StatusSuperseded),
+					newRelease(time.Second*10, 30, "c3", project, "app3", "pc", test.StatusAvailable),
 
-					newRelease(time.Second*10, 10, "a4", namespace, "app4", "pc", test.StatusSuperseded),
-					newRelease(time.Second*10, 20, "b4", namespace, "app4", "pc", test.StatusAvailable),
+					newRelease(time.Second*10, 10, "a4", project, "app4", "pc", test.StatusSuperseded),
+					newRelease(time.Second*10, 20, "b4", project, "app4", "pc", test.StatusAvailable),
 
-					newRelease(time.Second*15, 10, "a5", namespace, "app5", "pc", test.StatusSuperseded),
-					newRelease(time.Second*16, 30, "c5", namespace, "app5", "pc", test.StatusSuperseded),
-					newRelease(time.Second*11, 40, "d5", namespace, "app5", "pc", test.StatusAvailable),
+					newRelease(time.Second*15, 10, "a5", project, "app5", "pc", test.StatusSuperseded),
+					newRelease(time.Second*16, 30, "c5", project, "app5", "pc", test.StatusSuperseded),
+					newRelease(time.Second*11, 40, "d5", project, "app5", "pc", test.StatusAvailable),
 				},
 			},
 		},
@@ -197,7 +197,7 @@ func TestReleases(t *testing.T) {
 				}).
 				WithLists(releasesByCreationTime, otherAppReleasesByCreationTime).
 				Build()
-			apiClient := &api.Client{WithWatch: client, Namespace: namespace}
+			apiClient := &api.Client{WithWatch: client, Project: project}
 
 			get := &Cmd{
 				Output: full,
@@ -242,7 +242,7 @@ func TestReleases(t *testing.T) {
 func newRelease(
 	creationTimeOffset time.Duration,
 	creationTimeNanoOffset int64,
-	name, namespace, appName, providerName string,
+	name, project, appName, providerName string,
 	releaseStatus apps.ReleaseProcessStatus,
 ) apps.Release {
 	return apps.Release{
@@ -251,7 +251,7 @@ func newRelease(
 		CreationTimestampNano: defaultCreationTime.UnixNano() + creationTimeNanoOffset,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              name,
-			Namespace:         namespace,
+			Namespace:         project,
 			Labels:            map[string]string{util.ApplicationNameLabel: appName},
 			CreationTimestamp: metav1.NewTime(defaultCreationTime.Add(creationTimeOffset)),
 		},
@@ -271,8 +271,8 @@ func newRelease(
 
 				// we always have at least 2 hosts here
 				VerifiedHosts: []string{
-					fmt.Sprintf("%s-%s-short.example.org", name, namespace),
-					fmt.Sprintf("%s-%s-long.example.org", name, namespace),
+					fmt.Sprintf("%s-%s-short.example.org", name, project),
+					fmt.Sprintf("%s-%s-long.example.org", name, project),
 				},
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/lucasepe/codename v0.2.0
 	github.com/moby/moby v24.0.1+incompatible
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
-	github.com/ninech/apis v0.0.0-20230510151919-2b04a7af4f60
+	github.com/ninech/apis v0.0.0-20230608124205-754dcb16c446
 	github.com/posener/complete v1.2.3
 	github.com/stretchr/testify v1.8.1
 	github.com/theckman/yacspin v0.13.12

--- a/go.sum
+++ b/go.sum
@@ -1049,6 +1049,8 @@ github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/ninech/apis v0.0.0-20230510151919-2b04a7af4f60 h1:Us1Jn9ciObUw5sLQ2LnfSWgKxzuXYwAekVYjV/cYs6o=
 github.com/ninech/apis v0.0.0-20230510151919-2b04a7af4f60/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
+github.com/ninech/apis v0.0.0-20230608124205-754dcb16c446 h1:4PPjlj+BfoilIPDpseUy+jchNqS3RpR5YFUts3HHGuc=
+github.com/ninech/apis v0.0.0-20230608124205-754dcb16c446/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/internal/test/client.go
+++ b/internal/test/client.go
@@ -21,7 +21,7 @@ func SetupClient(initObjs ...client.Object) (*api.Client, error) {
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjs...).Build()
 
 	return &api.Client{
-		WithWatch: client, Namespace: "default",
+		WithWatch: client, Project: "default",
 	}, nil
 }
 

--- a/internal/test/client.go
+++ b/internal/test/client.go
@@ -1,7 +1,13 @@
 package test
 
 import (
+	"os"
+
 	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/auth"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -17,4 +23,57 @@ func SetupClient(initObjs ...client.Object) (*api.Client, error) {
 	return &api.Client{
 		WithWatch: client, Namespace: "default",
 	}, nil
+}
+
+// CreateTestKubeconfig creates a test kubeconfig which contains a nctl
+// extension config with the given organization
+func CreateTestKubeconfig(client *api.Client, organization string) (string, error) {
+	contextName := "test"
+	cfg := auth.NewConfig(organization)
+	cfgObject, err := cfg.ToObject()
+	if err != nil {
+		return "", err
+	}
+	// create and open a temporary file
+	f, err := os.CreateTemp("", "kubeconfig-")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	kubeconfig := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			contextName: {
+				Server: "not.so.important",
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			contextName: {
+				Token: "not-valid",
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			contextName: {
+				Cluster:   contextName,
+				AuthInfo:  contextName,
+				Namespace: "default",
+				Extensions: map[string]runtime.Object{
+					auth.NctlExtensionName: cfgObject,
+				},
+			},
+		},
+		CurrentContext: contextName,
+	}
+
+	content, err := clientcmd.Write(kubeconfig)
+	if err != nil {
+		return "", err
+	}
+	if _, err = f.Write(content); err != nil {
+		return "", err
+	}
+	client.KubeconfigContext = contextName
+	client.KubeconfigPath = f.Name()
+
+	return f.Name(), nil
 }

--- a/internal/test/projects.go
+++ b/internal/test/projects.go
@@ -1,0 +1,26 @@
+package test
+
+import (
+	management "github.com/ninech/apis/management/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Projects returns projects with the given organization namespace set
+func Projects(organization string, names ...string) []client.Object {
+	var projects []client.Object
+	for _, name := range names {
+		projects = append(projects, &management.Project{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: organization,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       management.ProjectKind,
+				APIVersion: management.SchemeGroupVersion.String(),
+			},
+			Spec: management.ProjectSpec{},
+		})
+	}
+	return projects
+}

--- a/logs/application.go
+++ b/logs/application.go
@@ -12,11 +12,11 @@ type applicationCmd struct {
 }
 
 func (cmd *applicationCmd) Run(ctx context.Context, client *api.Client) error {
-	return cmd.logsCmd.Run(ctx, client, ApplicationQuery(cmd.Name, client.Namespace))
+	return cmd.logsCmd.Run(ctx, client, ApplicationQuery(cmd.Name, client.Project))
 }
 
 const appLabel = "app"
 
-func ApplicationQuery(name, namespace string) string {
-	return queryString(appLabel, name, namespace)
+func ApplicationQuery(name, project string) string {
+	return queryString(appLabel, name, project)
 }

--- a/logs/build.go
+++ b/logs/build.go
@@ -12,11 +12,11 @@ type buildCmd struct {
 }
 
 func (cmd *buildCmd) Run(ctx context.Context, client *api.Client) error {
-	return cmd.logsCmd.Run(ctx, client, BuildQuery(cmd.Name, client.Namespace))
+	return cmd.logsCmd.Run(ctx, client, BuildQuery(cmd.Name, client.Project))
 }
 
 const buildLabel = "build"
 
-func BuildQuery(name, namespace string) string {
-	return queryString(buildLabel, name, namespace)
+func BuildQuery(name, project string) string {
+	return queryString(buildLabel, name, project)
 }

--- a/logs/logs.go
+++ b/logs/logs.go
@@ -53,6 +53,6 @@ func (cmd *logsCmd) Run(ctx context.Context, client *api.Client, queryString str
 	return client.Log.QueryRange(ctx, out, query)
 }
 
-func queryString(labelKey, labelValue, namespace string) string {
-	return fmt.Sprintf(`{%s="%s", namespace="%s"}`, labelKey, labelValue, namespace)
+func queryString(labelKey, labelValue, project string) string {
+	return fmt.Sprintf(`{%s="%s", namespace="%s"}`, labelKey, labelValue, project)
 }

--- a/logs/logs_test.go
+++ b/logs/logs_test.go
@@ -25,8 +25,8 @@ func TestApplication(t *testing.T) {
 	}
 
 	apiClient := &api.Client{
-		Namespace: "default",
-		Log:       &log.Client{Client: log.NewFake(t, expectedTime, lines...)},
+		Project: "default",
+		Log:     &log.Client{Client: log.NewFake(t, expectedTime, lines...)},
 	}
 	ctx := context.Background()
 

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 )
 
 type flags struct {
-	Namespace     string           `help:"Limit commands to a namespace." short:"n"`
+	Project       string           `help:"Limit commands to a specific project." short:"p"`
 	APICluster    string           `help:"Context name of the API cluster." default:"nineapis.ch"`
 	LogAPIAddress string           `help:"Address of the deplo.io logging API server." default:"https://logs.deplo.io"`
 	Version       kong.VersionFlag `name:"version" help:"Print version information and quit."`
@@ -76,7 +76,7 @@ func main() {
 		return
 	}
 
-	client, err := api.New(ctx, nctl.APICluster, nctl.Namespace, api.LogClient(nctl.LogAPIAddress))
+	client, err := api.New(ctx, nctl.APICluster, nctl.Project, api.LogClient(nctl.LogAPIAddress))
 	if err != nil {
 		fmt.Println(err)
 		fmt.Printf("\nUnable to get API client, are you logged in?\n\nUse `%s %s` to login.\n", kongCtx.Model.Name, auth.LoginCmdName)

--- a/update/application.go
+++ b/update/application.go
@@ -43,7 +43,7 @@ func (cmd *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 	app := &apps.Application{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      *cmd.Name,
-			Namespace: client.Namespace,
+			Namespace: client.Project,
 		},
 	}
 
@@ -63,7 +63,7 @@ func (cmd *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 			}
 
 			if auth.Enabled() {
-				secret := auth.Secret(app.Name, client.Namespace)
+				secret := auth.Secret(app.Name, client.Project)
 				if err := client.Get(ctx, client.Name(secret.Name), secret); err != nil {
 					return err
 				}

--- a/update/application_test.go
+++ b/update/application_test.go
@@ -162,7 +162,7 @@ func TestApplication(t *testing.T) {
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
 				tc.orig, tc.gitAuth.Secret(tc.orig.Name, tc.orig.Namespace),
 			).Build()
-			apiClient := &api.Client{WithWatch: client, Namespace: "default"}
+			apiClient := &api.Client{WithWatch: client, Project: "default"}
 			ctx := context.Background()
 
 			if err := tc.cmd.Run(ctx, apiClient); err != nil {

--- a/update/project_config.go
+++ b/update/project_config.go
@@ -23,8 +23,8 @@ type configCmd struct {
 func (cmd *configCmd) Run(ctx context.Context, client *api.Client) error {
 	cfg := &apps.ProjectConfig{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      client.Namespace,
-			Namespace: client.Namespace,
+			Name:      client.Project,
+			Namespace: client.Project,
 		},
 	}
 

--- a/update/project_config_test.go
+++ b/update/project_config_test.go
@@ -15,14 +15,14 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	const namespace = "some-namespace"
+	const project = "some-project"
 
 	initialSize := test.AppMicro
 
 	existingConfig := &apps.ProjectConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      namespace,
-			Namespace: namespace,
+			Name:      project,
+			Namespace: project,
 		},
 		Spec: apps.ProjectConfigSpec{
 			ForProvider: apps.ProjectConfigParameters{
@@ -38,13 +38,13 @@ func TestConfig(t *testing.T) {
 
 	cases := map[string]struct {
 		orig        *apps.ProjectConfig
-		namespace   string
+		project     string
 		cmd         configCmd
 		checkConfig func(t *testing.T, cmd configCmd, orig, updated *apps.ProjectConfig)
 	}{
 		"change port": {
-			orig:      existingConfig,
-			namespace: namespace,
+			orig:    existingConfig,
+			project: project,
 			cmd: configCmd{
 				Port: pointer.Int32(1234),
 			},
@@ -53,8 +53,8 @@ func TestConfig(t *testing.T) {
 			},
 		},
 		"port is unchanged when updating unrelated field": {
-			orig:      existingConfig,
-			namespace: namespace,
+			orig:    existingConfig,
+			project: project,
 			cmd: configCmd{
 				Size: pointer.String("newsize"),
 			},
@@ -64,8 +64,8 @@ func TestConfig(t *testing.T) {
 			},
 		},
 		"all fields update": {
-			orig:      existingConfig,
-			namespace: namespace,
+			orig:    existingConfig,
+			project: project,
 			cmd: configCmd{
 				Size:     pointer.String("newsize"),
 				Port:     pointer.Int32(1000),
@@ -89,7 +89,7 @@ func TestConfig(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			apiClient.Namespace = tc.namespace
+			apiClient.Project = tc.project
 
 			ctx := context.Background()
 


### PR DESCRIPTION
This adds create/get/delete for `projects` to nctl. As all `Project` CRDs are always located in the "main" namespace of the logged in organization, we need to store that information for later retrieval somewhere. To not have an extra configuration file for nctl , we decided to store that information in the context of the kubeconfig (utilizing "Extensions" for this).

As current users won't have that information in their kubeconfig yet, they will need to re-login when using `project` related features.

This PR also renames occurrences of "namespace" to "project" as we would like to have a common nomenclature. "Namespace" is still the Kubernetes underlying technical concept of a "Project".