### PR TITLE
Add build-time env vars to application

### DIFF
--- a/create/application.go
+++ b/create/application.go
@@ -33,6 +33,7 @@ type applicationCmd struct {
 	Hosts       []string          `help:"Host names where the application can be accessed. If empty, the application will just be accessible on a generated host name on the deploio.app domain."`
 	BasicAuth   bool              `default:"false" help:"Enable/Disable basic authentication for the application."`
 	Env         map[string]string `help:"Environment variables which are passed to the app at runtime."`
+	BuildEnv    map[string]string `help:"Environment variables which are passed to the app build process."`
 }
 
 type gitConfig struct {
@@ -163,6 +164,7 @@ func (app *applicationCmd) newApplication(project string) *apps.Application {
 					Env:             util.EnvVarsFromMap(app.Env),
 					EnableBasicAuth: pointer.Bool(app.BasicAuth),
 				},
+				BuildEnv: util.EnvVarsFromMap(app.BuildEnv),
 			},
 		},
 	}

--- a/create/application_test.go
+++ b/create/application_test.go
@@ -49,6 +49,7 @@ func TestApplication(t *testing.T) {
 				Replicas:  42,
 				BasicAuth: false,
 				Env:       map[string]string{"hello": "world"},
+				BuildEnv:  map[string]string{"BP_GO_TARGETS": "./cmd/web-server"},
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
 				assert.Equal(t, cmd.Name, app.Name)
@@ -61,6 +62,7 @@ func TestApplication(t *testing.T) {
 				assert.Equal(t, int32(cmd.Replicas), *app.Spec.ForProvider.Config.Replicas)
 				assert.Equal(t, cmd.BasicAuth, *app.Spec.ForProvider.Config.EnableBasicAuth)
 				assert.Equal(t, util.EnvVarsFromMap(cmd.Env), app.Spec.ForProvider.Config.Env)
+				assert.Equal(t, util.EnvVarsFromMap(cmd.BuildEnv), app.Spec.ForProvider.BuildEnv)
 				assert.Nil(t, app.Spec.ForProvider.Git.Auth)
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/lucasepe/codename v0.2.0
 	github.com/moby/moby v24.0.1+incompatible
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
-	github.com/ninech/apis v0.0.0-20230630090309-a9de5a5a3b7e
+	github.com/ninech/apis v0.0.0-20230705173917-4bac20a63fec
 	github.com/posener/complete v1.2.3
 	github.com/stretchr/testify v1.8.1
 	github.com/theckman/yacspin v0.13.12

--- a/go.sum
+++ b/go.sum
@@ -1047,14 +1047,8 @@ github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/ninech/apis v0.0.0-20230619202935-615a1724c34e h1:FzmvXlZJeJPFuKcVY8pttkhgq2X1HWyeaqDEOK5Ahh8=
-github.com/ninech/apis v0.0.0-20230619202935-615a1724c34e/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
-github.com/ninech/apis v0.0.0-20230629122912-7629043cc602 h1:QBDcoMYaQ5KgGG5AAT7S0FQO11q+D3u1NjK/g9yMGUc=
-github.com/ninech/apis v0.0.0-20230629122912-7629043cc602/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
-github.com/ninech/apis v0.0.0-20230630084642-e2ad2b4624f7 h1:X701hJcxGubQPYdnMsS/kCxM+rBUsMZNJfByASkQBJY=
-github.com/ninech/apis v0.0.0-20230630084642-e2ad2b4624f7/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
-github.com/ninech/apis v0.0.0-20230630090309-a9de5a5a3b7e h1:d3DTFSLbMEIGj/FYPi4XZxzXJZ4duiizVf6GcSzbVkY=
-github.com/ninech/apis v0.0.0-20230630090309-a9de5a5a3b7e/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
+github.com/ninech/apis v0.0.0-20230705173917-4bac20a63fec h1:iPmg9c5FBRUrPPXBv2X1WrrNS0WVNgdSFxUiDgaMkHY=
+github.com/ninech/apis v0.0.0-20230705173917-4bac20a63fec/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/update/application.go
+++ b/update/application.go
@@ -22,6 +22,7 @@ type applicationCmd struct {
 	Hosts     *[]string          `help:"Host names where the application can be accessed. If empty, the application will just be accessible on a generated host name on the deploio.app domain."`
 	BasicAuth *bool              `help:"Enable/Disable basic authentication for the application."`
 	Env       *map[string]string `help:"Environment variables which are passed to the app at runtime."`
+	BuildEnv  *map[string]string `help:"Environment variables which are passed to the app build process."`
 }
 
 type gitConfig struct {
@@ -109,6 +110,9 @@ func (cmd *applicationCmd) applyUpdates(app *apps.Application) {
 	}
 	if cmd.Env != nil {
 		app.Spec.ForProvider.Config.Env = util.EnvVarsFromMap(*cmd.Env)
+	}
+	if cmd.BuildEnv != nil {
+		app.Spec.ForProvider.BuildEnv = util.EnvVarsFromMap(*cmd.BuildEnv)
 	}
 	if cmd.BasicAuth != nil {
 		app.Spec.ForProvider.Config.EnableBasicAuth = cmd.BasicAuth


### PR DESCRIPTION
We should support buildpack env variables. This PR adds new flags to support passing these build-time env vars on app creation/update.