### PR TITLE
feat: add auth print-access-token command

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,11 +1,12 @@
 package auth
 
 type Cmd struct {
-	Login      LoginCmd      `cmd:"" help:"Login to nineapis.ch."`
-	Logout     LogoutCmd     `cmd:"" help:"Logout from nineapis.ch."`
-	Cluster    ClusterCmd    `cmd:"" help:"Authenticate with Kubernetes Cluster."`
-	OIDC       OIDCCmd       `cmd:"" help:"Perform interactive OIDC login." hidden:""`
-	SetProject SetProjectCmd `cmd:"" help:"Set the default project to be used."`
-	SetOrg     SetOrgCmd     `cmd:"" help:"Set the organization to be used."`
-	Whoami     WhoAmICmd     `cmd:"" help:"Show who you are logged in as, your active organization and all your available organizations."`
+	Login            LoginCmd            `cmd:"" help:"Login to nineapis.ch."`
+	Logout           LogoutCmd           `cmd:"" help:"Logout from nineapis.ch."`
+	Cluster          ClusterCmd          `cmd:"" help:"Authenticate with Kubernetes Cluster."`
+	OIDC             OIDCCmd             `cmd:"" help:"Perform interactive OIDC login." hidden:""`
+	SetProject       SetProjectCmd       `cmd:"" help:"Set the default project to be used."`
+	SetOrg           SetOrgCmd           `cmd:"" help:"Set the organization to be used."`
+	Whoami           WhoAmICmd           `cmd:"" help:"Show who you are logged in as, your active organization and all your available organizations."`
+	PrintAccessToken PrintAccessTokenCmd `cmd:"" help:"Print short-lived access token to authenticate against the API to stdout and exit."`
 }

--- a/auth/print_access_token.go
+++ b/auth/print_access_token.go
@@ -1,0 +1,15 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ninech/nctl/api"
+)
+
+type PrintAccessTokenCmd struct{}
+
+func (o *PrintAccessTokenCmd) Run(ctx context.Context, client *api.Client) error {
+	fmt.Println(client.Token)
+	return nil
+}


### PR DESCRIPTION
This is a convenience function to print the API client access token to stdout. Mainly useful when testing things on the API with curl and maybe some scriping use-cases.