### PR TITLE
fix: increase wait timeouts for app operations

### DIFF
--- a/create/application.go
+++ b/create/application.go
@@ -24,7 +24,7 @@ import (
 type applicationCmd struct {
 	Name        string            `arg:"" default:"" help:"Name of the application. A random name is generated if omitted."`
 	Wait        bool              `default:"true" help:"Wait until application is fully created."`
-	WaitTimeout time.Duration     `default:"10m" help:"Duration to wait for application getting ready. Only relevant if wait is set."`
+	WaitTimeout time.Duration     `default:"15m" help:"Duration to wait for application getting ready. Only relevant if wait is set."`
 	Git         gitConfig         `embed:"" prefix:"git-"`
 	Size        string            `default:"micro" help:"Size of the app."`
 	Port        int32             `default:"8080" help:"Port the app is listening on."`

--- a/delete/application.go
+++ b/delete/application.go
@@ -14,7 +14,7 @@ type applicationCmd struct {
 	Name        string        `arg:"" help:"Name of the Application."`
 	Force       bool          `default:"false" help:"Do not ask for confirmation of deletion."`
 	Wait        bool          `default:"true" help:"Wait until Application is fully deleted."`
-	WaitTimeout time.Duration `default:"10s" help:"Duration to wait for the deletion. Only relevant if wait is set."`
+	WaitTimeout time.Duration `default:"1m" help:"Duration to wait for the deletion. Only relevant if wait is set."`
 }
 
 func (app *applicationCmd) Run(ctx context.Context, client *api.Client) error {


### PR DESCRIPTION
We should wait slightly longer for slow to build apps on create. Also the deletion wait was really short and sometimes it just takes a few more seconds than the previous 10.