### PR TITLE
add -bin suffix for AUR package

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,7 +65,7 @@ brews:
 
 # .goreleaser.yaml
 aurs:
-  - name: nctl
+  - name: nctl-bin
     homepage: "https://github.com/ninech/nctl"
     description: "A CLI tool to interact with Nine API resources."
     maintainers:


### PR DESCRIPTION
From the go releaser docs:

    # The package name.
    #
    # Note that since this integration does not create a PKGBUILD to build from
    # source, per Arch's guidelines.
    # That said, GoReleaser will enforce a `-bin` suffix if its not present.
    #
    # Default: ProjectName with a -bin suffix.
    name: package-bin