### PR TITLE
require build name or application name on build logs

### DIFF
--- a/logs/build.go
+++ b/logs/build.go
@@ -2,6 +2,7 @@ package logs
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	apps "github.com/ninech/apis/apps/v1alpha1"
@@ -15,6 +16,9 @@ type buildCmd struct {
 }
 
 func (cmd *buildCmd) Run(ctx context.Context, client *api.Client) error {
+	if cmd.Name == "" && cmd.ApplicationName == "" {
+		return errors.New("please specify a build name or an application name to see build logs from")
+	}
 	build := &apps.Build{}
 	if cmd.Name != "" {
 		if err := client.Get(ctx, api.NamespacedName(cmd.Name, client.Project), build); err != nil {


### PR DESCRIPTION
Retrieving all possible builds of a project is not really useful as it does not indicate the application name of the corresponding build. Because of this, we require either a build name or an application name when retrieving build logs.