### PR TITLE
Basic auth

### DIFF
--- a/api/util/authentication.go
+++ b/api/util/authentication.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	meta "github.com/ninech/apis/meta/v1alpha1"
+	"github.com/ninech/nctl/api"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// BasicAuth key constants which represent the keys used in basic auth
+	// secrets
+	BasicAuthUsernameKey = "basicAuthUsername"
+	BasicAuthPasswordKey = "basicAuthPassword"
+)
+
+// BasicAuth contains credentials for basic authentication
+type BasicAuth struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// NewBasicAuthFromSecret returns a basic auth resource filled with data from
+// a secret.
+func NewBasicAuthFromSecret(ctx context.Context, secret meta.Reference, client *api.Client) (*BasicAuth, error) {
+	basicAuthSecret := &corev1.Secret{}
+	if err := client.Get(ctx, secret.NamespacedName(), basicAuthSecret); err != nil {
+		return nil, fmt.Errorf("error when retrieving secret: %w", err)
+	}
+	if _, ok := basicAuthSecret.Data[BasicAuthUsernameKey]; !ok {
+		return nil, fmt.Errorf("key %s not found in basic auth secret %s", BasicAuthUsernameKey, secret.Name)
+	}
+
+	if _, ok := basicAuthSecret.Data[BasicAuthPasswordKey]; !ok {
+		return nil, fmt.Errorf("key %s not found in basic auth secret %s", BasicAuthPasswordKey, secret.Name)
+	}
+
+	return &BasicAuth{
+		string(basicAuthSecret.Data[BasicAuthUsernameKey]),
+		string(basicAuthSecret.Data[BasicAuthPasswordKey]),
+	}, nil
+}

--- a/api/util/authentication.go
+++ b/api/util/authentication.go
@@ -18,8 +18,8 @@ const (
 
 // BasicAuth contains credentials for basic authentication
 type BasicAuth struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Username string `json:"username" yaml:"username"`
+	Password string `json:"password" yaml:"password"`
 }
 
 // NewBasicAuthFromSecret returns a basic auth resource filled with data from

--- a/auth/config.go
+++ b/auth/config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ninech/nctl/api"
 	"github.com/ninech/nctl/api/util"
+	"github.com/ninech/nctl/internal/format"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
@@ -42,7 +43,7 @@ func ReloginNeeded(err error) error {
 	return fmt.Errorf(
 		"%w, please re-login by executing %q",
 		err,
-		fmt.Sprintf("%s %s", os.Args[0], LoginCmdName),
+		format.Command().Login(),
 	)
 }
 

--- a/auth/login.go
+++ b/auth/login.go
@@ -23,10 +23,6 @@ type LoginCmd struct {
 	ExecPlugin   bool   `help:"Automatically run exec plugin after writing the kubeconfig." hidden:"" default:"true"`
 }
 
