### PR TITLE
use git information service on app creation and updates

### DIFF
--- a/api/validation/apps.go
+++ b/api/validation/apps.go
@@ -1,0 +1,91 @@
+package validation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	apps "github.com/ninech/apis/apps/v1alpha1"
+	"github.com/ninech/nctl/api/util"
+	"github.com/ninech/nctl/internal/format"
+	"github.com/theckman/yacspin"
+)
+
+// RepositoryValidator validates a git repository
+type RepositoryValidator struct {
+	GitInformationServiceURL string
+	Token                    string
+	Debug                    bool
+}
+
+// Validate validates the repository access and shows a visual spinner while doing so
+func (v *RepositoryValidator) Validate(ctx context.Context, git *apps.ApplicationGitConfig, auth util.GitAuth) error {
+	gitInfoClient, err := NewGitInformationClient(v.GitInformationServiceURL, v.Token)
+	if err != nil {
+		return err
+	}
+	msg := " testing repository access 🔐"
+	spinner, err := format.NewSpinner(msg, msg)
+	if err != nil {
+		return err
+	}
+	gitInfoClient.SetLogRetryFunc(retryRepoAccess(spinner, v.Debug))
+	if err := spinner.Start(); err != nil {
+		return err
+	}
+	if err := testRepositoryAccess(ctx, gitInfoClient, git, auth); err != nil {
+		if err := spinner.StopFail(); err != nil {
+			return err
+		}
+		return err
+	}
+	return spinner.Stop()
+}
+
+// testRepositoryAccess tests if the given git repository can be accessed.
+func testRepositoryAccess(ctx context.Context, client *GitInformationClient, git *apps.ApplicationGitConfig, auth util.GitAuth) error {
+	repoInfo, err := client.RepositoryInformation(ctx, git.URL, auth)
+	if err != nil {
+		// we are not returning a detailed error here as it might be
+		// too technical. The full error can still be seen by using
+		// a different RetryLog function in the client.
+		return errors.New(
+			"communication issue with git information service " +
+				"(use --skip-repo-access-check to skip this check)",
+		)
+	}
+	if len(repoInfo.Warnings) > 0 {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", strings.Join(repoInfo.Warnings, "."))
+	}
+	if repoInfo.Error != "" {
+		return errors.New(repoInfo.Error)
+	}
+	if !(containsBranch(git.Revision, repoInfo) ||
+		containsTag(git.Revision, repoInfo)) {
+		return fmt.Errorf(
+			"can not find specified git revision (%q) in repository",
+			git.Revision,
+		)
+	}
+	// it is possible to set a git URL without a proper scheme. In that
+	// case, HTTPS is used as a default. If the access check succeeds we
+	// need to overwrite the URL in the application as it will otherwise be
+	// denied by the webhook.
+	git.URL = repoInfo.RepositoryInfo.URL
+	return nil
+}
+
+func retryRepoAccess(spinner *yacspin.Spinner, debug bool) func(err error) {
+	return func(err error) {
+		// in non debug mode we just change the color of the spinner to
+		// indicate that something went wrong, but we are still on it
+		if err := spinner.Colors("fgYellow"); err != nil {
+			fmt.Fprintf(os.Stderr, "\nerror: %v\n", err)
+		}
+		if debug {
+			fmt.Fprintf(os.Stderr, "\nerror: %v\n", err)
+		}
+	}
+}

