### PR TITLE
Add whoami information on successful login

### DIFF
--- a/auth/login_test.go
+++ b/auth/login_test.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log"
 	"os"
@@ -39,8 +38,10 @@ func TestLoginCmd(t *testing.T) {
 
 	apiHost := "api.example.org"
 	tk := &fakeTokenGetter{}
-	// we run without the execPlugin, that would be something for an e2e test
-	cmd := &LoginCmd{ExecPlugin: false, APIURL: "https://" + apiHost, IssuerURL: "https://auth.example.org"}
+	cmd := &LoginCmd{
+		APIURL:    "https://" + apiHost,
+		IssuerURL: "https://auth.example.org",
+	}
 	if err := cmd.Run(context.Background(), "", tk); err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +70,7 @@ func TestLoginStaticToken(t *testing.T) {
 	os.Setenv(clientcmd.RecommendedConfigPathEnvVar, kubeconfig.Name())
 
 	apiHost := "api.example.org"
-	token := "faketoken"
+	token := FakeJWTToken
 
 	cmd := &LoginCmd{APIURL: "https://" + apiHost, APIToken: token, Organization: "test"}
 	tk := &fakeTokenGetter{}
@@ -88,7 +89,6 @@ func TestLoginStaticToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fmt.Printf("%s", b)
 	checkConfig(t, kc, 1, "")
 
 	if token != kc.AuthInfos[apiHost].Token {
@@ -111,8 +111,10 @@ func TestLoginCmdWithoutExistingKubeconfig(t *testing.T) {
 	os.Setenv(clientcmd.RecommendedConfigPathEnvVar, kubeconfig)
 
 	apiHost := "api.example.org"
-	// we run without the execPlugin, that would be something for an e2e test
-	cmd := &LoginCmd{ExecPlugin: false, APIURL: "https://" + apiHost, IssuerURL: "https://auth.example.org"}
+	cmd := &LoginCmd{
+		APIURL:    "https://" + apiHost,
+		IssuerURL: "https://auth.example.org",
+	}
 	tk := &fakeTokenGetter{}
 	if err := cmd.Run(context.Background(), "", tk); err != nil {
 		t.Fatal(err)

--- a/auth/set_org.go
+++ b/auth/set_org.go
@@ -12,7 +12,6 @@ type SetOrgCmd struct {
 	APIURL       string `help:"The URL of the Nine API" default:"https://nineapis.ch" env:"NCTL_API_URL" name:"api-url"`
 	IssuerURL    string `help:"Issuer URL is the OIDC issuer URL of the API." default:"https://auth.nine.ch/auth/realms/pub"`
 	ClientID     string `help:"Client ID is the OIDC client ID of the API." default:"nineapis.ch-f178254"`
-	ExecPlugin   bool   `help:"Automatically run exec plugin after writing the kubeconfig." hidden:"" default:"true"`
 }
 
 func (s *SetOrgCmd) Run(ctx context.Context, command string) error {
@@ -36,5 +35,7 @@ func (s *SetOrgCmd) Run(ctx context.Context, command string) error {
 		return err
 	}
 
-	return login(ctx, cfg, loadingRules.GetDefaultFilename(), s.Organization, runExecPlugin(s.ExecPlugin), project(s.Organization))
+	userInfo := &api.UserInfo{}
+
+	return login(ctx, cfg, loadingRules.GetDefaultFilename(), userInfo.User, s.Organization, project(s.Organization))
 }


### PR DESCRIPTION
Display `whoami` information on successful login. It displays user name for an OIDC login, and Service Account name for a static API token login. 