### PR TITLE
feat: add dynamic completion

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -25,7 +25,6 @@ type Client struct {
 	KubeconfigPath    string
 	Project           string
 	Log               *log.Client
-	Token             string
 	KubeconfigContext string
 }
 
@@ -48,7 +47,7 @@ func New(ctx context.Context, apiClusterContext, project string, opts ...ClientO
 	if err != nil {
 		return nil, err
 	}
-	client.Token = token
+	client.Config.BearerToken = token
 
 	scheme, err := NewScheme()
 	if err != nil {
@@ -75,7 +74,7 @@ func New(ctx context.Context, apiClusterContext, project string, opts ...ClientO
 // LogClient sets up a log client connected to the provided address.
 func LogClient(address string, insecure bool) ClientOpt {
 	return func(c *Client) error {
-		logClient, err := log.NewClient(address, c.Token, c.Project, insecure)
+		logClient, err := log.NewClient(address, c.Config.BearerToken, c.Project, insecure)
 		if err != nil {
 			return fmt.Errorf("unable to create log client: %w", err)
 		}
@@ -135,6 +134,14 @@ func (c *Client) GetConnectionSecret(ctx context.Context, mg resource.Managed) (
 	}
 
 	return secret, nil
+}
+
+func (c *Client) Token() string {
+	if c.Config == nil {
+		return ""
+	}
+
+	return c.Config.BearerToken
 }
 
 func LoadingRules() (*clientcmd.ClientConfigLoadingRules, error) {

--- a/auth/print_access_token.go
+++ b/auth/print_access_token.go
@@ -10,6 +10,6 @@ import (
 type PrintAccessTokenCmd struct{}
 
 func (o *PrintAccessTokenCmd) Run(ctx context.Context, client *api.Client) error {
-	fmt.Println(client.Token)
+	fmt.Println(client.Token())
 	return nil
 }

--- a/auth/set_project.go
+++ b/auth/set_project.go
@@ -7,7 +7,7 @@ import (
 )
 
 type SetProjectCmd struct {
-	Name string `arg:"" help:"Name of the default project to be used."`
+	Name string `arg:"" predictor:"resource_name" help:"Name of the default project to be used."`
 }
 
 func (s *SetProjectCmd) Run(ctx context.Context, client *api.Client) error {

--- a/auth/whoami.go
+++ b/auth/whoami.go
@@ -22,7 +22,7 @@ func (s *WhoAmICmd) Run(ctx context.Context, client *api.Client) error {
 		return err
 	}
 
-	userInfo, err := api.GetUserInfoFromToken(client.Token)
+	userInfo, err := api.GetUserInfoFromToken(client.Token())
 	if err != nil {
 		return err
 	}

--- a/auth/whoami_test.go
+++ b/auth/whoami_test.go
@@ -11,12 +11,14 @@ import (
 	"github.com/ninech/nctl/auth"
 	"github.com/ninech/nctl/internal/test"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestWhoAmICmd_Run(t *testing.T) {
 	client := fake.NewClientBuilder().Build()
-	apiClient := &api.Client{WithWatch: client, Project: "default", Token: auth.FakeJWTToken, KubeconfigPath: "*-kubeconfig.yaml"}
+	apiClient := &api.Client{WithWatch: client, Project: "default", KubeconfigPath: "*-kubeconfig.yaml"}
+	apiClient.Config = &rest.Config{BearerToken: auth.FakeJWTToken}
 
 	kubeconfig, err := test.CreateTestKubeconfig(apiClient, "test")
 	require.NoError(t, err)

--- a/create/application.go
+++ b/create/application.go
@@ -106,7 +106,7 @@ func (app *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 	if !app.SkipRepoAccessCheck {
 		validator := &validation.RepositoryValidator{
 			GitInformationServiceURL: app.GitInformationServiceURL,
-			Token:                    client.Token,
+			Token:                    client.Token(),
 			Debug:                    app.Debug,
 		}
 		if err := validator.Validate(ctx, &newApp.Spec.ForProvider.Git.GitTarget, auth); err != nil {

--- a/delete/delete.go
+++ b/delete/delete.go
@@ -26,7 +26,7 @@ type Cmd struct {
 }
 
 type resourceCmd struct {
-	Name        string        `arg:"" help:"Name of the resource to delete."`
+	Name        string        `arg:"" predictor:"resource_name" help:"Name of the resource to delete."`
 	Force       bool          `default:"false" help:"Do not ask for confirmation of deletion."`
 	Wait        bool          `default:"true" help:"Wait until resource is fully deleted"`
 	WaitTimeout time.Duration `default:"5m" help:"Duration to wait for the deletion. Only relevant if wait is set."`

--- a/get/build.go
+++ b/get/build.go
@@ -92,7 +92,7 @@ func pullImage(ctx context.Context, apiClient *api.Client, build *apps.Build) er
 	registryAuth, err := registry.EncodeAuthConfig(registry.AuthConfig{
 		// technically the username does not matter, it just needs to be set to something
 		Username: "registry",
-		Password: apiClient.Token,
+		Password: apiClient.Token(),
 	})
 	if err != nil {
 		return err

--- a/get/clusters.go
+++ b/get/clusters.go
@@ -13,12 +13,14 @@ import (
 	"github.com/ninech/nctl/internal/format"
 )
 
-type clustersCmd struct{}
+type clustersCmd struct {
+	resourceCmd
+}
 
 func (l *clustersCmd) Run(ctx context.Context, client *api.Client, get *Cmd) error {
 	clusterList := &infrastructure.KubernetesClusterList{}
 
-	if err := get.list(ctx, client, clusterList); err != nil {
+	if err := get.list(ctx, client, clusterList, matchName(l.Name)); err != nil {
 		return err
 	}
 

--- a/get/get.go
+++ b/get/get.go
@@ -33,7 +33,7 @@ type Cmd struct {
 }
 
 type resourceCmd struct {
-	Name string `arg:"" help:"Name of the resource to get. If omitted all in the project will be listed." default:""`
+	Name string `arg:"" predictor:"resource_name" help:"Name of the resource to get. If omitted all in the project will be listed." default:""`
 }
 
 type output string

--- a/internal/test/client.go
+++ b/internal/test/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ninech/nctl/api/util"
 	"github.com/ninech/nctl/auth"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -22,6 +23,7 @@ func SetupClient(initObjs ...client.Object) (*api.Client, error) {
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjs...).Build()
 
 	return &api.Client{
+		Config:    &rest.Config{BearerToken: "fake"},
 		WithWatch: client, Project: "default",
 	}, nil
 }

--- a/logs/logs.go
+++ b/logs/logs.go
@@ -19,7 +19,7 @@ type Cmd struct {
 }
 
 type resourceCmd struct {
-	Name string `arg:"" help:"Name of the resource." default:""`
+	Name string `arg:"" predictor:"resource_name" help:"Name of the resource." default:""`
 }
 
 type logsCmd struct {

--- a/predictor/predictor.go
+++ b/predictor/predictor.go
@@ -1,0 +1,99 @@
+package predictor
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/gobuffalo/flect"
+	"github.com/ninech/apis/management/v1alpha1"
+	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/auth"
+	"github.com/posener/complete"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	listSuffix  = "list"
+	groupSuffix = "nine.ch"
+)
+
+// argResourceMap maps certain unusual args to resource names to aid with
+// completion.
+var argResourceMap = map[string]string{
+	"clusters":    "kubernetesclusters",
+	"set-project": "projects",
+	"-p":          "projects",
+	"--project":   "projects",
+}
+
+type Resource struct {
+	client *api.Client
+}
+
+func NewResourceName(clientCreator func() (*api.Client, error)) *Resource {
+	c, err := clientCreator()
+	if err != nil {
+		return &Resource{}
+	}
+
+	return &Resource{client: c}
+}
+
+func (r *Resource) Predict(args complete.Args) []string {
+	if r.client == nil {
+		return []string{}
+	}
+
+	u := &unstructured.UnstructuredList{}
+	u.SetGroupVersionKind(r.findKind(args.LastCompleted))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	ns := r.client.Project
+	// if we're looking for projects, we need to use the org as the namespace
+	if u.GetObjectKind().GroupVersionKind().Kind == reflect.TypeOf(v1alpha1.ProjectList{}).Name() {
+		cfg, err := auth.ReadConfig(r.client.KubeconfigPath, r.client.KubeconfigContext)
+		if err != nil {
+			return []string{}
+		}
+		ns = cfg.Organization
+	}
+
+	if err := r.client.List(ctx, u, client.InNamespace(ns)); err != nil {
+		return []string{}
+	}
+
+	resources := make([]string, len(u.Items))
+	for _, res := range u.Items {
+		resources = append(resources, res.GetName())
+	}
+
+	return resources
+}
+
+func (r *Resource) findKind(arg string) schema.GroupVersionKind {
+	if v, ok := argResourceMap[arg]; ok {
+		arg = v
+	}
+
+	for gvk := range r.client.Scheme().AllKnownTypes() {
+		if !strings.HasSuffix(strings.ToLower(gvk.Kind), listSuffix) {
+			continue
+		}
+		if strings.HasSuffix(strings.ToLower(gvk.Group), groupSuffix) &&
+			listKindToResource(gvk.Kind) == flect.Pluralize(arg) {
+			return gvk
+		}
+	}
+
+	return schema.GroupVersionKind{}
+}
+
+func listKindToResource(kind string) string {
+	return flect.Pluralize(strings.TrimSuffix(strings.ToLower(kind), listSuffix))
+}

--- a/update/application.go
+++ b/update/application.go
@@ -111,7 +111,7 @@ func (cmd *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 		if !cmd.SkipRepoAccessCheck {
 			validator := &validation.RepositoryValidator{
 				GitInformationServiceURL: cmd.GitInformationServiceURL,
-				Token:                    client.Token,
+				Token:                    client.Token(),
 				Debug:                    cmd.Debug,
 			}
 

--- a/update/update.go
+++ b/update/update.go
@@ -19,7 +19,7 @@ type Cmd struct {
 }
 
 type resourceCmd struct {
-	Name string `arg:"" help:"Name of the resource to update."`
+	Name string `arg:"" predictor:"resource_name" help:"Name of the resource to update."`
 }
 
 type updater struct {


### PR DESCRIPTION
This adds initial support for dynamic completion. For example `nctl update application <tab><tab>` will return a list of applications in the current project. There are some edge-cases where the arg/flag name does not match the resource name. To make these cases work, they can be added to a map in the predictor.