### PR TITLE
fix: ignore ErrCloseSent during log tail

### DIFF
--- a/api/log/client.go
+++ b/api/log/client.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -200,7 +201,7 @@ func (c *Client) TailQuery(ctx context.Context, delayFor time.Duration, out outp
 				continue
 			}
 
-			if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure) || errors.Is(websocket.ErrCloseSent, err) {
 				return nil
 			}
 


### PR DESCRIPTION
Most of the time when the client closes the connection (nctl is terminated by ctrl+c) we get an ErrCloseSent so we should ignore it and not output an error to the user.