### PR TITLE
Fix set-org command

### DIFF
--- a/auth/set_org.go
+++ b/auth/set_org.go
@@ -2,40 +2,22 @@ package auth
 
 import (
 	"context"
-	"net/url"
 
 	"github.com/ninech/nctl/api"
 )
 
 type SetOrgCmd struct {
-	Organization string `arg:"" help:"Name of the organization to login to."`
+	Organization string `arg:"" help:"Name of the organization to login to." default:""`
 	APIURL       string `help:"The URL of the Nine API" default:"https://nineapis.ch" env:"NCTL_API_URL" name:"api-url"`
 	IssuerURL    string `help:"Issuer URL is the OIDC issuer URL of the API." default:"https://auth.nine.ch/auth/realms/pub"`
 	ClientID     string `help:"Client ID is the OIDC client ID of the API." default:"nineapis.ch-f178254"`
 }
 
-func (s *SetOrgCmd) Run(ctx context.Context, command string) error {
-	loadingRules, err := api.LoadingRules()
-	if err != nil {
-		return err
+func (s *SetOrgCmd) Run(ctx context.Context, client *api.Client) error {
+	if s.Organization == "" {
+		whoamicmd := WhoAmICmd{APIURL: s.APIURL, IssuerURL: s.IssuerURL, ClientID: s.ClientID}
+		return whoamicmd.Run(ctx, client)
 	}
 
-	apiURL, err := url.Parse(s.APIURL)
-	if err != nil {
-		return err
-	}
-
-	issuerURL, err := url.Parse(s.IssuerURL)
-	if err != nil {
-		return err
-	}
-
-	cfg, err := newAPIConfig(apiURL, issuerURL, command, s.ClientID, withOrganization(s.Organization))
-	if err != nil {
-		return err
-	}
-
-	userInfo := &api.UserInfo{}
-
-	return login(ctx, cfg, loadingRules.GetDefaultFilename(), userInfo.User, s.Organization, project(s.Organization))
+	return SetContextOrganization(client.KubeconfigPath, client.KubeconfigContext, s.Organization)
 }

--- a/auth/whoami.go
+++ b/auth/whoami.go
@@ -8,10 +8,9 @@ import (
 )
 
 type WhoAmICmd struct {
-	APIURL     string `help:"The URL of the Nine API" default:"https://nineapis.ch" env:"NCTL_API_URL" name:"api-url"`
-	IssuerURL  string `help:"Issuer URL is the OIDC issuer URL of the API." default:"https://auth.nine.ch/auth/realms/pub"`
-	ClientID   string `help:"Client ID is the OIDC client ID of the API." default:"nineapis.ch-f178254"`
-	ExecPlugin bool   `help:"Automatically run exec plugin after writing the kubeconfig." hidden:"" default:"true"`
+	APIURL    string `help:"The URL of the Nine API" default:"https://nineapis.ch" env:"NCTL_API_URL" name:"api-url"`
+	IssuerURL string `help:"Issuer URL is the OIDC issuer URL of the API." default:"https://auth.nine.ch/auth/realms/pub"`
+	ClientID  string `help:"Client ID is the OIDC client ID of the API." default:"nineapis.ch-f178254"`
 }
 
 func (s *WhoAmICmd) Run(ctx context.Context, client *api.Client) error {
@@ -38,13 +37,13 @@ func printUserInfo(userInfo *api.UserInfo, cfg *Config) {
 
 	fmt.Printf("Your current organization: %q\n", cfg.Organization)
 
-	if len(userInfo.Orgs) > 1 {
+	if len(userInfo.Orgs) > 0 {
 		printAvailableOrgsString(cfg.Organization, userInfo.Orgs)
 	}
 }
 
 func printAvailableOrgsString(currentorg string, orgs []string) {
-	fmt.Print("\nActive\tOrganization\n")
+	fmt.Println("\nAvailable Organizations:")
 
 	for _, org := range orgs {
 		activeMarker := ""

--- a/auth/whoami_test.go
+++ b/auth/whoami_test.go
@@ -23,9 +23,8 @@ func TestWhoAmICmd_Run(t *testing.T) {
 	defer os.Remove(kubeconfig)
 
 	s := &auth.WhoAmICmd{
-		IssuerURL:  "https://auth.nine.ch/auth/realms/pub",
-		ClientID:   "nineapis.ch-f178254",
-		ExecPlugin: true,
+		IssuerURL: "https://auth.nine.ch/auth/realms/pub",
+		ClientID:  "nineapis.ch-f178254",
 	}
 
 	err = s.Run(context.Background(), apiClient)

--- a/main.go
+++ b/main.go
@@ -110,11 +110,6 @@ func main() {
 		return
 	}
 
-	if strings.HasPrefix(kongCtx.Command(), format.SetOrgCommand) {
-		kongCtx.FatalIfErrorf(nctl.Auth.SetOrg.Run(ctx, command))
-		return
-	}
-
 	if strings.HasPrefix(kongCtx.Command(), auth.OIDCCmdName) {
 		kongCtx.FatalIfErrorf(nctl.Auth.OIDC.Run(ctx, os.Stdout))
 		return


### PR DESCRIPTION
This PR fixes the `nctl auth set-org` command so that it no longer overrides the login method currently defined in .kube/config (static API token or OIDC) with OIDC.

It also adds a small feature to display a list of available organizations when an organization name is not specified (only for OIDC login method).