### PR TITLE
release: do not auto-publish releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,10 @@ changelog:
       - '^docs:'
       - '^test:'
 
+release:
+  draft: true
+  replace_existing_draft: true
+
 brews:
   - name: nctl
 


### PR DESCRIPTION
This causes goreleaser to create a draft release so we can manually edit the release notes before we publish it.