### PR TITLE
fix: improve logbox interrupt handling

### DIFF
--- a/create/create.go
+++ b/create/create.go
@@ -60,6 +60,8 @@ type waitStage struct {
 	disableSpinner bool
 	// beforeWait is a hook that is called just before the wait is being run.
 	beforeWait func()
+	// afterWait is a hook that is called after the wait to clean up.
+	afterWait func()
 }
 
 type message struct {
@@ -106,6 +108,10 @@ func (c *creator) createResource(ctx context.Context) error {
 
 func (c *creator) wait(ctx context.Context, stages ...waitStage) error {
 	for _, stage := range stages {
+		if stage.afterWait != nil {
+			defer stage.afterWait()
+		}
+
 		stage.setDefaults(c)
 
 		spinner, err := format.NewSpinner(
@@ -174,7 +180,6 @@ func isWatchError(err error) bool {
 }
 
 func (w *waitStage) wait(ctx context.Context, client *api.Client) error {
-
 	if !w.disableSpinner {
 		_ = w.spinner.Start()
 	}

--- a/create/create.go
+++ b/create/create.go
@@ -218,11 +218,17 @@ func (w *waitStage) watch(ctx context.Context, client *api.Client) error {
 				return nil
 			}
 		case <-ctx.Done():
-			msg := "timeout waiting for %s"
-			w.spinner.StopFailMessage(format.ProgressMessagef("", msg, w.kind))
-			_ = w.spinner.StopFail()
+			switch ctx.Err() {
+			case context.DeadlineExceeded:
+				msg := "timeout waiting for %s"
+				w.spinner.StopFailMessage(format.ProgressMessagef("", msg, w.kind))
+				_ = w.spinner.StopFail()
 
-			return fmt.Errorf(msg, w.kind)
+				return fmt.Errorf(msg, w.kind)
+			case context.Canceled:
+				_ = w.spinner.StopFail()
+				return nil
+			}
 		}
 	}
 }

--- a/internal/logbox/logbox.go
+++ b/internal/logbox/logbox.go
@@ -34,19 +34,16 @@ type LogBox struct {
 	results     []Msg
 	quitting    bool
 	spinner     spinner.Model
-	interrupt   chan bool
 }
 
-// New initializes a LogBox. The interrupt channel will be written to on
-// ctrl+c/ctrl+d since it intercepts these.
-func New(height int, waitMessage string, interrupt chan bool) LogBox {
+// New initializes a LogBox.
+func New(height int, waitMessage string) LogBox {
 	s := spinner.New(spinner.WithSpinner(spinner.MiniDot), spinner.WithStyle(lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{})))
 	return LogBox{
 		height:      height,
 		waitMessage: waitMessage,
 		spinner:     s,
 		results:     []Msg{},
-		interrupt:   interrupt,
 	}
 }
 
@@ -56,14 +53,6 @@ func (lb LogBox) Init() tea.Cmd {
 
 func (lb LogBox) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "ctrl+c", "ctrl+d":
-			lb.interrupt <- true
-			return lb, tea.Quit
-		default:
-			return lb, nil
-		}
 	case Msg:
 		if msg.Done {
 			lb.quitting = true

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/alecthomas/kong"
 
@@ -145,7 +146,7 @@ func main() {
 
 func setupSignalHandler(ctx context.Context, cancel context.CancelFunc) {
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		defer func() {
 			signal.Stop(c)


### PR DESCRIPTION
This fixes a number of issues with the cancel/error handling while the
logbox (tea program) is running. Previously input was sent to the tea
program, which meant we had to handle ctrl+c/ctrl+d explicitly. Now the
tea program is stopped using the context and also in afterWait since
it's important to call `p.Wait()` so that the console is restored
properly before nctl exits.