-const (
-	LoginCmdName = "auth login"
-)
-
 func (l *LoginCmd) Run(ctx context.Context, command string) error {
 	loadingRules, err := api.LoadingRules()
 	if err != nil {

--- a/create/project_config.go
+++ b/create/project_config.go
@@ -12,10 +12,11 @@ import (
 // all fields need to be pointers so we can detect if they have been set by
 // the user.
 type configCmd struct {
-	Size     *string            `help:"Size of the app."`
-	Port     *int32             `help:"Port the app is listening on."`
-	Replicas *int32             `help:"Amount of replicas of the running app."`
-	Env      *map[string]string `help:"Environment variables which are passed to the app at runtime."`
+	Size      string             `help:"Size of the app."`
+	Port      *int32             `help:"Port the app is listening on."`
+	Replicas  *int32             `help:"Amount of replicas of the running app."`
+	Env       *map[string]string `help:"Environment variables which are passed to the app at runtime."`
+	BasicAuth *bool              `help:"Enable/Disable basic authentication for applications."`
 }
 
 func (cmd *configCmd) Run(ctx context.Context, client *api.Client) error {
@@ -25,22 +26,7 @@ func (cmd *configCmd) Run(ctx context.Context, client *api.Client) error {
 }
 
 func (cmd *configCmd) newProjectConfig(namespace string) *apps.ProjectConfig {
-	size := apps.ApplicationSize("")
-	if cmd.Size != nil {
-		applicationSize := apps.ApplicationSize(*cmd.Size)
-		size = applicationSize
-	}
-
-	var port *int32
-	if cmd.Port != nil {
-		port = cmd.Port
-	}
-
-	var replicas *int32
-	if cmd.Replicas != nil {
-		replicas = cmd.Replicas
-	}
-	var env apps.EnvVars
+	env := apps.EnvVars{}
 	if cmd.Env != nil {
 		env = util.EnvVarsFromMap(*cmd.Env)
 	}
@@ -53,10 +39,11 @@ func (cmd *configCmd) newProjectConfig(namespace string) *apps.ProjectConfig {
 		Spec: apps.ProjectConfigSpec{
 			ForProvider: apps.ProjectConfigParameters{
 				Config: apps.Config{
-					Size:     size,
-					Replicas: replicas,
-					Port:     port,
-					Env:      env,
+					Size:            apps.ApplicationSize(cmd.Size),
+					Replicas:        cmd.Replicas,
+					Port:            cmd.Port,
+					Env:             env,
+					EnableBasicAuth: cmd.BasicAuth,
 				},
 			},
 		},

--- a/create/project_config_test.go
+++ b/create/project_config_test.go
@@ -27,32 +27,35 @@ func TestProjectConfig(t *testing.T) {
 	}{
 		"all fields set": {
 			cmd: configCmd{
-				Size:     pointer.String(string(test.AppMini)),
-				Port:     pointer.Int32(1337),
-				Replicas: pointer.Int32(42),
-				Env:      &map[string]string{"key1": "val1"},
+				Size:      string(test.AppMini),
+				Port:      pointer.Int32(1337),
+				Replicas:  pointer.Int32(42),
+				Env:       &map[string]string{"key1": "val1"},
+				BasicAuth: pointer.Bool(true),
 			},
 			project: "namespace-1",
 			checkConfig: func(t *testing.T, cmd configCmd, cfg *apps.ProjectConfig) {
 				assert.Equal(t, apiClient.Project, cfg.Name)
-				assert.Equal(t, apps.ApplicationSize(*cmd.Size), cfg.Spec.ForProvider.Config.Size)
+				assert.Equal(t, apps.ApplicationSize(cmd.Size), cfg.Spec.ForProvider.Config.Size)
 				assert.Equal(t, *cmd.Port, *cfg.Spec.ForProvider.Config.Port)
 				assert.Equal(t, *cmd.Replicas, *cfg.Spec.ForProvider.Config.Replicas)
+				assert.Equal(t, *cmd.BasicAuth, *cfg.Spec.ForProvider.Config.EnableBasicAuth)
 				assert.Equal(t, util.EnvVarsFromMap(*cmd.Env), cfg.Spec.ForProvider.Config.Env)
 			},
 		},
 		"some fields not set": {
 			cmd: configCmd{
-				Size:     pointer.String(string(test.AppMicro)),
+				Size:     string(test.AppMicro),
 				Replicas: pointer.Int32(1),
 			},
 			project: "namespace-2",
 			checkConfig: func(t *testing.T, cmd configCmd, cfg *apps.ProjectConfig) {
 				assert.Equal(t, apiClient.Project, cfg.Name)
-				assert.Equal(t, apps.ApplicationSize(*cmd.Size), cfg.Spec.ForProvider.Config.Size)
+				assert.Equal(t, apps.ApplicationSize(cmd.Size), cfg.Spec.ForProvider.Config.Size)
 				assert.Nil(t, cfg.Spec.ForProvider.Config.Port)
+				assert.Nil(t, cfg.Spec.ForProvider.Config.EnableBasicAuth)
 				assert.Equal(t, *cmd.Replicas, *cfg.Spec.ForProvider.Config.Replicas)
-				assert.Nil(t, cfg.Spec.ForProvider.Config.Env)
+				assert.Empty(t, cfg.Spec.ForProvider.Config.Env)
 			},
 		},
 		"all fields not set": {
@@ -63,7 +66,8 @@ func TestProjectConfig(t *testing.T) {
 				assert.Equal(t, test.AppSizeNotSet, cfg.Spec.ForProvider.Config.Size)
 				assert.Nil(t, cfg.Spec.ForProvider.Config.Port)
 				assert.Nil(t, cfg.Spec.ForProvider.Config.Replicas)
-				assert.Nil(t, cfg.Spec.ForProvider.Config.Env)
+				assert.Empty(t, cfg.Spec.ForProvider.Config.Env)
+				assert.Nil(t, cfg.Spec.ForProvider.Config.EnableBasicAuth)
 			},
 		},
 	}

--- a/get/application.go
+++ b/get/application.go
@@ -2,10 +2,12 @@ package get
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strings"
 	"text/tabwriter"
 
+	"github.com/hashicorp/go-multierror"
 	apps "github.com/ninech/apis/apps/v1alpha1"
 	"github.com/ninech/nctl/api"
 	"github.com/ninech/nctl/api/util"
@@ -13,8 +15,9 @@ import (
 )
 
 type applicationsCmd struct {
-	Name string `arg:"" help:"Name of the Application to get. If omitted all in the project will be listed." default:""`
-	out  io.Writer
+	Name        string `arg:"" help:"Name of the Application to get. If omitted all in the project will be listed." default:""`
+	Credentials bool   `help:"Show the basic auth credentials of the application."`
+	out         io.Writer
 }
 
 func (cmd *applicationsCmd) Run(ctx context.Context, client *api.Client, get *Cmd) error {
@@ -27,6 +30,18 @@ func (cmd *applicationsCmd) Run(ctx context.Context, client *api.Client, get *Cm
 	if len(appList.Items) == 0 {
 		printEmptyMessage(cmd.out, apps.ApplicationKind, client.Project)
 		return nil
+	}
+
+	if cmd.Credentials {
+		creds, err := gatherCredentials(ctx, appList.Items, client)
+		if len(creds) == 0 {
+			fmt.Fprintf(defaultOut(cmd.out), "no application with basic auth enabled found\n")
+			return err
+		}
+		if printErr := printCredentials(creds, get, defaultOut(cmd.out)); printErr != nil {
+			err = multierror.Append(err, printErr)
+		}
+		return err
 	}
 
 	switch get.Output {
@@ -56,6 +71,60 @@ func printApplication(apps []apps.Application, get *Cmd, out io.Writer, header b
 	}
 
 	return w.Flush()
+}
+
+func printCredentials(creds []appCredentials, get *Cmd, out io.Writer) error {
+	if get.Output == yamlOut {
+		return format.PrettyPrintResource(creds, format.PrintOpts{Out: out})
+	}
+	return printCredentialsTabRow(creds, get, out)
+}
+
+func printCredentialsTabRow(creds []appCredentials, get *Cmd, out io.Writer) error {
+	w := tabwriter.NewWriter(out, 0, 0, 4, ' ', 0)
+
+	if get.Output == full {
+		get.writeHeader(w, "NAME", "USERNAME", "PASSWORD")
+	}
+
+	for _, cred := range creds {
+		get.writeTabRow(w, cred.Project, cred.Application, cred.Username, cred.Password)
+	}
+
+	return w.Flush()
+}
+
+type appCredentials struct {
+	Application string `yaml:"application"`
+	Project     string `yaml:"project"`
+	util.BasicAuth
+}
+
+func gatherCredentials(ctx context.Context, items []apps.Application, c *api.Client) ([]appCredentials, error) {
+	var resultErrors error
+	creds := []appCredentials{}
+	for _, app := range items {
+		app := app
+		if app.Status.AtProvider.BasicAuthSecret == nil {
+			// the app has no basic auth configured so we skip it
+			// in the output
+			continue
+		}
+		basicAuth, err := util.NewBasicAuthFromSecret(
+			ctx,
+			app.Status.AtProvider.BasicAuthSecret.InNamespace(&app),
+			c,
+		)
+		if err != nil {
+			resultErrors = multierror.Append(
+				resultErrors,
+				fmt.Errorf("can not gather credentials for application %q: %w", app.Name, err),
+			)
+			continue
+		}
+		creds = append(creds, appCredentials{Application: app.Name, Project: app.Namespace, BasicAuth: *basicAuth})
+	}
+	return creds, resultErrors
 }
 
 func join(list []string) string {

--- a/get/application_test.go
+++ b/get/application_test.go
@@ -6,9 +6,13 @@ import (
 	"testing"
 
 	apps "github.com/ninech/apis/apps/v1alpha1"
+	meta "github.com/ninech/apis/meta/v1alpha1"
 	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/api/util"
 	"github.com/ninech/nctl/internal/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -45,7 +49,8 @@ func TestApplication(t *testing.T) {
 
 	buf := &bytes.Buffer{}
 	cmd := applicationsCmd{
-		out: buf,
+		out:         buf,
+		Credentials: false,
 	}
 
 	if err := cmd.Run(ctx, apiClient, get); err != nil {
@@ -69,4 +74,229 @@ func TestApplication(t *testing.T) {
 	}
 
 	assert.Equal(t, 1, test.CountLines(buf.String()))
+}
+
+func TestApplicationCredentials(t *testing.T) {
+	t.Parallel()
+
+	const basicAuthNotFound = "no application with basic auth enabled found\n"
+	ctx := context.Background()
+
+	for name, testCase := range map[string]struct {
+		resources     []client.Object
+		name          string
+		outputFormat  output
+		project       string
+		output        string
+		errorExpected bool
+	}{
+		"no basic auth configured, all apps in project": {
+			resources:    []client.Object{newBasicAuthApplication("dev", "dev", "")},
+			outputFormat: full,
+			project:      "dev",
+			output:       basicAuthNotFound,
+		},
+		"no basic auth configured, specific app in project": {
+			resources:    []client.Object{newBasicAuthApplication("dev", "dev", "")},
+			outputFormat: full,
+			project:      "dev",
+			name:         "dev",
+			output:       basicAuthNotFound,
+		},
+		"no basic auth configured, all apps in all projects": {
+			resources:    []client.Object{newBasicAuthApplication("dev", "dev", "")},
+			outputFormat: full,
+			output:       basicAuthNotFound,
+		},
+		"missing basic auth secret leads to error": {
+			resources:     []client.Object{newBasicAuthApplication("dev", "dev", "does-not-exist")},
+			outputFormat:  full,
+			name:          "dev",
+			project:       "dev",
+			output:        basicAuthNotFound,
+			errorExpected: true,
+		},
+		"basic auth configured in one app and all apps in the project requested": {
+			resources: []client.Object{
+				newBasicAuthApplication("dev", "dev", "sample-basic-auth-secret"),
+				newBasicAuthSecret(
+					"sample-basic-auth-secret",
+					"dev",
+					util.BasicAuth{
+						Username: "dev",
+						Password: "sample",
+					},
+				),
+			},
+			outputFormat: full,
+			project:      "dev",
+			output: `NAME    USERNAME    PASSWORD
+dev     dev         sample
+`,
+		},
+		"basic auth configured in one app and all apps in the project requested, no header format": {
+			resources: []client.Object{
+				newBasicAuthApplication("dev", "dev", "sample-basic-auth-secret"),
+				newBasicAuthSecret(
+					"sample-basic-auth-secret",
+					"dev",
+					util.BasicAuth{
+						Username: "dev",
+						Password: "sample",
+					},
+				),
+			},
+			project:      "dev",
+			outputFormat: noHeader,
+			output:       "dev    dev    sample\n",
+		},
+		"basic auth configured in one app and all apps in the project requested, yaml format": {
+			resources: []client.Object{
+				newBasicAuthApplication("dev", "dev", "sample-basic-auth-secret"),
+				newBasicAuthSecret(
+					"sample-basic-auth-secret",
+					"dev",
+					util.BasicAuth{
+						Username: "dev",
+						Password: "sample",
+					},
+				),
+			},
+			project:      "dev",
+			outputFormat: yamlOut,
+			output:       "-\x1b[96m application\x1b[0m:\x1b[92m dev\x1b[0m\n\x1b[92m  \x1b[0m\x1b[96mproject\x1b[0m:\x1b[92m dev\x1b[0m\n\x1b[92m  \x1b[0m\x1b[96mbasicauth\x1b[0m:\x1b[96m\x1b[0m\n\x1b[96m    username\x1b[0m:\x1b[92m dev\x1b[0m\n\x1b[92m    \x1b[0m\x1b[96mpassword\x1b[0m:\x1b[92m sample\x1b[0m\n",
+		},
+		"multiple apps with basic auth configured and all apps in the project requested": {
+			resources: []client.Object{
+				newBasicAuthApplication("dev", "dev", "dev-basic-auth-secret"),
+				newBasicAuthApplication("dev-second", "dev", "dev-second-basic-auth-secret"),
+				newBasicAuthSecret(
+					"dev-basic-auth-secret",
+					"dev",
+					util.BasicAuth{
+						Username: "dev",
+						Password: "sample",
+					},
+				),
+				newBasicAuthSecret(
+					"dev-second-basic-auth-secret",
+					"dev",
+					util.BasicAuth{
+						Username: "dev-second",
+						Password: "sample-second",
+					},
+				),
+			},
+			outputFormat: full,
+			project:      "dev",
+			output: `NAME          USERNAME      PASSWORD
+dev           dev           sample
+dev-second    dev-second    sample-second
+`,
+		},
+		"multiple apps in different projects and all apps requested, yaml format": {
+			resources: []client.Object{
+				newBasicAuthApplication("dev", "dev", "dev-basic-auth-secret"),
+				newBasicAuthApplication("prod", "prod", "prod-basic-auth-secret"),
+				newBasicAuthSecret(
+					"dev-basic-auth-secret",
+					"dev",
+					util.BasicAuth{
+						Username: "dev",
+						Password: "sample",
+					},
+				),
+				newBasicAuthSecret(
+					"prod-basic-auth-secret",
+					"prod",
+					util.BasicAuth{
+						Username: "prod",
+						Password: "secret",
+					},
+				),
+			},
+			outputFormat: yamlOut,
+			output:       "-\x1b[96m application\x1b[0m:\x1b[92m dev\x1b[0m\n\x1b[92m  \x1b[0m\x1b[96mproject\x1b[0m:\x1b[92m dev\x1b[0m\n\x1b[92m  \x1b[0m\x1b[96mbasicauth\x1b[0m:\x1b[96m\x1b[0m\n\x1b[96m    username\x1b[0m:\x1b[92m dev\x1b[0m\n\x1b[92m    \x1b[0m\x1b[96mpassword\x1b[0m:\x1b[92m sample\x1b[0m\n\x1b[92m\x1b[0m-\x1b[96m application\x1b[0m:\x1b[92m prod\x1b[0m\n\x1b[92m  \x1b[0m\x1b[96mproject\x1b[0m:\x1b[92m prod\x1b[0m\n\x1b[92m  \x1b[0m\x1b[96mbasicauth\x1b[0m:\x1b[96m\x1b[0m\n\x1b[96m    username\x1b[0m:\x1b[92m prod\x1b[0m\n\x1b[92m    \x1b[0m\x1b[96mpassword\x1b[0m:\x1b[92m secret\x1b[0m\n",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			testCase := testCase
+			get := &Cmd{
+				Output:      testCase.outputFormat,
+				AllProjects: testCase.project == "",
+			}
+			scheme, err := api.NewScheme()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			client := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithIndex(&apps.Application{}, "metadata.name", func(o client.Object) []string {
+					return []string{o.GetName()}
+				}).
+				WithObjects(testCase.resources...).
+				Build()
+			apiClient := &api.Client{WithWatch: client, Project: testCase.project}
+
+			buf := &bytes.Buffer{}
+			cmd := applicationsCmd{
+				out:         buf,
+				Name:        testCase.name,
+				Credentials: true,
+			}
+
+			err = cmd.Run(ctx, apiClient, get)
+			if testCase.errorExpected {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, testCase.output, buf.String())
+		})
+	}
+}
+
+func newBasicAuthApplication(name, project, secret string) *apps.Application {
+	app := &apps.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: project,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       apps.ApplicationKind,
+			APIVersion: apps.SchemeGroupVersion.String(),
+		},
+		Spec: apps.ApplicationSpec{
+			ForProvider: apps.ApplicationParameters{
+				Git: apps.ApplicationGitConfig{
+					GitTarget: apps.GitTarget{
+						URL:      "https://does-not-exist.example.com",
+						Revision: "main",
+					},
+				},
+			},
+		},
+	}
+	if secret != "" {
+		app.Status.AtProvider.BasicAuthSecret = &meta.LocalReference{Name: secret}
+	}
+	return app
+}
+
+func newBasicAuthSecret(name, project string, basicAuth util.BasicAuth) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: project,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		Data: map[string][]byte{
+			util.BasicAuthUsernameKey: []byte(basicAuth.Username),
+			util.BasicAuthPasswordKey: []byte(basicAuth.Password),
+		},
+	}
 }

--- a/get/get.go
+++ b/get/get.go
@@ -75,19 +75,22 @@ func (cmd *Cmd) writeHeader(w io.Writer, headings ...string) {
 // cmd.AllProjects is set and the project is not empty.
 func (cmd *Cmd) writeTabRow(w io.Writer, project string, row ...string) {
 	if cmd.AllProjects && len(project) != 0 {
-		fmt.Fprintf(w, "%s\t", project)
+		row = append([]string{project}, row...)
 	}
 
-	format := "%s\t"
-	// if there is just one element to be printed, we do not need a tab
-	// separator
-	if len(row) == 1 {
-		format = "%s"
+	switch length := len(row); length {
+	case 0:
+		break
+	case 1:
+		fmt.Fprintf(w, "%s\n", row[0])
+	default:
+		fmt.Fprintf(w, "%s", row[0])
+		for _, r := range row[1:] {
+			fmt.Fprintf(w, "\t%s", r)
+		}
+		fmt.Fprint(w, "\n")
+		return
 	}
-	for _, r := range row {
-		fmt.Fprintf(w, format, r)
-	}
-	fmt.Fprintf(w, "\n")
 }
 
 func printEmptyMessage(out io.Writer, kind, project string) {
@@ -96,7 +99,7 @@ func printEmptyMessage(out io.Writer, kind, project string) {
 		return
 	}
 
-	fmt.Printf("no %s found in project %s\n", flect.Pluralize(kind), project)
+	fmt.Fprintf(defaultOut(out), "no %s found in project %s\n", flect.Pluralize(kind), project)
 }
 
 func defaultOut(out io.Writer) io.Writer {

--- a/get/project_config_test.go
+++ b/get/project_config_test.go
@@ -27,11 +27,12 @@ func TestConfigs(t *testing.T) {
 	ctx := context.Background()
 
 	cases := map[string]struct {
-		cmd          configsCmd
-		get          *Cmd
-		project      string
-		configs      *apps.ProjectConfigList
-		otherConfigs *apps.ProjectConfigList
+		cmd                configsCmd
+		get                *Cmd
+		project            string
+		configs            *apps.ProjectConfigList
+		otherConfigs       *apps.ProjectConfigList
+		expectExactMessage string
 	}{
 		"get configs for all projects": {
 			cmd: configsCmd{},
@@ -86,6 +87,7 @@ func TestConfigs(t *testing.T) {
 			configs: &apps.ProjectConfigList{
 				Items: []apps.ProjectConfig{},
 			},
+			expectExactMessage: "no ProjectConfigs found in project ns-3\n",
 			otherConfigs: &apps.ProjectConfigList{
 				Items: []apps.ProjectConfig{
 					*fakeProjectConfig(time.Second*10, "ns-1", "ns-1"),
@@ -156,7 +158,11 @@ func TestConfigs(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			assert.Equal(t, len(tc.configs.Items), test.CountLines(buf.String()))
+			if tc.expectExactMessage != "" {
+				assert.Equal(t, buf.String(), tc.expectExactMessage)
+			} else {
+				assert.Equal(t, len(tc.configs.Items), test.CountLines(buf.String()))
+			}
 			buf.Reset()
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/lucasepe/codename v0.2.0
 	github.com/moby/moby v24.0.1+incompatible
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
-	github.com/ninech/apis v0.0.0-20230629122912-7629043cc602
+	github.com/ninech/apis v0.0.0-20230630090309-a9de5a5a3b7e
 	github.com/posener/complete v1.2.3
 	github.com/stretchr/testify v1.8.1
 	github.com/theckman/yacspin v0.13.12

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/lucasepe/codename v0.2.0
 	github.com/moby/moby v24.0.1+incompatible
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
-	github.com/ninech/apis v0.0.0-20230619202935-615a1724c34e
+	github.com/ninech/apis v0.0.0-20230629122912-7629043cc602
 	github.com/posener/complete v1.2.3
 	github.com/stretchr/testify v1.8.1
 	github.com/theckman/yacspin v0.13.12

--- a/go.sum
+++ b/go.sum
@@ -1049,6 +1049,8 @@ github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/ninech/apis v0.0.0-20230619202935-615a1724c34e h1:FzmvXlZJeJPFuKcVY8pttkhgq2X1HWyeaqDEOK5Ahh8=
 github.com/ninech/apis v0.0.0-20230619202935-615a1724c34e/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
+github.com/ninech/apis v0.0.0-20230629122912-7629043cc602 h1:QBDcoMYaQ5KgGG5AAT7S0FQO11q+D3u1NjK/g9yMGUc=
+github.com/ninech/apis v0.0.0-20230629122912-7629043cc602/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/go.sum
+++ b/go.sum
@@ -1051,6 +1051,10 @@ github.com/ninech/apis v0.0.0-20230619202935-615a1724c34e h1:FzmvXlZJeJPFuKcVY8p
 github.com/ninech/apis v0.0.0-20230619202935-615a1724c34e/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
 github.com/ninech/apis v0.0.0-20230629122912-7629043cc602 h1:QBDcoMYaQ5KgGG5AAT7S0FQO11q+D3u1NjK/g9yMGUc=
 github.com/ninech/apis v0.0.0-20230629122912-7629043cc602/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
+github.com/ninech/apis v0.0.0-20230630084642-e2ad2b4624f7 h1:X701hJcxGubQPYdnMsS/kCxM+rBUsMZNJfByASkQBJY=
+github.com/ninech/apis v0.0.0-20230630084642-e2ad2b4624f7/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
+github.com/ninech/apis v0.0.0-20230630090309-a9de5a5a3b7e h1:d3DTFSLbMEIGj/FYPi4XZxzXJZ4duiizVf6GcSzbVkY=
+github.com/ninech/apis v0.0.0-20230630090309-a9de5a5a3b7e/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/internal/format/command.go
+++ b/internal/format/command.go
@@ -1,0 +1,32 @@
+package format
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	LoginCommand          = "auth login"
+	getApplicationCommand = "get application"
+)
+
+type command string
+
+// Command can be used to print how certain nctl commands can be executed
+func Command() command {
+	return command(os.Args[0])
+}
+
+// Login returns the login command
+func (c command) Login() string {
+	return fmt.Sprintf("%s %s", string(c), LoginCommand)
+}
+
+// GetApplication returns the command for getting applications with nctl
+func (c command) GetApplication(extraFields ...string) string {
+	if len(extraFields) == 0 {
+		return fmt.Sprintf("%s %s", string(c), getApplicationCommand)
+	}
+	return fmt.Sprintf("%s %s %s", string(c), getApplicationCommand, strings.Join(extraFields, " "))
+}

--- a/internal/format/print.go
+++ b/internal/format/print.go
@@ -107,7 +107,11 @@ type PrintOpts struct {
 // multiple objects are supplied, they will be divided with a yaml divider.
 func PrettyPrintObjects[T resource.Managed](objs []T, opts PrintOpts) error {
 	for i, obj := range objs {
-		if err := prettyPrintObject(obj, opts); err != nil {
+		strippedObj, err := stripObj(obj, opts.ExcludeAdditional)
+		if err != nil {
+			return err
+		}
+		if err := PrettyPrintResource(strippedObj, opts); err != nil {
 			return err
 		}
 		// if there's another object we print a yaml divider
@@ -119,15 +123,10 @@ func PrettyPrintObjects[T resource.Managed](objs []T, opts PrintOpts) error {
 	return nil
 }
 
-// prettyPrintObject strips the supplied obj and prints it out similar to how
+// PrettyPrintResource prints the resource similar to how
 // https://github.com/goccy/go-yaml#ycat does it.
-func prettyPrintObject(obj resource.Managed, opts PrintOpts) error {
-	strippedObj, err := stripObj(obj, opts.ExcludeAdditional)
-	if err != nil {
-		return err
-	}
-
-	b, err := yaml.Marshal(strippedObj)
+func PrettyPrintResource(obj interface{}, opts PrintOpts) error {
+	b, err := yaml.Marshal(obj)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ninech/nctl/create"
 	"github.com/ninech/nctl/delete"
 	"github.com/ninech/nctl/get"
+	"github.com/ninech/nctl/internal/format"
 	"github.com/ninech/nctl/logs"
 	"github.com/ninech/nctl/update"
 	"github.com/posener/complete"
@@ -72,7 +73,7 @@ func main() {
 	if err != nil {
 		kongCtx.Fatalf("can not identify executable path of %s: %v", util.NctlName, err)
 	}
-	if strings.HasPrefix(kongCtx.Command(), auth.LoginCmdName) {
+	if strings.HasPrefix(kongCtx.Command(), format.LoginCommand) {
 		kongCtx.FatalIfErrorf(nctl.Auth.Login.Run(ctx, command))
 		return
 	}
@@ -85,7 +86,7 @@ func main() {
 	client, err := api.New(ctx, nctl.APICluster, nctl.Project, api.LogClient(nctl.LogAPIAddress, nctl.LogAPIInsecure))
 	if err != nil {
 		fmt.Println(err)
-		fmt.Printf("\nUnable to get API client, are you logged in?\n\nUse `%s %s` to login.\n", kongCtx.Model.Name, auth.LoginCmdName)
+		fmt.Printf("\nUnable to get API client, are you logged in?\n\nUse `%s` to login.\n", format.Command().Login())
 		os.Exit(1)
 	}
 

--- a/update/application.go
+++ b/update/application.go
@@ -14,13 +14,14 @@ import (
 // all fields need to be pointers so we can detect if they have been set by
 // the user.
 type applicationCmd struct {
-	Name     *string            `arg:"" help:"Name of the application."`
-	Git      *gitConfig         `embed:"" prefix:"git-"`
-	Size     *string            `help:"Size of the app."`
-	Port     *int32             `help:"Port the app is listening on."`
-	Replicas *int32             `help:"Amount of replicas of the running app."`
-	Hosts    *[]string          `help:"Host names where the application can be accessed. If empty, the application will just be accessible on a generated host name on the deploio.app domain."`
-	Env      *map[string]string `help:"Environment variables which are passed to the app at runtime."`
+	Name      *string            `arg:"" help:"Name of the application."`
+	Git       *gitConfig         `embed:"" prefix:"git-"`
+	Size      *string            `help:"Size of the app."`
+	Port      *int32             `help:"Port the app is listening on."`
+	Replicas  *int32             `help:"Amount of replicas of the running app."`
+	Hosts     *[]string          `help:"Host names where the application can be accessed. If empty, the application will just be accessible on a generated host name on the deploio.app domain."`
+	BasicAuth *bool              `help:"Enable/Disable basic authentication for the application."`
+	Env       *map[string]string `help:"Environment variables which are passed to the app at runtime."`
 }
 
 type gitConfig struct {
@@ -108,5 +109,8 @@ func (cmd *applicationCmd) applyUpdates(app *apps.Application) {
 	}
 	if cmd.Env != nil {
 		app.Spec.ForProvider.Config.Env = util.EnvVarsFromMap(*cmd.Env)
+	}
+	if cmd.BasicAuth != nil {
+		app.Spec.ForProvider.Config.EnableBasicAuth = cmd.BasicAuth
 	}
 }

--- a/update/application_test.go
+++ b/update/application_test.go
@@ -39,10 +39,11 @@ func TestApplication(t *testing.T) {
 				},
 				Hosts: []string{"one.example.org"},
 				Config: apps.Config{
-					Size:     initialSize,
-					Replicas: pointer.Int32(1),
-					Port:     pointer.Int32(1337),
-					Env:      util.EnvVarsFromMap(map[string]string{"foo": "bar"}),
+					Size:            initialSize,
+					Replicas:        pointer.Int32(1),
+					Port:            pointer.Int32(1337),
+					Env:             util.EnvVarsFromMap(map[string]string{"foo": "bar"}),
+					EnableBasicAuth: pointer.Bool(false),
 				},
 			},
 		},
@@ -85,11 +86,12 @@ func TestApplication(t *testing.T) {
 					SubPath:  pointer.String("new/path"),
 					Revision: pointer.String("some-change"),
 				},
-				Size:     pointer.String("newsize"),
-				Port:     pointer.Int32(1234),
-				Replicas: pointer.Int32(999),
-				Hosts:    &[]string{"one.example.org", "two.example.org"},
-				Env:      &map[string]string{"bar": "zoo"},
+				Size:      pointer.String("newsize"),
+				Port:      pointer.Int32(1234),
+				Replicas:  pointer.Int32(999),
+				Hosts:     &[]string{"one.example.org", "two.example.org"},
+				Env:       &map[string]string{"bar": "zoo"},
+				BasicAuth: pointer.Bool(true),
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, orig, updated *apps.Application) {
 				assert.Equal(t, *cmd.Git.URL, updated.Spec.ForProvider.Git.URL)
@@ -98,6 +100,7 @@ func TestApplication(t *testing.T) {
 				assert.Equal(t, apps.ApplicationSize(*cmd.Size), updated.Spec.ForProvider.Config.Size)
 				assert.Equal(t, *cmd.Port, *updated.Spec.ForProvider.Config.Port)
 				assert.Equal(t, *cmd.Replicas, *updated.Spec.ForProvider.Config.Replicas)
+				assert.Equal(t, *cmd.BasicAuth, *updated.Spec.ForProvider.Config.EnableBasicAuth)
 				assert.Equal(t, *cmd.Hosts, updated.Spec.ForProvider.Hosts)
 				assert.Equal(t, util.EnvVarsFromMap(*cmd.Env), updated.Spec.ForProvider.Config.Env)
 			},

--- a/update/project_config.go
+++ b/update/project_config.go
@@ -14,10 +14,11 @@ import (
 // all fields need to be pointers so we can detect if they have been set by
 // the user.
 type configCmd struct {
-	Size     *string            `help:"Size of the app."`
-	Port     *int32             `help:"Port the app is listening on."`
-	Replicas *int32             `help:"Amount of replicas of the running app."`
-	Env      *map[string]string `help:"Environment variables which are passed to the app at runtime."`
+	Size      *string            `help:"Size of the app."`
+	Port      *int32             `help:"Port the app is listening on."`
+	Replicas  *int32             `help:"Amount of replicas of the running app."`
+	Env       *map[string]string `help:"Environment variables which are passed to the app at runtime."`
+	BasicAuth *bool              `help:"Enable/Disable basic authentication for applications."`
 }
 
 func (cmd *configCmd) Run(ctx context.Context, client *api.Client) error {
@@ -44,8 +45,7 @@ func (cmd *configCmd) Run(ctx context.Context, client *api.Client) error {
 
 func (cmd *configCmd) applyUpdates(cfg *apps.ProjectConfig) {
 	if cmd.Size != nil {
-		newSize := apps.ApplicationSize(*cmd.Size)
-		cfg.Spec.ForProvider.Config.Size = newSize
+		cfg.Spec.ForProvider.Config.Size = apps.ApplicationSize(*cmd.Size)
 	}
 	if cmd.Port != nil {
 		cfg.Spec.ForProvider.Config.Port = cmd.Port
@@ -55,5 +55,8 @@ func (cmd *configCmd) applyUpdates(cfg *apps.ProjectConfig) {
 	}
 	if cmd.Env != nil {
 		cfg.Spec.ForProvider.Config.Env = util.EnvVarsFromMap(*cmd.Env)
+	}
+	if cmd.BasicAuth != nil {
+		cfg.Spec.ForProvider.Config.EnableBasicAuth = cmd.BasicAuth
 	}
 }

--- a/update/project_config_test.go
+++ b/update/project_config_test.go
@@ -27,10 +27,11 @@ func TestConfig(t *testing.T) {
 		Spec: apps.ProjectConfigSpec{
 			ForProvider: apps.ProjectConfigParameters{
 				Config: apps.Config{
-					Size:     initialSize,
-					Replicas: pointer.Int32(1),
-					Port:     pointer.Int32(1337),
-					Env:      util.EnvVarsFromMap(map[string]string{"foo": "bar"}),
+					Size:            initialSize,
+					Replicas:        pointer.Int32(1),
+					Port:            pointer.Int32(1337),
+					Env:             util.EnvVarsFromMap(map[string]string{"foo": "bar"}),
+					EnableBasicAuth: pointer.Bool(false),
 				},
 			},
 		},
@@ -63,19 +64,31 @@ func TestConfig(t *testing.T) {
 				assert.NotEqual(t, orig.Spec.ForProvider.Config.Size, updated.Spec.ForProvider.Config.Size)
 			},
 		},
+		"update basic auth": {
+			orig:    existingConfig,
+			project: project,
+			cmd: configCmd{
+				BasicAuth: pointer.Bool(true),
+			},
+			checkConfig: func(t *testing.T, cmd configCmd, orig, updated *apps.ProjectConfig) {
+				assert.True(t, *updated.Spec.ForProvider.Config.EnableBasicAuth)
+			},
+		},
 		"all fields update": {
 			orig:    existingConfig,
 			project: project,
 			cmd: configCmd{
-				Size:     pointer.String("newsize"),
-				Port:     pointer.Int32(1000),
-				Replicas: pointer.Int32(2),
-				Env:      &map[string]string{"zoo": "bar"},
+				Size:      pointer.String("newsize"),
+				Port:      pointer.Int32(1000),
+				Replicas:  pointer.Int32(2),
+				Env:       &map[string]string{"zoo": "bar"},
+				BasicAuth: pointer.Bool(true),
 			},
 			checkConfig: func(t *testing.T, cmd configCmd, orig, updated *apps.ProjectConfig) {
 				assert.Equal(t, apps.ApplicationSize(*cmd.Size), updated.Spec.ForProvider.Config.Size)
 				assert.Equal(t, *cmd.Port, *updated.Spec.ForProvider.Config.Port)
 				assert.Equal(t, *cmd.Replicas, *updated.Spec.ForProvider.Config.Replicas)
+				assert.Equal(t, *cmd.BasicAuth, *updated.Spec.ForProvider.Config.EnableBasicAuth)
 				assert.Equal(t, util.EnvVarsFromMap(*cmd.Env), updated.Spec.ForProvider.Config.Env)
 			},
 		},


### PR DESCRIPTION
This adds basic auth functionality for applications. Basic auth can now be handled in the applications `create`, `get` and `update` commands. Furthermore the corresponding project config commands also got support. Credentials of one application or all applications can then be shown by using the `--credentials` option to the `get application` command.