### PR TITLE
find absolute path to nctl binary

### DIFF
--- a/auth/cluster.go
+++ b/auth/cluster.go
@@ -10,6 +10,7 @@ import (
 
 	infrastructure "github.com/ninech/apis/infrastructure/v1alpha1"
 	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/api/util"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -48,7 +49,11 @@ func (a *ClusterCmd) Run(ctx context.Context, client *api.Client) error {
 	if len(os.Args) == 0 {
 		return fmt.Errorf("could not get command name from os.Args")
 	}
-	command := os.Args[0]
+	// we try to find out where the nctl binary is located
+	command, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("can not identify executable path of %s: %w", util.NctlName, err)
+	}
 
 	cfg, err := newAPIConfig(
 		apiEndpoint,

--- a/auth/login.go
+++ b/auth/login.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"os/exec"
 
 	"github.com/ninech/nctl/api"
 	"github.com/ninech/nctl/api/util"
@@ -130,11 +129,6 @@ func newAPIConfig(apiURL, issuerURL *url.URL, command, clientID string, opts ...
 			Token: cfg.token,
 		}
 		return clientConfig, nil
-	}
-
-	// we make sure our command is in the $PATH as the client-go credential plugin will need to find it.
-	if _, err := exec.LookPath(command); err != nil && command != "" {
-		return nil, fmt.Errorf("%s not found in $PATH, please add it first before logging in", command)
 	}
 
 	clientConfig.AuthInfos[cfg.name] = &clientcmdapi.AuthInfo{

--- a/main.go
+++ b/main.go
@@ -67,8 +67,12 @@ func main() {
 
 	// handle the login/oidc cmds separately as we should not try to get the
 	// API client if we're not logged in.
+	command, err := os.Executable()
+	if err != nil {
+		kongCtx.Fatalf("can not identify executable path of %s: %v", util.NctlName, err)
+	}
 	if strings.HasPrefix(kongCtx.Command(), auth.LoginCmdName) {
-		kongCtx.FatalIfErrorf(nctl.Auth.Login.Run(ctx, kongCtx.Model.Name))
+		kongCtx.FatalIfErrorf(nctl.Auth.Login.Run(ctx, command))
 		return
 	}
 


### PR DESCRIPTION
This will resolve the absolute path of the nctl binary so it can be used as credential helper in the kubeconfig. It allows for locally build "nctl" versions and calling them via "./nctl" for example.