### PR TITLE
feat: allow configuring API/Logs server via env

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -78,9 +78,9 @@ func New(ctx context.Context, apiClusterContext, project string, opts ...ClientO
 }
 
 // LogClient sets up a log client connected to the provided address.
-func LogClient(address string) ClientOpt {
+func LogClient(address string, insecure bool) ClientOpt {
 	return func(c *Client) error {
-		logClient, err := log.NewClient(address, c.Token, c.Project)
+		logClient, err := log.NewClient(address, c.Token, c.Project, insecure)
 		if err != nil {
 			return fmt.Errorf("unable to create log client: %w", err)
 		}

--- a/api/log/client.go
+++ b/api/log/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logqlmodel"
 	"github.com/grafana/loki/pkg/util/unmarshal"
+	"github.com/prometheus/common/config"
 )
 
 type Client struct {
@@ -34,10 +35,15 @@ type Query struct {
 }
 
 // NewClient returns a new log API client.
-func NewClient(address, token, orgID string) (*Client, error) {
+func NewClient(address, token, orgID string, insecure bool) (*Client, error) {
 	out, err := StdOut("default")
 	if err != nil {
 		return nil, err
+	}
+
+	tls := config.TLSConfig{}
+	if insecure {
+		tls.InsecureSkipVerify = true
 	}
 
 	return &Client{
@@ -46,6 +52,7 @@ func NewClient(address, token, orgID string) (*Client, error) {
 			Address:     address,
 			BearerToken: token,
 			OrgID:       orgID,
+			TLSConfig:   tls,
 		},
 	}, nil
 }

--- a/main.go
+++ b/main.go
@@ -24,10 +24,11 @@ import (
 )
 
 type flags struct {
-	Project       string           `help:"Limit commands to a specific project." short:"p"`
-	APICluster    string           `help:"Context name of the API cluster." default:"nineapis.ch"`
-	LogAPIAddress string           `help:"Address of the deplo.io logging API server." default:"https://logs.deplo.io"`
-	Version       kong.VersionFlag `name:"version" help:"Print version information and quit."`
+	Project        string           `help:"Limit commands to a specific project." short:"p"`
+	APICluster     string           `help:"Context name of the API cluster." default:"nineapis.ch" env:"NCTL_API_CLUSTER"`
+	LogAPIAddress  string           `help:"Address of the deplo.io logging API server." default:"https://logs.deplo.io" env:"NCTL_LOG_ADDR"`
+	LogAPIInsecure bool             `help:"Don't verify TLS connection to the logging API server." hidden:"" default:"false" env:"NCTL_LOG_INSECURE"`
+	Version        kong.VersionFlag `name:"version" help:"Print version information and quit."`
 }
 
 type rootCommand struct {
@@ -81,7 +82,7 @@ func main() {
 		return
 	}
 
-	client, err := api.New(ctx, nctl.APICluster, nctl.Project, api.LogClient(nctl.LogAPIAddress))
+	client, err := api.New(ctx, nctl.APICluster, nctl.Project, api.LogClient(nctl.LogAPIAddress, nctl.LogAPIInsecure))
 	if err != nil {
 		fmt.Println(err)
 		fmt.Printf("\nUnable to get API client, are you logged in?\n\nUse `%s %s` to login.\n", kongCtx.Model.Name, auth.LoginCmdName)


### PR DESCRIPTION
This is helpful for connecting nctl to the staging API(s) without always having to specify the flags.