### PR TITLE
Add app build retries

### DIFF
--- a/api/util/apps.go
+++ b/api/util/apps.go
@@ -107,6 +107,16 @@ func EnvVarToString(envs apps.EnvVars) string {
 	return strings.Join(keyValuePairs, ";")
 }
 
+func EnvVarByName(envVars apps.EnvVars, name string) *apps.EnvVar {
+	for _, e := range envVars {
+		if e.Name == name {
+			return &e
+		}
+	}
+
+	return nil
+}
+
 type GitAuth struct {
 	Username      *string
 	Password      *string

--- a/update/application_test.go
+++ b/update/application_test.go
@@ -125,6 +125,8 @@ func TestApplication(t *testing.T) {
 				assert.Equal(t, *cmd.DeployJob.Name, updated.Spec.ForProvider.Config.DeployJob.Name)
 				assert.Equal(t, *cmd.DeployJob.Timeout, updated.Spec.ForProvider.Config.DeployJob.Timeout.Duration)
 				assert.Equal(t, *cmd.DeployJob.Retries, *updated.Spec.ForProvider.Config.DeployJob.Retries)
+				// RetryBuild should be not set by default:
+				assert.Nil(t, util.EnvVarByName(updated.Spec.ForProvider.BuildEnv, BuildTrigger))
 			},
 		},
 		"reset env variables": {
@@ -207,6 +209,26 @@ func TestApplication(t *testing.T) {
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, orig, updated *apps.Application) {
 				assert.Nil(t, updated.Spec.ForProvider.Config.DeployJob)
+			},
+		},
+		"retry build": {
+			orig: existingApp,
+			cmd: applicationCmd{
+				Name:       pointer.String(existingApp.Name),
+				RetryBuild: pointer.Bool(true),
+			},
+			checkApp: func(t *testing.T, cmd applicationCmd, orig, updated *apps.Application) {
+				assert.NotNil(t, util.EnvVarByName(updated.Spec.ForProvider.BuildEnv, BuildTrigger))
+			},
+		},
+		"do not retry build": {
+			orig: existingApp,
+			cmd: applicationCmd{
+				Name:       pointer.String(existingApp.Name),
+				RetryBuild: pointer.Bool(false),
+			},
+			checkApp: func(t *testing.T, cmd applicationCmd, orig, updated *apps.Application) {
+				assert.Nil(t, util.EnvVarByName(updated.Spec.ForProvider.BuildEnv, BuildTrigger))
 			},
 		},
 	}


### PR DESCRIPTION
In case a build fails, there's no idiomatic way to retry it. Sometimes the failure is temporary, such as an image upload that fails and a simple retry would fix it. There's a workaround that works well but is maybe not the most user-friendly: 
```bash
`nctl update app <app> --build-env=BUILD_TRIGGER=$(date)`
```
A very pragmatic solution is to simply hide this behind a retry-build flag. And this PR does just that.