--- a/api/validation/git_information_client.go
+++ b/api/validation/git_information_client.go
@@ -1,0 +1,192 @@
+package validation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	apps "github.com/ninech/apis/apps/v1alpha1"
+	"github.com/ninech/nctl/api/util"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+)
+
+type GitInformationClient struct {
+	token        string
+	url          *url.URL
+	client       *http.Client
+	logRetryFunc func(err error)
+	retryBackoff wait.Backoff
+}
+
+// NewGitInformationClient returns a client which can be used to retrieve
+// metadata information about a given git repository
+func NewGitInformationClient(address string, token string) (*GitInformationClient, error) {
+	u, err := url.Parse(address)
+	if err != nil {
+		return nil, fmt.Errorf("can not parse git information service URL: %w", err)
+	}
+	return defaultGitInformationClient(setURLDefaults(u), token), nil
+}
+
+func setURLDefaults(u *url.URL) *url.URL {
+	// the git information service just responds to messages on /explore
+	newURL := u.JoinPath("explore")
+	if u.Scheme == "" {
+		newURL.Scheme = "https"
+	}
+	return newURL
+}
+
+func defaultGitInformationClient(url *url.URL, token string) *GitInformationClient {
+	g := &GitInformationClient{
+		token:  token,
+		url:    url,
+		client: http.DefaultClient,
+		retryBackoff: wait.Backoff{
+			Steps:    5,
+			Duration: 200 * time.Millisecond,
+			Factor:   2.0,
+			Jitter:   0.1,
+			Cap:      2 * time.Second,
+		},
+	}
+	g.logRetryFunc = func(err error) {
+		g.logError("Retrying because of error: %v\n", err)
+	}
+	return g
+}
+
+func (g *GitInformationClient) logError(format string, v ...any) {
+	fmt.Fprintf(os.Stderr, format, v...)
+}
+
+// SetLogRetryFunc allows to set the function which logs retries when doing
+// requests to the git information service
+func (g *GitInformationClient) SetLogRetryFunc(f func(err error)) {
+	g.logRetryFunc = f
+}
+
+// SetRetryBackoffs sets the backoff properties for retries
+func (g *GitInformationClient) SetRetryBackoffs(backoff wait.Backoff) {
+	g.retryBackoff = backoff
+}
+
+func (g *GitInformationClient) repositoryInformation(ctx context.Context, url string, auth util.GitAuth) (*apps.GitExploreResponse, error) {
+	req := apps.GitExploreRequest{
+		Repository: url,
+	}
+	if auth.Enabled() {
+		req.Auth = &apps.Auth{}
+		if auth.HasBasicAuth() {
+			req.Auth.BasicAuth = &apps.BasicAuth{
+				Username: *auth.Username,
+				Password: *auth.Password,
+			}
+		}
+		if auth.HasPrivateKey() {
+			req.Auth.PrivateKey = []byte(*auth.SSHPrivateKey)
+		}
+	}
+	return g.sendRequest(ctx, req)
+}
+
+// RepositoryInformation returns information about a given git repository. It retries on client connection issues.
+func (g *GitInformationClient) RepositoryInformation(ctx context.Context, url string, auth util.GitAuth) (*apps.GitExploreResponse, error) {
+	var repoInfo *apps.GitExploreResponse
+	err := retry.OnError(
+		g.retryBackoff,
+		func(err error) bool {
+			if g.logRetryFunc != nil {
+				g.logRetryFunc(err)
+			}
+			// retry regardless of the error
+			return true
+		},
+		func() error {
+			var err error
+			repoInfo, err = g.repositoryInformation(ctx, url, auth)
+			return err
+		})
+	return repoInfo, err
+}
+
+func (g *GitInformationClient) sendRequest(ctx context.Context, req apps.GitExploreRequest) (*apps.GitExploreResponse, error) {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("can not JSON marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequest(http.MethodPost, g.url.String(), bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("can not create HTTP request: %w", err)
+	}
+	if g.token != "" {
+		httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", g.token))
+	}
+
+	resp, err := g.client.Do(httpReq.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("can not read response body: %w", err)
+	}
+
+	exploreResponse := &apps.GitExploreResponse{}
+	if err := json.Unmarshal(body, exploreResponse); err != nil {
+		return nil, fmt.Errorf(
+			"can not unmarshal response %q with status code %d: %w",
+			string(body),
+			resp.StatusCode,
+			err,
+		)
+	}
+	return exploreResponse, nil
+}
+
+// containsTag returns true of the given tag exists in the git explore response
+func containsTag(tag string, response *apps.GitExploreResponse) bool {
+	if response.RepositoryInfo == nil {
+		return false
+	}
+	for _, item := range response.RepositoryInfo.Tags {
+		if item == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// containsBranch returns true of the given branch exists in the git explore response
+func containsBranch(branch string, response *apps.GitExploreResponse) bool {
+	if response.RepositoryInfo == nil {
+		return false
+	}
+	for _, item := range response.RepositoryInfo.Branches {
+		if item == branch {
+			return true
+		}
+	}
+	return false
+}
+
+// RetryLogFunc returns a retry log function depending on the given showErrors
+// parameter. If it is set to true, exact errors are shown when retrying to
+// connect to the git information service. Otherwise they are not shown.
+func RetryLogFunc(showErrors bool) func(err error) {
+	return func(err error) {
+		if showErrors {
+			fmt.Fprintf(os.Stderr, "got error: %v\n", err)
+		}
+		fmt.Fprintln(os.Stderr, "Retrying...")
+	}
+}

--- a/api/validation/git_information_client_test.go
+++ b/api/validation/git_information_client_test.go
@@ -1,0 +1,129 @@
+package validation_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	apps "github.com/ninech/apis/apps/v1alpha1"
+	"github.com/ninech/nctl/api/util"
+	"github.com/ninech/nctl/api/validation"
+	"github.com/ninech/nctl/internal/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
+)
+
+func TestRepositoryInformation(t *testing.T) {
+	ctx := context.Background()
+	gitInfo := test.NewGitInformationService()
+	gitInfo.Start()
+	defer gitInfo.Close()
+
+	dummyPrivateKey, err := test.GenerateRSAPrivateKey()
+	require.NoError(t, err)
+
+	for name, testCase := range map[string]struct {
+		url              string
+		token            string
+		auth             util.GitAuth
+		verifyRequest    func(t *testing.T) func(p test.GitInfoServiceParsed, err error)
+		setResponse      *test.GitInformationServiceResponse
+		expectedResponse *apps.GitExploreResponse
+		expectedRetries  int
+		backoff          *wait.Backoff
+		errorExpected    bool
+	}{
+		"validate request": {
+			url:   "https://github.com/ninech/deploio-examples",
+			token: "fake",
+			auth: util.GitAuth{
+				Username:      ptr.To("fake"),
+				Password:      ptr.To("fakePass"),
+				SSHPrivateKey: &dummyPrivateKey,
+			},
+			setResponse: &test.GitInformationServiceResponse{
+				Code: http.StatusOK,
+				Content: apps.GitExploreResponse{
+					RepositoryInfo: &apps.RepositoryInfo{
+						URL:      "https://github.com/ninech/deploio-examples",
+						Branches: []string{"main"},
+						Tags:     []string{"v1.0"},
+					},
+				},
+			},
+			expectedResponse: &apps.GitExploreResponse{
+				RepositoryInfo: &apps.RepositoryInfo{
+					URL:      "https://github.com/ninech/deploio-examples",
+					Branches: []string{"main"},
+					Tags:     []string{"v1.0"},
+				},
+			},
+			verifyRequest: func(t *testing.T) func(p test.GitInfoServiceParsed, err error) {
+				return func(p test.GitInfoServiceParsed, err error) {
+					is := assert.New(t)
+					is.NoError(err)
+					is.Equal("https://github.com/ninech/deploio-examples", p.Request.Repository)
+					is.Equal("fake", p.Token)
+					is.Equal(http.MethodPost, p.Method)
+					is.NotNil(p.Request.Auth)
+					is.NotNil(p.Request.Auth.BasicAuth)
+					is.Equal("fake", p.Request.Auth.BasicAuth.Username)
+					is.Equal("fakePass", p.Request.Auth.BasicAuth.Password)
+					is.Equal(dummyPrivateKey, string(p.Request.Auth.PrivateKey))
+				}
+			},
+		},
+		"we retry on server errors": {
+			url:             "https://github.com/ninech/deploio-examples",
+			token:           "fake",
+			expectedRetries: 2,
+			backoff: &wait.Backoff{
+				Duration: 100 * time.Millisecond,
+				Steps:    2,
+			},
+			setResponse: &test.GitInformationServiceResponse{
+				Code: http.StatusBadGateway,
+				Raw:  ptr.To("currently unavailable"),
+			},
+			errorExpected: true,
+		},
+	} {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			if testCase.setResponse != nil {
+				gitInfo.SetResponse(*testCase.setResponse)
+			}
+
+			c, err := validation.NewGitInformationClient(gitInfo.URL(), testCase.token)
+			require.NoError(t, err)
+
+			// we count the retries of the request
+			retries := 0
+			c.SetLogRetryFunc(func(_ error) {
+				retries++
+			})
+			if testCase.backoff != nil {
+				c.SetRetryBackoffs(*testCase.backoff)
+			}
+
+			response, err := c.RepositoryInformation(ctx, testCase.url, testCase.auth)
+			if testCase.errorExpected {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, testCase.expectedRetries, retries)
+			if testCase.expectedResponse != nil {
+				require.Equal(t, *testCase.expectedResponse, *response)
+			}
+			if testCase.verifyRequest != nil {
+				data, err := gitInfo.Request()
+				testCase.verifyRequest(t)(data, err)
+			}
+		})
+	}
+}

