### PR TITLE
Add phase label to logs

### DIFF
--- a/logs/application.go
+++ b/logs/application.go
@@ -15,8 +15,11 @@ func (cmd *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 	return cmd.logsCmd.Run(ctx, client, ApplicationQuery(cmd.Name, client.Project))
 }
 
-const appLabel = "app"
+const (
+	appLabel     = "app"
+	runtimePhase = "runtime"
+)
 
 func ApplicationQuery(name, project string) string {
-	return queryString(appLabel, name, project)
+	return queryString(map[string]string{appLabel: name, phaseLabel: runtimePhase}, project)
 }

--- a/logs/build.go
+++ b/logs/build.go
@@ -7,16 +7,28 @@ import (
 )
 
 type buildCmd struct {
-	Name string `arg:"" help:"Name of the Build."`
+	Name            string `arg:"" default:"" help:"Name of the Build."`
+	ApplicationName string `short:"a" help:"Name of the application to get build logs for."`
 	logsCmd
 }
 
 func (cmd *buildCmd) Run(ctx context.Context, client *api.Client) error {
-	return cmd.logsCmd.Run(ctx, client, BuildQuery(cmd.Name, client.Project))
+	query := BuildQuery(cmd.Name, client.Project)
+	if len(cmd.ApplicationName) != 0 {
+		query = queryString(map[string]string{
+			appLabel:   cmd.ApplicationName,
+			phaseLabel: buildPhase,
+		}, client.Project)
+	}
+
+	return cmd.logsCmd.Run(ctx, client, query)
 }
 
-const buildLabel = "build"
+const (
+	buildLabel = "build"
+	buildPhase = "build"
+)
 
 func BuildQuery(name, project string) string {
-	return queryString(buildLabel, name, project)
+	return queryString(map[string]string{buildLabel: name, phaseLabel: buildPhase}, project)
 }

--- a/logs/logs_test.go
+++ b/logs/logs_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestApplication(t *testing.T) {
+func TestRun(t *testing.T) {
 	expectedTime := time.Now()
 	lines := []string{}
 
@@ -103,4 +103,11 @@ func TestApplication(t *testing.T) {
 			buf.Reset()
 		})
 	}
+}
+
+func TestQueryString(t *testing.T) {
+	assert.Equal(t,
+		queryString(map[string]string{appLabel: "some-app", phaseLabel: "some-phase"}, "default"),
+		`{app="some-app",namespace="default",phase="some-phase"}`,
+	)
 }


### PR DESCRIPTION
With the phase label we can now differentiate between app logs and build logs that belong to an application. So we can now view all build logs of a specific application instead of having to know the build name.

I also changed the way we build the loki query a bit so we can add arbitrary labels if required.