### PR TITLE
add a short option to refer to the application when listing releases

### DIFF
--- a/get/releases.go
+++ b/get/releases.go
@@ -18,7 +18,7 @@ import (
 
 type releasesCmd struct {
 	Name            string `arg:"" help:"Name of the Release to get. If omitted all in the projects will be listed." default:""`
-	ApplicationName string `help:"Name of the Application to get releases for. If omitted all applications in the project will be listed."`
+	ApplicationName string `short:"a" help:"Name of the Application to get releases for. If omitted all applications in the project will be listed."`
 	out             io.Writer
 }
 


### PR DESCRIPTION
As the same short option already exists for getting builds, we should have them for releases as well.