### PR TITLE
fix: app co2 compensation message format

### DIFF
--- a/create/application.go
+++ b/create/application.go
@@ -200,7 +200,7 @@ func (app *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 		return err
 	}
 
-	if err := spinnerMessage("co2 compensating the app 🌳", 2*time.Second); err != nil {
+	if err := spinnerMessage("CO₂ compensating the app", "🌳", 2*time.Second); err != nil {
 		return err
 	}
 
@@ -228,8 +228,9 @@ func (app *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 	return nil
 }
 
-func spinnerMessage(msg string, sleepTime time.Duration) error {
-	spinner, err := format.NewSpinner(msg, msg)
+func spinnerMessage(msg, icon string, sleepTime time.Duration) error {
+	fullMsg := format.ProgressMessagef(icon, msg)
+	spinner, err := format.NewSpinner(fullMsg, fullMsg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
the message was misaligned as it lacked a space between the spinner and the message. Since the format.ProgrssMessagef function handles the formatting for spinners, we simply call that. While at it, we also use the proper subscript character for the 2.

```bash
# before
Creating new application
 ✓ testing repository access 🔐
 ✓ created application "profound-barracuda" 🏗
 ✓ waiting for build to start ⏳
 ✓ building application 📦
 ✓ releasing application 🚦
 ✓ release available ⛺
 ✓co2 compensating the app 🌳

# after
Creating new application
 ✓ testing repository access 🔐
 ✓ created application "intent-chat" 🏗
 ✓ waiting for build to start ⏳
 ✓ building application 📦  
 ✓ releasing application 🚦
 ✓ release available ⛺
 ✓ CO₂ compensating the app 🌳
```