### PR TITLE
delete secrets created by nctl when deleting applications

### DIFF
--- a/auth/config.go
+++ b/auth/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/api/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
@@ -154,7 +155,7 @@ func readConfig(kubeconfigContent []byte, contextName string) (*Config, error) {
 	if !exists {
 		return nil, fmt.Errorf("could not find context %q in kubeconfig", contextName)
 	}
-	extension, exists := context.Extensions[NctlExtensionName]
+	extension, exists := context.Extensions[util.NctlName]
 	if !exists {
 		return nil, ErrConfigNotFound
 	}

--- a/auth/config_test.go
+++ b/auth/config_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"testing"
 
+	"github.com/ninech/nctl/api/util"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
@@ -22,7 +23,7 @@ func TestConfigParsing(t *testing.T) {
 			kubeconfig: func() clientcmdapi.Config {
 				kubeCfg := testKubeconfig(contextName)
 				kubeCfg.Contexts[contextName].Extensions = map[string]runtime.Object{
-					NctlExtensionName: objectCfg,
+					util.NctlName: objectCfg,
 				}
 				return kubeCfg
 			}(),

--- a/auth/login.go
+++ b/auth/login.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 
 	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/api/util"
 	"github.com/ninech/nctl/internal/format"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
@@ -24,8 +25,7 @@ type LoginCmd struct {
 }
 
 const (
-	LoginCmdName      = "auth login"
-	NctlExtensionName = "nctl"
+	LoginCmdName = "auth login"
 )
 
 func (l *LoginCmd) Run(ctx context.Context, command string) error {
@@ -117,7 +117,7 @@ func newAPIConfig(apiURL, issuerURL *url.URL, command, clientID string, opts ...
 				Cluster:  cfg.name,
 				AuthInfo: cfg.name,
 				Extensions: map[string]runtime.Object{
-					NctlExtensionName: extension,
+					util.NctlName: extension,
 				},
 			},
 		},

--- a/create/application.go
+++ b/create/application.go
@@ -64,7 +64,7 @@ func (app *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 
 	if auth.Enabled() {
 		// for git auth we create a separate secret and then reference it in the app.
-		secret := auth.Secret(newApp.Name, client.Project)
+		secret := auth.Secret(newApp)
 		if err := client.Create(ctx, secret); err != nil {
 			return fmt.Errorf("unable to create git auth secret: %w", err)
 		}

--- a/create/application_test.go
+++ b/create/application_test.go
@@ -72,13 +72,14 @@ func TestApplication(t *testing.T) {
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
 				auth := util.GitAuth{Username: cmd.Git.Username, Password: cmd.Git.Password}
-				authSecret := auth.Secret(app.Name, app.Namespace)
+				authSecret := auth.Secret(app)
 				if err := apiClient.Get(ctx, api.ObjectName(authSecret), authSecret); err != nil {
 					t.Fatal(err)
 				}
 
 				assert.Equal(t, *cmd.Git.Username, string(authSecret.Data[util.UsernameSecretKey]))
 				assert.Equal(t, *cmd.Git.Password, string(authSecret.Data[util.PasswordSecretKey]))
+				assert.Equal(t, authSecret.Annotations[util.ManagedByAnnotation], util.NctlName)
 			},
 		},
 		"with ssh key git auth": {
@@ -93,12 +94,13 @@ func TestApplication(t *testing.T) {
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
 				auth := util.GitAuth{SSHPrivateKey: cmd.Git.SSHPrivateKey}
-				authSecret := auth.Secret(app.Name, app.Namespace)
+				authSecret := auth.Secret(app)
 				if err := apiClient.Get(ctx, api.ObjectName(authSecret), authSecret); err != nil {
 					t.Fatal(err)
 				}
 
 				assert.Equal(t, *cmd.Git.SSHPrivateKey, string(authSecret.Data[util.PrivateKeySecretKey]))
+				assert.Equal(t, authSecret.Annotations[util.ManagedByAnnotation], util.NctlName)
 			},
 		},
 	}

--- a/delete/application_test.go
+++ b/delete/application_test.go
@@ -5,41 +5,198 @@ import (
 	"testing"
 
 	apps "github.com/ninech/apis/apps/v1alpha1"
+	meta "github.com/ninech/apis/meta/v1alpha1"
 	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/api/util"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestApplication(t *testing.T) {
-	app := &apps.Application{
+	project := "evilcorp"
+	for name, testCase := range map[string]struct {
+		testObjects    testObjectList
+		name           string
+		errorExpected  bool
+		errorCheck     func(err error) bool
+		deletedSecrets []corev1.Secret
+	}{
+		"application-without-git-auth-secret": {
+			testObjects:   toTestObj(dummyApp("dev", project)),
+			name:          "dev",
+			errorExpected: false,
+		},
+		"application-does-not-exist": {
+			name:          "dev",
+			errorExpected: true,
+			errorCheck: func(err error) bool {
+				return errors.IsNotFound(err)
+			},
+		},
+		"application-with-git-auth-secret": {
+			testObjects: func() []testObject {
+				app := dummyApp("dev", project)
+				secret := gitSecretFor(app)
+				return toTestObj(app, secret)
+			}(),
+			name:          "dev",
+			errorExpected: false,
+		},
+		"application-with-referenced-git-auth-secret": {
+			testObjects: func() []testObject {
+				appOne := dummyApp("dev", project)
+				appTwo := dummyApp("test", project)
+				secret := gitSecretFor(appOne)
+				appTwo.Spec.ForProvider.Git.Auth = &apps.GitAuth{
+					FromSecret: &meta.LocalReference{
+						Name: secret.Name,
+					},
+				}
+				return toTestObj(
+					appOne,
+					noDeletionExpected(appTwo),
+					noDeletionExpected(secret),
+				)
+			}(),
+			name:          "dev",
+			errorExpected: false,
+		},
+		// here we have 2 secrets. One secret created by nctl which is
+		// not in use and another non nctl managed secret which
+		// is used by the application.
+		"application-with-non-nctl-secret": {
+			testObjects: func() []testObject {
+				appOne := dummyApp("dev", project)
+				nctlSecret := gitSecretFor(appOne)
+
+				customSecret := nctlSecret.DeepCopy()
+				customSecret.Name = "custom"
+				delete(customSecret.Annotations, util.ManagedByAnnotation)
+				appOne.Spec.ForProvider.Git.Auth = &apps.GitAuth{
+					FromSecret: &meta.LocalReference{
+						Name: customSecret.Name,
+					},
+				}
+				return toTestObj(
+					appOne,
+					nctlSecret,
+					noDeletionExpected(customSecret),
+				)
+			}(),
+			name:          "dev",
+			errorExpected: false,
+		},
+		// a secret which has the same name as the application, but no
+		// nctl annotation will not be deleted
+		"application-git-auth-secret-no-annotation": {
+			testObjects: func() []testObject {
+				appOne := dummyApp("dev", project)
+				nctlSecret := gitSecretFor(appOne)
+				delete(nctlSecret.Annotations, util.ManagedByAnnotation)
+				return toTestObj(
+					appOne,
+					noDeletionExpected(nctlSecret),
+				)
+			}(),
+			name:          "dev",
+			errorExpected: false,
+		},
+	} {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			cmd := applicationCmd{
+				Force: true,
+				Wait:  false,
+				Name:  testCase.name,
+			}
+
+			scheme, err := api.NewScheme()
+			require.NoError(t, err)
+
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				testCase.testObjects.clientObjects()...,
+			).Build()
+			apiClient := &api.Client{WithWatch: client, Project: project}
+
+			ctx := context.Background()
+			err = cmd.Run(ctx, apiClient)
+			if testCase.errorExpected {
+				require.Error(t, err)
+				if testCase.errorCheck != nil {
+					require.True(t, testCase.errorCheck(err))
+				}
+			} else {
+				require.NoError(t, err)
+			}
+
+			for _, delObj := range testCase.testObjects {
+				err := apiClient.Get(ctx, api.ObjectName(delObj), delObj.Object)
+				if delObj.noDeletion {
+					require.NoError(t, err)
+				} else {
+					require.True(t, errors.IsNotFound(err))
+				}
+			}
+		})
+	}
+}
+
+func dummyApp(name, namespace string) *apps.Application {
+	return &apps.Application{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "default",
+			Name:      name,
+			Namespace: namespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apps.SchemeGroupVersion.String(),
+			Kind:       apps.ApplicationKind,
 		},
 		Spec: apps.ApplicationSpec{},
 	}
