### PR TITLE
do not set defaults in the application on creation

### DIFF
--- a/create/application.go
+++ b/create/application.go
@@ -27,23 +27,23 @@ import (
 // note: when adding/changing fields here also make sure to carry it over to
 // update/application.go.
 type applicationCmd struct {
-	Name        string            `arg:"" default:"" help:"Name of the application. A random name is generated if omitted."`
-	Wait        bool              `default:"true" help:"Wait until application is fully created."`
-	WaitTimeout time.Duration     `default:"15m" help:"Duration to wait for application getting ready. Only relevant if wait is set."`
+	Name        string            `arg:"" default:"" help:"Name of the app. A random name is generated if omitted."`
+	Wait        bool              `default:"true" help:"Wait until the app is fully created."`
+	WaitTimeout time.Duration     `default:"15m" help:"Duration to wait for the app getting ready. Only relevant if wait is set."`
 	Git         gitConfig         `embed:"" prefix:"git-"`
-	Size        *string           `help:"Size of the app (defaults to \"${app_default_size}\")."`
-	Port        *int32            `help:"Port the app is listening on (defaults to ${app_default_port})."`
-	Replicas    *int32            `help:"Amount of replicas of the running app (defaults to ${app_default_replicas})."`
-	Hosts       []string          `help:"Host names where the application can be accessed. If empty, the application will just be accessible on a generated host name on the deploio.app domain."`
-	BasicAuth   *bool             `help:"Enable/Disable basic authentication for the applicaton (defaults to ${app_default_basic_auth})."`
+	Size        *string           `help:"Size of the app (defaults to \"${app_default_size}\")." placeholder:"${app_default_size}"`
+	Port        *int32            `help:"Port the app is listening on (defaults to ${app_default_port})." placeholder:"${app_default_port}"`
+	Replicas    *int32            `help:"Amount of replicas of the running app (defaults to ${app_default_replicas})." placeholder:"${app_default_replicas}"`
+	Hosts       []string          `help:"Host names where the app can be accessed. If empty, the app will just be accessible on a generated host name on the deploio.app domain."`
+	BasicAuth   *bool             `help:"Enable/Disable basic authentication for the app (defaults to ${app_default_basic_auth})." placeholder:"${app_default_basic_auth}"`
 	Env         map[string]string `help:"Environment variables which are passed to the app at runtime."`
 	BuildEnv    map[string]string `help:"Environment variables which are passed to the app build process."`
 }
 
 type gitConfig struct {
-	URL                   string  `required:"" help:"URL to the Git repository containing the application source. Both HTTPS and SSH formats are supported."`
-	SubPath               string  `help:"SubPath is a path in the git repo which contains the application code. If not given, the root directory of the git repo will be used."`
-	Revision              string  `default:"main" help:"Revision defines the revision of the source to deploy the application to. This can be a commit, tag or branch."`
+	URL                   string  `required:"" help:"URL to the Git repository containing the app source. Both HTTPS and SSH formats are supported."`
+	SubPath               string  `help:"SubPath is a path in the git repo which contains the app code. If not given, the root directory of the git repo will be used."`
+	Revision              string  `default:"main" help:"Revision defines the revision of the source to deploy the app to. This can be a commit, tag or branch."`
 	Username              *string `help:"Username to use when authenticating to the git repository over HTTPS." env:"GIT_USERNAME"`
 	Password              *string `help:"Password to use when authenticating to the git repository over HTTPS. In case of GitHub or GitLab, this can also be an access token." env:"GIT_PASSWORD"`
 	SSHPrivateKey         *string `help:"Private key in PEM format to connect to the git repository via SSH." env:"GIT_SSH_PRIVATE_KEY" xor:"SSH_KEY"`

--- a/create/application.go
+++ b/create/application.go
@@ -3,11 +3,14 @@ package create
 import (
 	"context"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/alecthomas/kong"
 	"github.com/grafana/loki/pkg/logproto"
 	apps "github.com/ninech/apis/apps/v1alpha1"
 	meta "github.com/ninech/apis/meta/v1alpha1"
@@ -18,7 +21,6 @@ import (
 	"github.com/ninech/nctl/logs"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/utils/pointer"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -29,11 +31,11 @@ type applicationCmd struct {
 	Wait        bool              `default:"true" help:"Wait until application is fully created."`
 	WaitTimeout time.Duration     `default:"15m" help:"Duration to wait for application getting ready. Only relevant if wait is set."`
 	Git         gitConfig         `embed:"" prefix:"git-"`
-	Size        string            `default:"micro" help:"Size of the app."`
-	Port        int32             `default:"8080" help:"Port the app is listening on."`
-	Replicas    int32             `default:"1" help:"Amount of replicas of the running app."`
+	Size        *string           `help:"Size of the app (defaults to \"${app_default_size}\")."`
+	Port        *int32            `help:"Port the app is listening on (defaults to ${app_default_port})."`
+	Replicas    *int32            `help:"Amount of replicas of the running app (defaults to ${app_default_replicas})."`
 	Hosts       []string          `help:"Host names where the application can be accessed. If empty, the application will just be accessible on a generated host name on the deploio.app domain."`
-	BasicAuth   bool              `default:"false" help:"Enable/Disable basic authentication for the application."`
+	BasicAuth   *bool             `help:"Enable/Disable basic authentication for the applicaton (defaults to ${app_default_basic_auth})."`
 	Env         map[string]string `help:"Environment variables which are passed to the app at runtime."`
 	BuildEnv    map[string]string `help:"Environment variables which are passed to the app build process."`
 }
@@ -159,9 +161,25 @@ func (app *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 	return nil
 }
 
+func (app *applicationCmd) config() apps.Config {
+	config := apps.Config{
+		EnableBasicAuth: app.BasicAuth,
+		Env:             util.EnvVarsFromMap(app.Env),
+	}
+	if app.Size != nil {
+		config.Size = apps.ApplicationSize(*app.Size)
+	}
+	if app.Port != nil {
+		config.Port = app.Port
+	}
+	if app.Replicas != nil {
+		config.Replicas = app.Replicas
+	}
+	return config
+}
+
 func (app *applicationCmd) newApplication(project string) *apps.Application {
 	name := getName(app.Name)
-	size := apps.ApplicationSize(app.Size)
 
 	return &apps.Application{
 		ObjectMeta: metav1.ObjectMeta{
@@ -177,14 +195,8 @@ func (app *applicationCmd) newApplication(project string) *apps.Application {
 						Revision: app.Git.Revision,
 					},
 				},
-				Hosts: app.Hosts,
-				Config: apps.Config{
-					Size:            size,
-					Replicas:        pointer.Int32(app.Replicas),
-					Port:            pointer.Int32(app.Port),
-					Env:             util.EnvVarsFromMap(app.Env),
-					EnableBasicAuth: pointer.Bool(app.BasicAuth),
-				},
+				Hosts:    app.Hosts,
+				Config:   app.config(),
 				BuildEnv: util.EnvVarsFromMap(app.BuildEnv),
 			},
 		},
@@ -385,4 +397,24 @@ func validatePEM(content string) (*string, error) {
 		return nil, fmt.Errorf("no valid PEM formatted data found")
 	}
 	return &content, nil
+}
+
+// ApplicationKongVars returns all variables which are used in the application
+// create command
+func ApplicationKongVars() (kong.Vars, error) {
+	result := make(kong.Vars)
+	result["app_default_size"] = string(apps.DefaultConfig.Size)
+	if apps.DefaultConfig.Port == nil {
+		return nil, errors.New("no default application port found")
+	}
+	result["app_default_port"] = strconv.Itoa(int(*apps.DefaultConfig.Port))
+	if apps.DefaultConfig.Replicas == nil {
+		return nil, errors.New("no default application replicas found")
+	}
+	result["app_default_replicas"] = strconv.Itoa(int(*apps.DefaultConfig.Replicas))
+	if apps.DefaultConfig.EnableBasicAuth == nil {
+		return nil, errors.New("no default application basic authentication settings found")
+	}
+	result["app_default_basic_auth"] = strconv.FormatBool(*apps.DefaultConfig.EnableBasicAuth)
+	return result, nil
 }

--- a/create/application_test.go
+++ b/create/application_test.go
@@ -120,11 +120,11 @@ func TestApplication(t *testing.T) {
 				},
 				Wait:      false,
 				Name:      "custom-name",
-				Size:      "mini",
+				Size:      pointer.String("mini"),
 				Hosts:     []string{"custom.example.org", "custom2.example.org"},
-				Port:      1337,
-				Replicas:  42,
-				BasicAuth: false,
+				Port:      pointer.Int32(1337),
+				Replicas:  pointer.Int32(42),
+				BasicAuth: pointer.Bool(false),
 				Env:       map[string]string{"hello": "world"},
 				BuildEnv:  map[string]string{"BP_GO_TARGETS": "./cmd/web-server"},
 			},
@@ -134,10 +134,10 @@ func TestApplication(t *testing.T) {
 				assert.Equal(t, cmd.Git.SubPath, app.Spec.ForProvider.Git.SubPath)
 				assert.Equal(t, cmd.Git.Revision, app.Spec.ForProvider.Git.Revision)
 				assert.Equal(t, cmd.Hosts, app.Spec.ForProvider.Hosts)
-				assert.Equal(t, apps.ApplicationSize(cmd.Size), app.Spec.ForProvider.Config.Size)
-				assert.Equal(t, int32(cmd.Port), *app.Spec.ForProvider.Config.Port)
-				assert.Equal(t, int32(cmd.Replicas), *app.Spec.ForProvider.Config.Replicas)
-				assert.Equal(t, cmd.BasicAuth, *app.Spec.ForProvider.Config.EnableBasicAuth)
+				assert.Equal(t, apps.ApplicationSize(*cmd.Size), app.Spec.ForProvider.Config.Size)
+				assert.Equal(t, *cmd.Port, *app.Spec.ForProvider.Config.Port)
+				assert.Equal(t, *cmd.Replicas, *app.Spec.ForProvider.Config.Replicas)
+				assert.Equal(t, *cmd.BasicAuth, *app.Spec.ForProvider.Config.EnableBasicAuth)
 				assert.Equal(t, util.EnvVarsFromMap(cmd.Env), app.Spec.ForProvider.Config.Env)
 				assert.Equal(t, util.EnvVarsFromMap(cmd.BuildEnv), app.Spec.ForProvider.BuildEnv)
 				assert.Nil(t, app.Spec.ForProvider.Git.Auth)
@@ -147,13 +147,13 @@ func TestApplication(t *testing.T) {
 			cmd: applicationCmd{
 				Wait:      false,
 				Name:      "basic-auth",
-				Size:      "mini",
-				BasicAuth: true,
+				Size:      pointer.String("mini"),
+				BasicAuth: pointer.Bool(true),
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
 				assert.Equal(t, cmd.Name, app.Name)
-				assert.Equal(t, apps.ApplicationSize(cmd.Size), app.Spec.ForProvider.Config.Size)
-				assert.Equal(t, cmd.BasicAuth, *app.Spec.ForProvider.Config.EnableBasicAuth)
+				assert.Equal(t, apps.ApplicationSize(*cmd.Size), app.Spec.ForProvider.Config.Size)
+				assert.Equal(t, *cmd.BasicAuth, *app.Spec.ForProvider.Config.EnableBasicAuth)
 			},
 		},
 		"with user/pass git auth": {
@@ -186,7 +186,7 @@ func TestApplication(t *testing.T) {
 				},
 				Wait: false,
 				Name: "ssh-key-auth",
-				Size: "mini",
+				Size: pointer.String("mini"),
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
 				auth := util.GitAuth{SSHPrivateKey: cmd.Git.SSHPrivateKey}
@@ -207,7 +207,7 @@ func TestApplication(t *testing.T) {
 				},
 				Wait: false,
 				Name: "ssh-key-auth-ed25519",
-				Size: "mini",
+				Size: pointer.String("mini"),
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
 				auth := util.GitAuth{SSHPrivateKey: cmd.Git.SSHPrivateKey}
@@ -228,7 +228,7 @@ func TestApplication(t *testing.T) {
 				},
 				Wait: false,
 				Name: "ssh-key-auth-from-file",
-				Size: "mini",
+				Size: pointer.String("mini"),
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
 				auth := util.GitAuth{SSHPrivateKey: pointer.String("notused")}
@@ -249,7 +249,7 @@ func TestApplication(t *testing.T) {
 				},
 				Wait: false,
 				Name: "ssh-key-auth-from-file-ed25519",
-				Size: "mini",
+				Size: pointer.String("mini"),
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
 				auth := util.GitAuth{SSHPrivateKey: pointer.String("notused")}
@@ -270,7 +270,7 @@ func TestApplication(t *testing.T) {
 				},
 				Wait: false,
 				Name: "ssh-key-auth-non-valid",
-				Size: "mini",
+				Size: pointer.String("mini"),
 			},
 			errorExpected: true,
 		},
@@ -301,7 +301,7 @@ func TestApplicationWait(t *testing.T) {
 		Wait:        true,
 		WaitTimeout: time.Second * 5,
 		Name:        "some-name",
-		BasicAuth:   true,
+		BasicAuth:   pointer.Bool(true),
 	}
 	project := "default"
 

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/theckman/yacspin v0.13.12
 	github.com/willabides/kongplete v0.3.0
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
+	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1

--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,9 @@ require (
 	github.com/lucasepe/codename v0.2.0
 	github.com/moby/moby v24.0.1+incompatible
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
-	github.com/ninech/apis v0.0.0-20230705173917-4bac20a63fec
+	github.com/ninech/apis v0.0.0-20230710190412-d2f781d73be9
 	github.com/posener/complete v1.2.3
+	github.com/prometheus/common v0.39.0
 	github.com/stretchr/testify v1.8.1
 	github.com/theckman/yacspin v0.13.12
 	github.com/willabides/kongplete v0.3.0
@@ -140,7 +141,6 @@ require (
 	github.com/prometheus/alertmanager v0.25.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
-	github.com/prometheus/common v0.39.0 // indirect
 	github.com/prometheus/common/sigv4 v0.1.0 // indirect
 	github.com/prometheus/exporter-toolkit v0.8.2 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1047,8 +1047,8 @@ github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/ninech/apis v0.0.0-20230705173917-4bac20a63fec h1:iPmg9c5FBRUrPPXBv2X1WrrNS0WVNgdSFxUiDgaMkHY=
-github.com/ninech/apis v0.0.0-20230705173917-4bac20a63fec/go.mod h1:/9HF0pE1ovvrfH4gUGzeYOVSSG3dgx4FosUBQsurzm0=
+github.com/ninech/apis v0.0.0-20230710190412-d2f781d73be9 h1:5j5lFP7bAoF7h4Kpd36DAJgSQ3IrkcHdv1Nd8i0PY0U=
+github.com/ninech/apis v0.0.0-20230710190412-d2f781d73be9/go.mod h1:wrOupX4C8yri9Ydt60VZNv0fJrOL32F02/NcVka5WPo=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/internal/format/interpolation.go
+++ b/internal/format/interpolation.go
@@ -1,0 +1,76 @@
+package format
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/alecthomas/kong"
+)
+
+// interpolationRegex is the regex to find if a given string contains variables
+// for interpolation
+var interpolationRegex = regexp.MustCompile(`(\$\$)|((?:\${([[:alpha:]_][[:word:]]*))(?:=([^}]+))?})|(\$)|([^$]+)`)
+
+// interpolate interpolates the given string s with variables from vars
+// The [upstream
+// function](https://github.com/alecthomas/kong/blob/v0.8.0/interpolate.go#L22)
+// was sadly not exported, so we had to copy it.
+func interpolate(s string, vars kong.Vars) (string, error) {
+	out := ""
+	matches := interpolationRegex.FindAllStringSubmatch(s, -1)
+	if len(matches) == 0 {
+		return s, nil
+	}
+	for _, match := range matches {
+		if dollar := match[1]; dollar != "" {
+			out += "$"
+		} else if name := match[3]; name != "" {
+			value, ok := vars[name]
+			if !ok {
+				// No default value.
+				if match[4] == "" {
+					return "", fmt.Errorf("undefined variable ${%s}", name)
+				}
+				value = match[4]
+			}
+			out += value
+		} else {
+			out += match[0]
+		}
+	}
+	return out, nil
+}
+
+// InterpolateFlagPlaceholders will return a function which walks the whole kong
+// model and interpolates variables in placeholders in flags.
+func InterpolateFlagPlaceholders(vars kong.Vars) func(*kong.Kong) error {
+	var walkNode func(n *kong.Node) error
+	walkNode = func(n *kong.Node) error {
+		var err error
+		if n == nil {
+			return nil
+		}
+		for i := range n.Flags {
+			if n.Flags[i] == nil {
+				continue
+			}
+			if n.Flags[i].PlaceHolder, err = interpolate(n.Flags[i].PlaceHolder, vars); err != nil {
+				return fmt.Errorf("error when interpolating placeholder tag of flag %q: %w", n.Flags[i].Name, err)
+			}
+		}
+		// we are now calling ourselves for all child nodes
+		for i := range n.Children {
+			if err := walkNode(n.Children[i]); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return func(k *kong.Kong) error {
+		if k.Model == nil {
+			return errors.New("no kong model found")
+		}
+		return walkNode(k.Model.Node)
+	}
+}

--- a/internal/format/interpolation_test.go
+++ b/internal/format/interpolation_test.go
@@ -1,0 +1,54 @@
+package format
+
+import (
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
+)
+
+func TestPlaceholderInterpolation(t *testing.T) {
+	var cli struct {
+		FlagPointer *string `placeholder:"${flag_default}"`
+		Flag        string  `default:"${flag_default}"`
+		Sub         struct {
+			SubFlag        int  `default:"${subflag_default}"`
+			SubFlagPointer *int `placeholder:"${subflag_default}"`
+		} `cmd:""`
+	}
+	vars := kong.Vars{
+		"flag_default":    "chicken",
+		"subflag_default": "coleslaw!",
+	}
+
+	p, err := kong.New(
+		&cli,
+		vars,
+		kong.PostBuild(InterpolateFlagPlaceholders(vars)),
+	)
+	require.NoError(t, err)
+	// we expect 3 flags because the first one is always the "-h" help flag
+	require.Len(t, p.Model.Flags, 3)
+	flagPointer := p.Model.Flags[1]
+	assert.Equal(t, "chicken", flagPointer.PlaceHolder)
+	// we expect one sub command
+	require.Len(t, p.Model.Children, 1)
+	// no help flag this time...
+	require.Len(t, p.Model.Children[0].Flags, 2)
+	subFlagPointer := p.Model.Children[0].Flags[1]
+	require.Equal(t, "coleslaw!", subFlagPointer.PlaceHolder)
+}
+
+// TestPlaceholderInterpolationError makes sure that an error gets thrown if a
+// variable in a placeholder was not defined
+func TestPlaceholderInterpolationError(t *testing.T) {
+	var cli struct {
+		FlagPointer *string `placeholder:"${flag_default}"`
+	}
+	_, err := kong.New(
+		&cli,
+		kong.PostBuild(InterpolateFlagPlaceholders(kong.Vars{"unused": "garbage"})),
+	)
+	require.Error(t, err)
+}

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func main() {
 		kong.Name(util.NctlName),
 		kong.Description("Interact with Nine API resources. See https://docs.nineapis.ch for the full API docs."),
 		kong.UsageOnError(),
+		kong.PostBuild(format.InterpolateFlagPlaceholders(kongVars)),
 		kongVars,
 		kong.BindTo(ctx, (*context.Context)(nil)),
 	)

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"os"
 	"os/signal"
@@ -51,13 +52,17 @@ func main() {
 	defer cancel()
 	setupSignalHandler(ctx, cancel)
 
+	kongVars, err := kongVariables()
+	if err != nil {
+		log.Fatal(err)
+	}
 	nctl := &rootCommand{}
 	parser := kong.Must(
 		nctl,
 		kong.Name(util.NctlName),
 		kong.Description("Interact with Nine API resources. See https://docs.nineapis.ch for the full API docs."),
 		kong.UsageOnError(),
-		kong.Vars{"version": version},
+		kongVars,
 		kong.BindTo(ctx, (*context.Context)(nil)),
 	)
 
@@ -107,4 +112,30 @@ func setupSignalHandler(ctx context.Context, cancel context.CancelFunc) {
 		case <-ctx.Done():
 		}
 	}()
+}
+
+// kongVariables collects all variables which should be passed to kong. It
+// checks for variables which would overwrite already existing ones.
+func kongVariables() (kong.Vars, error) {
+	result := make(kong.Vars)
+	result["version"] = version
+	appCreateKongVars, err := create.ApplicationKongVars()
+	if err != nil {
+		return nil, fmt.Errorf("error on application create kong vars: %w", err)
+	}
+	if err := merge(result, appCreateKongVars); err != nil {
+		return nil, fmt.Errorf("error when merging application create kong variables: %w", err)
+	}
+	return result, nil
+}
+
+func merge(existing kong.Vars, with kong.Vars) error {
+	for k, v := range with {
+		_, exists := existing[k]
+		if exists {
+			return fmt.Errorf("variable %q is already in use", k)
+		}
+		existing[k] = v
+	}
+	return nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestKongVars makes sure that the kongVariables function will not run into an
+// error. As it is based mostly on static input, a simple test should be enough.
+func TestKongVars(t *testing.T) {
+	vars, err := kongVariables()
+	require.NoError(t, err)
+	require.NotEmpty(t, vars)
+}


### PR DESCRIPTION
If we set defaults in the application on creation, existing content in the .deploio.yaml file will be ignored (as the config which is set on the Application itself has higher precedence). As we will always fall back to valid defaults, we can just leave them out in the application if the user did not set an explicit value.