### PR TITLE
rename credentials argument for consistency

### DIFF
--- a/get/application.go
+++ b/get/application.go
@@ -15,9 +15,9 @@ import (
 )
 
 type applicationsCmd struct {
-	Name        string `arg:"" help:"Name of the Application to get. If omitted all in the project will be listed." default:""`
-	Credentials bool   `help:"Show the basic auth credentials of the application."`
-	out         io.Writer
+	Name                 string `arg:"" help:"Name of the Application to get. If omitted all in the project will be listed." default:""`
+	BasicAuthCredentials bool   `help:"Show the basic auth credentials of the application."`
+	out                  io.Writer
 }
 
 func (cmd *applicationsCmd) Run(ctx context.Context, client *api.Client, get *Cmd) error {
@@ -32,7 +32,7 @@ func (cmd *applicationsCmd) Run(ctx context.Context, client *api.Client, get *Cm
 		return nil
 	}
 
-	if cmd.Credentials {
+	if cmd.BasicAuthCredentials {
 		creds, err := gatherCredentials(ctx, appList.Items, client)
 		if len(creds) == 0 {
 			fmt.Fprintf(defaultOut(cmd.out), "no application with basic auth enabled found\n")

--- a/get/application_test.go
+++ b/get/application_test.go
@@ -49,8 +49,8 @@ func TestApplication(t *testing.T) {
 
 	buf := &bytes.Buffer{}
 	cmd := applicationsCmd{
-		out:         buf,
-		Credentials: false,
+		out:                  buf,
+		BasicAuthCredentials: false,
 	}
 
 	if err := cmd.Run(ctx, apiClient, get); err != nil {
@@ -241,9 +241,9 @@ dev-second    dev-second    sample-second
 
 			buf := &bytes.Buffer{}
 			cmd := applicationsCmd{
-				out:         buf,
-				Name:        testCase.name,
-				Credentials: true,
+				out:                  buf,
+				Name:                 testCase.name,
+				BasicAuthCredentials: true,
 			}
 
 			err = cmd.Run(ctx, apiClient, get)


### PR DESCRIPTION
Gathering credentials can now be done via:
```bash
nctl get app <name> --basic-auth-credentials
```

which is more consistent with the `--basic-auth` argument on the application create command.