+}
 
-	cmd := applicationCmd{
-		Force: true,
-		Wait:  false,
-		Name:  app.Name,
+func gitSecretFor(app *apps.Application) *corev1.Secret {
+	s := util.GitAuth{}.Secret(app)
+	s.TypeMeta = metav1.TypeMeta{
+		APIVersion: corev1.SchemeGroupVersion.String(),
+		Kind:       "Secret",
 	}
+	return s
+}
 
-	scheme, err := api.NewScheme()
-	if err != nil {
-		t.Fatal(err)
+type testObject struct {
+	client.Object
+	noDeletion bool
+}
+
+type testObjectList []testObject
+
+func (l testObjectList) clientObjects() (result []client.Object) {
+	for _, item := range l {
+		result = append(result, item.Object)
 	}
+	return result
+}
 
-	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).Build()
-	apiClient := &api.Client{WithWatch: client, Project: "default"}
-
-	ctx := context.Background()
-	if err := cmd.Run(ctx, apiClient); err != nil {
-		t.Fatal(err)
+func toTestObj(objs ...client.Object) testObjectList {
+	var result []testObject
+	for _, o := range objs {
+		if testObj, is := o.(testObject); is {
+			result = append(result, testObj)
+			continue
+		}
+		result = append(result, testObject{Object: o})
 	}
+	return result
+}
 
-	if !errors.IsNotFound(apiClient.Get(ctx, api.ObjectName(app), app)) {
-		t.Fatalf("expected application to not exist after delete, got %s", err)
+func noDeletionExpected(obj client.Object) testObject {
+	return testObject{
+		Object:     obj,
+		noDeletion: true,
 	}
 }

--- a/internal/test/client.go
+++ b/internal/test/client.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/api/util"
 	"github.com/ninech/nctl/auth"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
@@ -36,7 +37,7 @@ func CreateTestKubeconfig(client *api.Client, organization string) (string, erro
 			return "", err
 		}
 		extensions = map[string]runtime.Object{
-			auth.NctlExtensionName: cfgObject,
+			util.NctlName: cfgObject,
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alecthomas/kong"
 
 	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/api/util"
 	"github.com/ninech/nctl/apply"
 	"github.com/ninech/nctl/auth"
 	"github.com/ninech/nctl/create"
@@ -51,7 +52,7 @@ func main() {
 	nctl := &rootCommand{}
 	parser := kong.Must(
 		nctl,
-		kong.Name("nctl"),
+		kong.Name(util.NctlName),
 		kong.Description("Interact with Nine API resources. See https://docs.nineapis.ch for the full API docs."),
 		kong.UsageOnError(),
 		kong.Vars{"version": version},

--- a/update/application.go
+++ b/update/application.go
@@ -63,7 +63,7 @@ func (cmd *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 			}
 
 			if auth.Enabled() {
-				secret := auth.Secret(app.Name, client.Project)
+				secret := auth.Secret(app)
 				if err := client.Get(ctx, client.Name(secret.Name), secret); err != nil {
 					return err
 				}

--- a/update/application_test.go
+++ b/update/application_test.go
@@ -118,6 +118,7 @@ func TestApplication(t *testing.T) {
 			checkSecret: func(t *testing.T, cmd applicationCmd, authSecret *corev1.Secret) {
 				assert.Equal(t, *cmd.Git.Username, string(authSecret.Data[util.UsernameSecretKey]))
 				assert.Equal(t, *cmd.Git.Password, string(authSecret.Data[util.PasswordSecretKey]))
+				assert.Equal(t, authSecret.Annotations[util.ManagedByAnnotation], util.NctlName)
 			},
 		},
 		"git auth update ssh key": {
@@ -133,6 +134,7 @@ func TestApplication(t *testing.T) {
 			},
 			checkSecret: func(t *testing.T, cmd applicationCmd, authSecret *corev1.Secret) {
 				assert.Equal(t, *cmd.Git.SSHPrivateKey, string(authSecret.Data[util.PrivateKeySecretKey]))
+				assert.Equal(t, authSecret.Annotations[util.ManagedByAnnotation], util.NctlName)
 			},
 		},
 		"git auth is unchanged on normal field update": {
@@ -151,6 +153,7 @@ func TestApplication(t *testing.T) {
 			},
 			checkSecret: func(t *testing.T, cmd applicationCmd, authSecret *corev1.Secret) {
 				assert.Equal(t, "fakekey", string(authSecret.Data[util.PrivateKeySecretKey]))
+				assert.Equal(t, authSecret.Annotations[util.ManagedByAnnotation], util.NctlName)
 			},
 		},
 	}
@@ -160,7 +163,7 @@ func TestApplication(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) {
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
-				tc.orig, tc.gitAuth.Secret(tc.orig.Name, tc.orig.Namespace),
+				tc.orig, tc.gitAuth.Secret(tc.orig),
 			).Build()
 			apiClient := &api.Client{WithWatch: client, Project: "default"}
 			ctx := context.Background()


### PR DESCRIPTION
This will delete git auth secrets which were created by `nctl` on application delete. If the secret is still referenced by another application, a corresponding message will be printed.