### PR TITLE
rename output column

### DIFF
--- a/create/application.go
+++ b/create/application.go
@@ -385,7 +385,7 @@ func printUnverifiedHostsMessage(app *apps.Application) {
 
 		fmt.Print("\nYour DNS details are:\n")
 		fmt.Printf("  TXT record:\t%s\n", dnsDetails[0].TXTRecord)
-		fmt.Printf("  CNAME target:\t%s\n", dnsDetails[0].CNAMETarget)
+		fmt.Printf("  DNS TARGET:\t%s\n", dnsDetails[0].CNAMETarget)
 
 		fmt.Printf("\nTo make your app available on your custom hosts, please use \n"+
 			"the DNS details and visit %s\n"+

--- a/get/application.go
+++ b/get/application.go
@@ -150,7 +150,7 @@ func printDNSDetailsTabRow(items []util.DNSDetail, get *Cmd, out io.Writer) erro
 	w := tabwriter.NewWriter(out, 0, 0, 4, ' ', 0)
 
 	if get.Output == full {
-		get.writeHeader(w, "NAME", "TXT RECORD", "CNAME TARGET")
+		get.writeHeader(w, "NAME", "TXT RECORD", "DNS TARGET")
 	}
 
 	for _, item := range items {

--- a/get/application_test.go
+++ b/get/application_test.go
@@ -281,7 +281,7 @@ func TestApplicationDNS(t *testing.T) {
 			},
 			outputFormat: full,
 			project:      "dev",
-			output: `NAME             TXT RECORD       CNAME TARGET
+			output: `NAME             TXT RECORD       DNS TARGET
 no-txt-record    <not set yet>    <not set yet>
 
 Visit https://docs.nine.ch/a/myshbw3EY1 to see instructions on how to setup custom hosts
@@ -298,7 +298,7 @@ Visit https://docs.nine.ch/a/myshbw3EY1 to see instructions on how to setup cust
 			},
 			outputFormat: full,
 			project:      "dev",
-			output: `NAME      TXT RECORD                                      CNAME TARGET
+			output: `NAME      TXT RECORD                                      DNS TARGET
 sample    deploio-site-verification=sample-dev-3ksdk23    sample.3ksdk23.deploio.app
 
 Visit https://docs.nine.ch/a/myshbw3EY1 to see instructions on how to setup custom hosts
@@ -336,7 +336,7 @@ Visit https://docs.nine.ch/a/myshbw3EY1 to see instructions on how to setup cust
 				),
 			},
 			outputFormat: full,
-			output: `PROJECT    NAME      TXT RECORD                                      CNAME TARGET
+			output: `PROJECT    NAME      TXT RECORD                                      DNS TARGET
 dev        sample    deploio-site-verification=sample-dev-3ksdk23    sample.3ksdk23.deploio.app
 test       test      deploio-site-verification=test-test-4ksdk23     test.4ksdk23.deploio.app
 


### PR DESCRIPTION
The value of the CNAME Target column is technically used for a potential CNAME DNS record, but also for an ALIAS record or an IP address resolution which is needed when creating an A record. That is why we rename it to `DNS TARGET`.