### PR TITLE
fix: do not use pointers for env maps

### DIFF
--- a/update/application.go
+++ b/update/application.go
@@ -21,22 +21,22 @@ const BuildTrigger = "BUILD_TRIGGER"
 // all fields need to be pointers so we can detect if they have been set by
 // the user.
 type applicationCmd struct {
-	Name                     *string            `arg:"" help:"Name of the application."`
-	Git                      *gitConfig         `embed:"" prefix:"git-"`
-	Size                     *string            `help:"Size of the app."`
-	Port                     *int32             `help:"Port the app is listening on."`
-	Replicas                 *int32             `help:"Amount of replicas of the running app."`
-	Hosts                    *[]string          `help:"Host names where the application can be accessed. If empty, the application will just be accessible on a generated host name on the deploio.app domain."`
-	BasicAuth                *bool              `help:"Enable/Disable basic authentication for the application."`
-	Env                      *map[string]string `help:"Environment variables which are passed to the app at runtime."`
-	DeleteEnv                *[]string          `help:"Runtime environment variables names which are to be deleted."`
-	BuildEnv                 *map[string]string `help:"Environment variables names which are passed to the app build process."`
-	DeleteBuildEnv           *[]string          `help:"Build environment variables which are to be deleted."`
-	DeployJob                *deployJob         `embed:"" prefix:"deploy-job-"`
-	RetryBuild               *bool              `help:"Retries build for the application if set to true." placeholder:"false"`
-	GitInformationServiceURL string             `help:"URL of the git information service." default:"https://git-info.deplo.io" env:"GIT_INFORMATION_SERVICE_URL" hidden:""`
-	SkipRepoAccessCheck      bool               `help:"Skip the git repository access check" default:"false"`
-	Debug                    bool               `help:"Enable debug messages" default:"false"`
+	Name                     *string           `arg:"" help:"Name of the application."`
+	Git                      *gitConfig        `embed:"" prefix:"git-"`
+	Size                     *string           `help:"Size of the app."`
+	Port                     *int32            `help:"Port the app is listening on."`
+	Replicas                 *int32            `help:"Amount of replicas of the running app."`
+	Hosts                    *[]string         `help:"Host names where the application can be accessed. If empty, the application will just be accessible on a generated host name on the deploio.app domain."`
+	BasicAuth                *bool             `help:"Enable/Disable basic authentication for the application."`
+	Env                      map[string]string `help:"Environment variables which are passed to the app at runtime."`
+	DeleteEnv                *[]string         `help:"Runtime environment variables names which are to be deleted."`
+	BuildEnv                 map[string]string `help:"Environment variables names which are passed to the app build process."`
+	DeleteBuildEnv           *[]string         `help:"Build environment variables which are to be deleted."`
+	DeployJob                *deployJob        `embed:"" prefix:"deploy-job-"`
+	RetryBuild               *bool             `help:"Retries build for the application if set to true." placeholder:"false"`
+	GitInformationServiceURL string            `help:"URL of the git information service." default:"https://git-info.deplo.io" env:"GIT_INFORMATION_SERVICE_URL" hidden:""`
+	SkipRepoAccessCheck      bool              `help:"Skip the git repository access check" default:"false"`
+	Debug                    bool              `help:"Enable debug messages" default:"false"`
 }
 
 type gitConfig struct {
@@ -178,19 +178,15 @@ func (cmd *applicationCmd) applyUpdates(app *apps.Application) {
 		cmd.DeployJob.applyUpdates(&app.Spec.ForProvider.Config)
 	}
 
-	var env map[string]string
-	if cmd.Env != nil {
-		env = *cmd.Env
-	}
 	var delEnv []string
 	if cmd.DeleteEnv != nil {
 		delEnv = *cmd.DeleteEnv
 	}
-	app.Spec.ForProvider.Config.Env = util.UpdateEnvVars(app.Spec.ForProvider.Config.Env, env, delEnv)
+	app.Spec.ForProvider.Config.Env = util.UpdateEnvVars(app.Spec.ForProvider.Config.Env, cmd.Env, delEnv)
 
 	buildEnv := make(map[string]string)
 	if cmd.BuildEnv != nil {
-		buildEnv = *cmd.BuildEnv
+		buildEnv = cmd.BuildEnv
 	}
 
 	if cmd.RetryBuild != nil && *cmd.RetryBuild {

--- a/update/application_test.go
+++ b/update/application_test.go
@@ -117,8 +117,8 @@ func TestApplication(t *testing.T) {
 				Port:      ptr.To(int32(1234)),
 				Replicas:  ptr.To(int32(999)),
 				Hosts:     &[]string{"one.example.org", "two.example.org"},
-				Env:       &map[string]string{"bar": "zoo"},
-				BuildEnv:  &map[string]string{"BP_GO_TARGETS": "./cmd/web-server"},
+				Env:       map[string]string{"bar": "zoo"},
+				BuildEnv:  map[string]string{"BP_GO_TARGETS": "./cmd/web-server"},
 				BasicAuth: ptr.To(true),
 				DeployJob: &deployJob{
 					Command: ptr.To("exit 0"), Name: ptr.To("exit"),
@@ -135,8 +135,8 @@ func TestApplication(t *testing.T) {
 				assert.Equal(t, *cmd.Replicas, *updated.Spec.ForProvider.Config.Replicas)
 				assert.Equal(t, *cmd.BasicAuth, *updated.Spec.ForProvider.Config.EnableBasicAuth)
 				assert.Equal(t, *cmd.Hosts, updated.Spec.ForProvider.Hosts)
-				assert.Equal(t, util.UpdateEnvVars(existingApp.Spec.ForProvider.Config.Env, *cmd.Env, nil), updated.Spec.ForProvider.Config.Env)
-				assert.Equal(t, util.UpdateEnvVars(existingApp.Spec.ForProvider.BuildEnv, *cmd.BuildEnv, nil), updated.Spec.ForProvider.BuildEnv)
+				assert.Equal(t, util.UpdateEnvVars(existingApp.Spec.ForProvider.Config.Env, cmd.Env, nil), updated.Spec.ForProvider.Config.Env)
+				assert.Equal(t, util.UpdateEnvVars(existingApp.Spec.ForProvider.BuildEnv, cmd.BuildEnv, nil), updated.Spec.ForProvider.BuildEnv)
 				assert.Equal(t, *cmd.DeployJob.Command, updated.Spec.ForProvider.Config.DeployJob.Command)
 				assert.Equal(t, *cmd.DeployJob.Name, updated.Spec.ForProvider.Config.DeployJob.Name)
 				assert.Equal(t, *cmd.DeployJob.Timeout, updated.Spec.ForProvider.Config.DeployJob.Timeout.Duration)
@@ -160,7 +160,7 @@ func TestApplication(t *testing.T) {
 			orig: existingApp,
 			cmd: applicationCmd{
 				Name: ptr.To(existingApp.Name),
-				Env:  &map[string]string{"bar1": "zoo", "bar2": "foo"},
+				Env:  map[string]string{"bar1": "zoo", "bar2": "foo"},
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, orig, updated *apps.Application) {
 				assert.Contains(t, updated.Spec.ForProvider.Config.Env, apps.EnvVar{Name: "bar1", Value: "zoo"})

--- a/update/project_config.go
+++ b/update/project_config.go
@@ -14,12 +14,12 @@ import (
 // all fields need to be pointers so we can detect if they have been set by
 // the user.
 type configCmd struct {
-	Size      *string            `help:"Size of the app."`
-	Port      *int32             `help:"Port the app is listening on."`
-	Replicas  *int32             `help:"Amount of replicas of the running app."`
-	Env       *map[string]string `help:"Environment variables which are passed to the app at runtime."`
-	BasicAuth *bool              `help:"Enable/Disable basic authentication for applications."`
-	DeployJob *deployJob         `embed:"" prefix:"deploy-job-"`
+	Size      *string           `help:"Size of the app."`
+	Port      *int32            `help:"Port the app is listening on."`
+	Replicas  *int32            `help:"Amount of replicas of the running app."`
+	Env       map[string]string `help:"Environment variables which are passed to the app at runtime."`
+	BasicAuth *bool             `help:"Enable/Disable basic authentication for applications."`
+	DeployJob *deployJob        `embed:"" prefix:"deploy-job-"`
 }
 
 func (cmd *configCmd) Run(ctx context.Context, client *api.Client) error {
@@ -55,7 +55,7 @@ func (cmd *configCmd) applyUpdates(cfg *apps.ProjectConfig) {
 		cfg.Spec.ForProvider.Config.Replicas = cmd.Replicas
 	}
 	if cmd.Env != nil {
-		cfg.Spec.ForProvider.Config.Env = util.EnvVarsFromMap(*cmd.Env)
+		cfg.Spec.ForProvider.Config.Env = util.EnvVarsFromMap(cmd.Env)
 	}
 	if cmd.BasicAuth != nil {
 		cfg.Spec.ForProvider.Config.EnableBasicAuth = cmd.BasicAuth

--- a/update/project_config_test.go
+++ b/update/project_config_test.go
@@ -82,7 +82,7 @@ func TestConfig(t *testing.T) {
 				Size:      ptr.To("newsize"),
 				Port:      ptr.To(int32(1000)),
 				Replicas:  ptr.To(int32(2)),
-				Env:       &map[string]string{"zoo": "bar"},
+				Env:       map[string]string{"zoo": "bar"},
 				BasicAuth: ptr.To(true),
 				DeployJob: &deployJob{
 					Command: ptr.To("exit 0"), Name: ptr.To("exit"),
@@ -94,7 +94,7 @@ func TestConfig(t *testing.T) {
 				assert.Equal(t, *cmd.Port, *updated.Spec.ForProvider.Config.Port)
 				assert.Equal(t, *cmd.Replicas, *updated.Spec.ForProvider.Config.Replicas)
 				assert.Equal(t, *cmd.BasicAuth, *updated.Spec.ForProvider.Config.EnableBasicAuth)
-				assert.Equal(t, util.EnvVarsFromMap(*cmd.Env), updated.Spec.ForProvider.Config.Env)
+				assert.Equal(t, util.EnvVarsFromMap(cmd.Env), updated.Spec.ForProvider.Config.Env)
 				assert.Equal(t, *cmd.DeployJob.Command, updated.Spec.ForProvider.Config.DeployJob.Command)
 				assert.Equal(t, *cmd.DeployJob.Name, updated.Spec.ForProvider.Config.DeployJob.Name)
 				assert.Equal(t, *cmd.DeployJob.Timeout, updated.Spec.ForProvider.Config.DeployJob.Timeout.Duration)


### PR DESCRIPTION
using pointers breaks kong's arg parsing somewhat as it fails to merge multiple values of the same arg. Removing the pointer fixes that while still making it possible to detect if the arg has been supplied or not as a map has nil as the zero value.