### PR TITLE
fix: make go install work again

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/grafana/dskit v0.0.0-20230201083518-528d8a7d52f2
 	github.com/grafana/loki v1.6.2-0.20230503110102-9f809eda70ba
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/int128/kubelogin v1.25.3
 	github.com/lucasepe/codename v0.2.0
 	github.com/moby/moby v24.0.1+incompatible
@@ -98,7 +99,6 @@ require (
 	github.com/hashicorp/go-hclog v1.2.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/hashicorp/golang-lru v0.6.0 // indirect
@@ -203,8 +203,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-// this is for the loki import to work
-exclude k8s.io/client-go v12.0.0+incompatible
-
-replace github.com/gocql/gocql => github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85

--- a/go.sum
+++ b/go.sum
@@ -1047,10 +1047,6 @@ github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/ninech/apis v0.0.0-20230510151919-2b04a7af4f60 h1:Us1Jn9ciObUw5sLQ2LnfSWgKxzuXYwAekVYjV/cYs6o=
-github.com/ninech/apis v0.0.0-20230510151919-2b04a7af4f60/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
-github.com/ninech/apis v0.0.0-20230608124205-754dcb16c446 h1:4PPjlj+BfoilIPDpseUy+jchNqS3RpR5YFUts3HHGuc=
-github.com/ninech/apis v0.0.0-20230608124205-754dcb16c446/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
 github.com/ninech/apis v0.0.0-20230619153508-1a3f1d870d42 h1:6T4bITO549JjVyEp825oKNfTSdqQ5eZ9/eN6SBWcw1o=
 github.com/ninech/apis v0.0.0-20230619153508-1a3f1d870d42/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=


### PR DESCRIPTION
This removes the replace/exclude directives in the go.mod as it turns out these are not needed anymore after all.