--- a/create/application_test.go
+++ b/create/application_test.go
@@ -25,56 +25,6 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-const (
-	// dummySSHRSAPrivateKey is a dummy private RSA SSH key with some
-	// whitespace around
-	dummySSHRSAPrivateKey = `
-
------BEGIN RSA PRIVATE KEY-----
-MIIEogIBAAKCAQEAgv9MjQEnssfXn8OCcVMZQUS0iP9Cpo643RkS2ENvNlnXFTgy
-mLX35RgkuHoAeQIlCFgYKA9bneJNRVDLcKQg3dElsMSdx6e2W879LChKrlhu904v
-XYv09Txm6+MHd69agQEU8STWXrw39Fpdk8a36MMAEe+4SzSSoh0b/2wuwRLZmapS
-gQF3HmqzxlfwupPUCbVtiWf6okJFO39TCI5vWD1bVUG5WqemVD+WY+AHjFrk41LM
-+i+gwlnn392FUB+NrCYlx6dKXhGTr1IMX15l6JVtgDp3AvlvNGG6JrA/CLqoOf9f
-Hv8pMLqPquVnDVNB/t3U0m7x/ZV2MUetklX6KwIDAQABAoIBAFjRZoLYPKVgEBe3
-xLK3iBET12BnyjYJ4NewD3HoTvhH86fkgZG/F0QSmZsmxTlGtfsxV7eZqiGjdYbA
-4B8QeWRMUUTIGr5rPR6Eem29J92MAjjVnxHLOhwohxP6y25fy3paVGun8V0sOrgH
-qRjwDHPZ+ysuIQOEssMN/5SwMgcflXFgbLMjdNJxiP2TnJcjuEEHzDmXs7KAsch2
-8dE6Wj+0W3FH1HRPxnlLfqALGxB+7I8CngXaRExbHYpWyFr+ke4PAGcLuHZ7eyZ0
-86jqoo5ekyj0TTaflJVR851CQkRk9DWeFWEfQOeM5d17VWYqibHRs3r3jASMggus
-61rmYRECgYEA4/blEB9CG6VRY0WMFljZrPtkr0zh0s01q3yUY95xizUOZknVLsk5
-bOvf9Ovw5DL3YMMQ8a09MVGcUFIRq6KlNdoh87hYIipEii8lRB536r3yyNHGAGVo
-BGon+iOZc/ma4U7pBewooUZGF5RgSlrSlGTwusgZRADUi7ncavU81tkCgYEAkxuL
-Od6HaQkZP6OtUsf/pd+Y6xLjWm6Pf+xM6eu5PIyBsvWvcTBnit765Wy/VLDK1mzr
-vNgSueIi6k41MjBJdCf91R6U3WulEV7xj9uPBeQbDMFDPoZPqEeyOqlb07D++Bk9
-IJN6mVJWM/cOiQdJAhrXwqrk4vAsfeaiRKjx3qMCgYBPthE6pfNzv0bKM5NcbQ0Q
-U4dNVNDR6TePEyzADxQc3Rx/3+lPRsVxtLjG54mAAeJGT28pUq5HBIZn/4p2PZUP
-U4rzsc3/hFAbEYkyXIUJ7Als9w0JLmxEvunjqXcK+oiRqAoLLBy4592yeQuCdGeV
-xAX5CebrxG6NvRu5uq7fYQKBgDd6j8tHTTIjqE4D4H3zx0o7RWSCPxP/1kacS3V8
-3OMk6lUfqwa5BpOs/FpB5PZ/pj+v3EfgBU/tJNXQoOdIpqsT2friCapnylz+vYNP
-fmTuXfU1fbK63JfOUj0lWehAPCg8/HyooffowXHfnq+2+6W7kdtsr92WTnE85b2X
-KYCZAoGAZ8hdRurgNcmaBzQfRF/lYQVvlmBkCy00YmTeSrwLerWlFHsh7T8icBDT
-k2dECAM99MLPJKkOwI/E0v1pAncQunLkWDJpWwb3egr+3Az+LE2TBTaDkP4kLgOw
-sMVLxmbNrxvMSjJZlSiw3jYVOnXW2jZe+ceIN4LKRwW06ifnBpg=
------END RSA PRIVATE KEY-----
-
-`
-
-	// dummySSHED25519PrivateKey is a dummy SSH private key in ed25519 format with
-	// some whitespace around it
-	dummySSHED25519PrivateKey = `
-
------BEGIN OPENSSH PRIVATE KEY-----
-b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
-QyNTUxOQAAACBSKbcOHZTe121IZz0EyMZMyvKPxRs8Rq1LTr+Uftr4zQAAAJDfP9T53z/U
-+QAAAAtzc2gtZWQyNTUxOQAAACBSKbcOHZTe121IZz0EyMZMyvKPxRs8Rq1LTr+Uftr4zQ
-AAAEDlLk0cOZ375YeCqvnfoTYl0pbFEGDaAAF4BwHqn6WqG1Iptw4dlN7XbUhnPQTIxkzK
-8o/FGzxGrUtOv5R+2vjNAAAABm5vbmFtZQECAwQFBgc=
------END OPENSSH PRIVATE KEY-----
-
-`
-)
-
 func createTempKeyFile(content string) (string, error) {
 	file, err := os.CreateTemp("", "temp-private-ssh-key.*.pem")
 	if err != nil {
@@ -94,22 +44,35 @@ func TestApplication(t *testing.T) {
 
 	ctx := context.Background()
 
-	filenameRSAKey, err := createTempKeyFile(dummySSHRSAPrivateKey)
+	dummyRSAKey, err := test.GenerateRSAPrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	filenameRSAKey, err := createTempKeyFile("   " + dummyRSAKey + "     ")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(filenameRSAKey)
 
-	filenameED25519Key, err := createTempKeyFile(dummySSHED25519PrivateKey)
+	dummyED25519Key, err := test.GenerateED25519PrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	filenameED25519Key, err := createTempKeyFile(dummyED25519Key)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(filenameED25519Key)
 
+	gitInfoService := test.NewGitInformationService()
+	gitInfoService.Start()
+	defer gitInfoService.Close()
+
 	cases := map[string]struct {
-		cmd           applicationCmd
-		checkApp      func(t *testing.T, cmd applicationCmd, app *apps.Application)
-		errorExpected bool
+		cmd                           applicationCmd
+		checkApp                      func(t *testing.T, cmd applicationCmd, app *apps.Application)
+		gitInformationServiceResponse test.GitInformationServiceResponse
+		errorExpected                 bool
 	}{
 		"without git auth": {
 			cmd: applicationCmd{
@@ -118,16 +81,17 @@ func TestApplication(t *testing.T) {
 					SubPath:  "/my/app",
 					Revision: "superbug",
 				},
-				Wait:      false,
-				Name:      "custom-name",
-				Size:      ptr.To("mini"),
-				Hosts:     []string{"custom.example.org", "custom2.example.org"},
-				Port:      ptr.To(int32(1337)),
-				Replicas:  ptr.To(int32(42)),
-				BasicAuth: ptr.To(false),
-				Env:       map[string]string{"hello": "world"},
-				BuildEnv:  map[string]string{"BP_GO_TARGETS": "./cmd/web-server"},
-				DeployJob: deployJob{Command: "date", Name: "print-date", Retries: 2, Timeout: time.Minute},
+				Wait:                false,
+				Name:                "custom-name",
+				Size:                ptr.To("mini"),
+				Hosts:               []string{"custom.example.org", "custom2.example.org"},
+				Port:                ptr.To(int32(1337)),
+				Replicas:            ptr.To(int32(42)),
+				BasicAuth:           ptr.To(false),
+				Env:                 map[string]string{"hello": "world"},
+				BuildEnv:            map[string]string{"BP_GO_TARGETS": "./cmd/web-server"},
+				DeployJob:           deployJob{Command: "date", Name: "print-date", Retries: 2, Timeout: time.Minute},
+				SkipRepoAccessCheck: true,
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
 				assert.Equal(t, cmd.Name, app.Name)
@@ -150,10 +114,11 @@ func TestApplication(t *testing.T) {
 		},
 		"with basic auth": {
 			cmd: applicationCmd{
-				Wait:      false,
-				Name:      "basic-auth",
-				Size:      ptr.To("mini"),
-				BasicAuth: ptr.To(true),
+				Wait:                false,
+				Name:                "basic-auth",
+				Size:                ptr.To("mini"),
+				BasicAuth:           ptr.To(true),
+				SkipRepoAccessCheck: true,
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
 				assert.Equal(t, cmd.Name, app.Name)
@@ -168,8 +133,9 @@ func TestApplication(t *testing.T) {
 					Username: ptr.To("deploy"),
 					Password: ptr.To("hunter2"),
 				},
-				Wait: false,
-				Name: "user-pass-auth",
+				Wait:                false,
+				Name:                "user-pass-auth",
+				SkipRepoAccessCheck: true,
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
 				auth := util.GitAuth{Username: cmd.Git.Username, Password: cmd.Git.Password}
@@ -187,11 +153,12 @@ func TestApplication(t *testing.T) {
 			cmd: applicationCmd{
 				Git: gitConfig{
 					URL:           "https://github.com/ninech/doesnotexist.git",
-					SSHPrivateKey: ptr.To(dummySSHRSAPrivateKey),
+					SSHPrivateKey: &dummyRSAKey,
 				},
-				Wait: false,
-				Name: "ssh-key-auth",
-				Size: ptr.To("mini"),
+				Wait:                false,
+				Name:                "ssh-key-auth",
+				Size:                ptr.To("mini"),
+				SkipRepoAccessCheck: true,
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
 				auth := util.GitAuth{SSHPrivateKey: cmd.Git.SSHPrivateKey}
@@ -208,11 +175,12 @@ func TestApplication(t *testing.T) {
 			cmd: applicationCmd{
 				Git: gitConfig{
 					URL:           "https://github.com/ninech/doesnotexist.git",
-					SSHPrivateKey: ptr.To(dummySSHED25519PrivateKey),
+					SSHPrivateKey: &dummyED25519Key,
 				},
-				Wait: false,
-				Name: "ssh-key-auth-ed25519",
-				Size: ptr.To("mini"),
+				Wait:                false,
+				Name:                "ssh-key-auth-ed25519",
+				Size:                ptr.To("mini"),
+				SkipRepoAccessCheck: true,
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
 				auth := util.GitAuth{SSHPrivateKey: cmd.Git.SSHPrivateKey}
@@ -231,9 +199,10 @@ func TestApplication(t *testing.T) {
 					URL:                   "https://github.com/ninech/doesnotexist.git",
 					SSHPrivateKeyFromFile: ptr.To(filenameRSAKey),
 				},
-				Wait: false,
-				Name: "ssh-key-auth-from-file",
-				Size: ptr.To("mini"),
+				Wait:                false,
+				Name:                "ssh-key-auth-from-file",
+				Size:                ptr.To("mini"),
+				SkipRepoAccessCheck: true,
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
 				auth := util.GitAuth{SSHPrivateKey: ptr.To("notused")}
@@ -242,7 +211,7 @@ func TestApplication(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				assert.Equal(t, strings.TrimSpace(dummySSHRSAPrivateKey), string(authSecret.Data[util.PrivateKeySecretKey]))
+				assert.Equal(t, dummyRSAKey, string(authSecret.Data[util.PrivateKeySecretKey]))
 				assert.Equal(t, authSecret.Annotations[util.ManagedByAnnotation], util.NctlName)
 			},
 		},
@@ -252,9 +221,10 @@ func TestApplication(t *testing.T) {
 					URL:                   "https://github.com/ninech/doesnotexist.git",
 					SSHPrivateKeyFromFile: ptr.To(filenameED25519Key),
 				},
-				Wait: false,
-				Name: "ssh-key-auth-from-file-ed25519",
-				Size: ptr.To("mini"),
+				Wait:                false,
+				Name:                "ssh-key-auth-from-file-ed25519",
+				Size:                ptr.To("mini"),
+				SkipRepoAccessCheck: true,
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
 				auth := util.GitAuth{SSHPrivateKey: ptr.To("notused")}
@@ -263,7 +233,7 @@ func TestApplication(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				assert.Equal(t, strings.TrimSpace(dummySSHED25519PrivateKey), string(authSecret.Data[util.PrivateKeySecretKey]))
+				assert.Equal(t, strings.TrimSpace(dummyED25519Key), string(authSecret.Data[util.PrivateKeySecretKey]))
 				assert.Equal(t, authSecret.Annotations[util.ManagedByAnnotation], util.NctlName)
 			},
 		},
@@ -273,9 +243,10 @@ func TestApplication(t *testing.T) {
 					URL:           "https://github.com/ninech/doesnotexist.git",
 					SSHPrivateKey: ptr.To("not valid"),
 				},
-				Wait: false,
-				Name: "ssh-key-auth-non-valid",
-				Size: ptr.To("mini"),
+				Wait:                false,
+				Name:                "ssh-key-auth-non-valid",
+				Size:                ptr.To("mini"),
+				SkipRepoAccessCheck: true,
 			},
 			errorExpected: true,
 		},
@@ -284,10 +255,11 @@ func TestApplication(t *testing.T) {
 				Git: gitConfig{
 					URL: "https://github.com/ninech/doesnotexist.git",
 				},
-				Wait:      false,
-				Name:      "deploy-job-empty-command",
-				Size:      ptr.To("mini"),
-				DeployJob: deployJob{Command: "", Name: "print-date", Retries: 2, Timeout: time.Minute},
+				Wait:                false,
+				Name:                "deploy-job-empty-command",
+				Size:                ptr.To("mini"),
+				DeployJob:           deployJob{Command: "", Name: "print-date", Retries: 2, Timeout: time.Minute},
+				SkipRepoAccessCheck: true,
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
 				assert.Nil(t, app.Spec.ForProvider.Config.DeployJob)
@@ -298,13 +270,132 @@ func TestApplication(t *testing.T) {
 				Git: gitConfig{
 					URL: "https://github.com/ninech/doesnotexist.git",
 				},
-				Wait:      false,
-				Name:      "deploy-job-empty-name",
-				Size:      ptr.To("mini"),
-				DeployJob: deployJob{Command: "date", Name: "", Retries: 2, Timeout: time.Minute},
+				Wait:                false,
+				Name:                "deploy-job-empty-name",
+				Size:                ptr.To("mini"),
+				DeployJob:           deployJob{Command: "date", Name: "", Retries: 2, Timeout: time.Minute},
+				SkipRepoAccessCheck: true,
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
 				assert.Nil(t, app.Spec.ForProvider.Config.DeployJob)
+			},
+		},
+		"git-information-service happy path": {
+			cmd: applicationCmd{
+				Git: gitConfig{
+					URL:      "https://github.com/ninech/doesnotexist.git",
+					SubPath:  "/my/app",
+					Revision: "superbug",
+				},
+				Wait: false,
+				Name: "git-information-happy-path",
+				Size: ptr.To("mini"),
+			},
+			gitInformationServiceResponse: test.GitInformationServiceResponse{
+				Code: 200,
+				Content: apps.GitExploreResponse{
+					RepositoryInfo: &apps.RepositoryInfo{
+						URL:      "https://github.com/ninech/doesnotexist.git",
+						Branches: []string{"main"},
+						Tags:     []string{"superbug"},
+					},
+				},
+			},
+			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
+				assert.Equal(t, cmd.Name, app.Name)
+				assert.Equal(t, cmd.Git.URL, app.Spec.ForProvider.Git.URL)
+				assert.Equal(t, cmd.Git.SubPath, app.Spec.ForProvider.Git.SubPath)
+				assert.Equal(t, cmd.Git.Revision, app.Spec.ForProvider.Git.Revision)
+				assert.Equal(t, apps.ApplicationSize(*cmd.Size), app.Spec.ForProvider.Config.Size)
+				assert.Nil(t, app.Spec.ForProvider.Git.Auth)
+			},
+		},
+		"git-information-service received errors": {
+			cmd: applicationCmd{
+				Git: gitConfig{
+					URL:      "https://github.com/ninech/doesnotexist.git",
+					SubPath:  "/my/app",
+					Revision: "superbug",
+				},
+				Wait: false,
+				Name: "git-information-errors",
+				Size: ptr.To("mini"),
+			},
+			gitInformationServiceResponse: test.GitInformationServiceResponse{
+				Code: 200,
+				Content: apps.GitExploreResponse{
+					Error: "repository does not exist",
+				},
+			},
+			errorExpected: true,
+		},
+		"git-information-service revision unknown": {
+			cmd: applicationCmd{
+				Git: gitConfig{
+					URL:      "https://github.com/ninech/doesnotexist.git",
+					SubPath:  "/my/app",
+					Revision: "notexistent",
+				},
+				Wait: false,
+				Name: "git-information-unknown-revision",
+				Size: ptr.To("mini"),
+			},
+			gitInformationServiceResponse: test.GitInformationServiceResponse{
+				Code: 200,
+				Content: apps.GitExploreResponse{
+					RepositoryInfo: &apps.RepositoryInfo{
+						URL:      "https://github.com/ninech/doesnotexist.git",
+						Branches: []string{"main"},
+						Tags:     []string{"v1.0"},
+					},
+				},
+			},
+			errorExpected: true,
+		},
+		"git-information-service has issues": {
+			cmd: applicationCmd{
+				Git: gitConfig{
+					URL:      "https://github.com/ninech/doesnotexist.git",
+					SubPath:  "/my/app",
+					Revision: "notexistent",
+				},
+				Wait: false,
+				Name: "git-information-unknown-revision",
+				Size: ptr.To("mini"),
+			},
+			gitInformationServiceResponse: test.GitInformationServiceResponse{
+				Code: 501,
+				Raw:  ptr.To("maintenance mode - we will be back soon"),
+			},
+			errorExpected: true,
+		},
+		"git URL without proper scheme should be updated to HTTPS on success": {
+			cmd: applicationCmd{
+				Git: gitConfig{
+					URL:      "github.com/ninech/doesnotexist.git",
+					SubPath:  "/my/app",
+					Revision: "main",
+				},
+				Wait: false,
+				Name: "git-information-update-url-to-https",
+				Size: ptr.To("mini"),
+			},
+			gitInformationServiceResponse: test.GitInformationServiceResponse{
+				Code: 200,
+				Content: apps.GitExploreResponse{
+					RepositoryInfo: &apps.RepositoryInfo{
+						URL:      "https://github.com/ninech/doesnotexist.git",
+						Branches: []string{"main"},
+					},
+				},
+			},
+			checkApp: func(t *testing.T, cmd applicationCmd, app *apps.Application) {
+				assert.Equal(t, cmd.Name, app.Name)
+				assert.Equal(t, "https://github.com/ninech/doesnotexist.git", app.Spec.ForProvider.Git.URL)
+				assert.Equal(t, cmd.Git.SubPath, app.Spec.ForProvider.Git.SubPath)
+				assert.Equal(t, cmd.Git.Revision, app.Spec.ForProvider.Git.Revision)
+				assert.Equal(t, apps.ApplicationSize(*cmd.Size), app.Spec.ForProvider.Config.Size)
+				assert.Nil(t, app.Spec.ForProvider.Git.Auth)
 			},
 		},
 	}
@@ -312,6 +403,10 @@ func TestApplication(t *testing.T) {
 	for name, tc := range cases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			if tc.cmd.GitInformationServiceURL == "" {
+				tc.cmd.GitInformationServiceURL = gitInfoService.URL()
+			}
+			gitInfoService.SetResponse(tc.gitInformationServiceResponse)
 			app := tc.cmd.newApplication("default")
 
 			err := tc.cmd.Run(ctx, apiClient)
@@ -331,10 +426,11 @@ func TestApplication(t *testing.T) {
 
 func TestApplicationWait(t *testing.T) {
 	cmd := applicationCmd{
-		Wait:        true,
-		WaitTimeout: time.Second * 5,
-		Name:        "some-name",
-		BasicAuth:   ptr.To(true),
+		Wait:                true,
+		WaitTimeout:         time.Second * 5,
+		Name:                "some-name",
+		BasicAuth:           ptr.To(true),
+		SkipRepoAccessCheck: true,
 	}
 	project := "default"
 
@@ -470,9 +566,10 @@ func TestApplicationWait(t *testing.T) {
 
 func TestApplicationBuildFail(t *testing.T) {
 	cmd := applicationCmd{
-		Wait:        true,
-		WaitTimeout: time.Second * 5,
-		Name:        "some-name",
+		Wait:                true,
+		WaitTimeout:         time.Second * 5,
+		Name:                "some-name",
+		SkipRepoAccessCheck: true,
 	}
 	project := "default"
 

--- a/internal/test/apps.go
+++ b/internal/test/apps.go
@@ -1,0 +1,51 @@
+package test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/pem"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/ed25519"
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	keySize = 4096
+)
+
+// GenerateRSAPrivateKey generates an RSA private key
+func GenerateRSAPrivateKey() (string, error) {
+	// Private Key generation
+	privateKey, err := rsa.GenerateKey(rand.Reader, keySize)
+	if err != nil {
+		return "", err
+	}
+	// Validate Private Key
+	err = privateKey.Validate()
+	if err != nil {
+		return "", err
+	}
+	privBlock, err := ssh.MarshalPrivateKey(privateKey, "")
+	if err != nil {
+		return "", err
+	}
+	// Private key in PEM format
+	return strings.TrimSpace(string(pem.EncodeToMemory(privBlock))), nil
+}
+
+// GenerateED25519PrivateKey generates an ED25519 private key
+func GenerateED25519PrivateKey() (string, error) {
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		return "", fmt.Errorf("can not create ed25519 key: %w", err)
+	}
+	pemKey, err := ssh.MarshalPrivateKey(privateKey, "")
+	if err != nil {
+		return "", fmt.Errorf("can not marshal ed25519 private key: %w", err)
+	}
+
+	// Private key in PEM format
+	return strings.TrimSpace(string(pem.EncodeToMemory(pemKey))), nil
+}

--- a/internal/test/git_information_service.go
+++ b/internal/test/git_information_service.go
@@ -1,0 +1,147 @@
+package test
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+
+	apps "github.com/ninech/apis/apps/v1alpha1"
+	"k8s.io/utils/ptr"
+)
+
+// GitInformationServiceResponse describes a response of the git information service
+type GitInformationServiceResponse struct {
+	// Code is the status code to be set
+	Code int
+	// Content describes the GitExploreResponse to be returned.
+	Content apps.GitExploreResponse
+	// Raw allows to return any text instead of a real GitExploreResponse.
+	// If it is set, it has precedence over the Content field.
+	Raw *string
+}
+
+// GitInfoServiceParsed represents are parsed request received by the git
+// information service
+type GitInfoServiceParsed struct {
+	Token   string
+	Method  string
+	Request apps.GitExploreRequest
+}
+
+// VerifyRequestFunc can be used to verify the parsed request which was sent to
+// the git information service
+type VerifyRequestFunc func(p GitInfoServiceParsed, err error)
+
+type gitInformationService struct {
+	sync.Mutex
+	server   *httptest.Server
+	logger   *slog.Logger
+	response GitInformationServiceResponse
+	request  struct {
+		data GitInfoServiceParsed
+		err  error
+	}
+}
+
+func defaultResponse() GitInformationServiceResponse {
+	return GitInformationServiceResponse{
+		Code: 404,
+		Raw:  ptr.To("no response set"),
+	}
+}
+
+// NewGitInformationService returns a new git information service mock. It can
+// be used to verify requests sent to it and also to just return with a
+// previously set response.
+func NewGitInformationService() *gitInformationService {
+	g := &gitInformationService{
+		logger:   slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+		response: defaultResponse(),
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/explore", g)
+	g.server = httptest.NewUnstartedServer(mux)
+	return g
+}
+
+// SetResponse sets the response to be returned
+func (g *gitInformationService) SetResponse(r GitInformationServiceResponse) {
+	g.Lock()
+	defer g.Unlock()
+	g.response = r
+}
+
+func (g *gitInformationService) Start() {
+	g.server.Start()
+}
+
+func (g *gitInformationService) Close() {
+	if g.server != nil {
+		g.server.Close()
+	}
+}
+
+func (g *gitInformationService) URL() string {
+	return g.server.URL
+}
+
+// Request returns the parsed last request to the service or an eventual error which occured during parsing
+func (g *gitInformationService) Request() (GitInfoServiceParsed, error) {
+	return g.request.data, g.request.err
+}
+
+func (g *gitInformationService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	g.request.data, g.request.err = parseRequest(r)
+
+	w.WriteHeader(g.response.Code)
+	if g.response.Raw != nil {
+		_, err := w.Write([]byte(*g.response.Raw))
+		if err != nil {
+			g.logger.Error(err.Error())
+		}
+		return
+	}
+	content, err := json.Marshal(g.response.Content)
+	if err != nil {
+		g.logger.Error("error when marshaling response", "error", err.Error())
+	}
+	_, err = w.Write(content)
+	if err != nil {
+		g.logger.Error(err.Error())
+	}
+}
+
+func parseRequest(r *http.Request) (GitInfoServiceParsed, error) {
+	p := GitInfoServiceParsed{}
+	p.Token = r.Header.Get("Authorization")
+	if strings.HasPrefix(p.Token, "Bearer") {
+		p.Token = strings.TrimSpace(p.Token[len("Bearer"):])
+	}
+
+	exploreRequest := apps.GitExploreRequest{}
+	if err := unmarshalRequest(r.Body, &exploreRequest); err != nil {
+		return p, err
+	}
+	p.Request = exploreRequest
+	p.Method = r.Method
+	return p, nil
+}
+
+func unmarshalRequest(data io.Reader, request *apps.GitExploreRequest) error {
+	decoder := json.NewDecoder(data)
+	err := decoder.Decode(request)
+	if err != nil {
+		return err
+	}
+	_, err = decoder.Token()
+	if err == nil || !errors.Is(err, io.EOF) {
+		return errors.New("invalid data after top-level JSON value")
+	}
+	return nil
+}


### PR DESCRIPTION
This implements the usage of the git information service into `nctl`. It allows to check if the specified git repository and revision can be accessed/found.