### PR TITLE
fix: do not update/sort env vars when nothing changes

### DIFF
--- a/api/util/apps.go
+++ b/api/util/apps.go
@@ -73,6 +73,10 @@ func EnvVarsFromMap(env map[string]string) apps.EnvVars {
 }
 
 func UpdateEnvVars(oldEnvs []apps.EnvVar, newEnvs map[string]string, toDelete []string) apps.EnvVars {
+	if len(newEnvs) == 0 && len(toDelete) == 0 {
+		return oldEnvs
+	}
+
 	envMap := map[string]apps.EnvVar{}
 	for _, v := range oldEnvs {
 		envMap[v.Name] = v


### PR DESCRIPTION
When updating an app with an unrelated change, we should not sort the existing env vars as that can trigger an unexpected build. We simply return the old env vars if the new envs and to delete is empty.