### PR TITLE
Do not error on missing command/argument

### DIFF
--- a/create/application.go
+++ b/create/application.go
@@ -153,7 +153,7 @@ func (app *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 			"could not gather basic auth credentials: %w\n"+
 				"Please use %q to gather credentials manually",
 			err,
-			format.Command().GetApplication(newApp.Name, "--credentials"),
+			format.Command().GetApplication(newApp.Name, "--basic-auth-credentials"),
 		)
 	}
 	printCredentials(basicAuth)


### PR DESCRIPTION
Do not error on missing command/argument. Print Usage + friendly message instead (and exit). For example:

missing command:
```bash
> nctl
Usage: nctl <command> 
...
Your query: "nctl": expected one of "get",  "auth",  "completions",  "create",  "apply",  ...
```

```bash
> nctl get
Usage: nctl get <command>
...
Your query: "nctl get": expected one of "clusters",  "apiserviceaccounts",  "projects",  "applications",  "builds",  ...
```

missing arg:
```bash
> nctl delete project
Usage: nctl delete project (proj) <name>
...
Your query: "nctl delete project": expected "<name>"
```
