### PR TITLE
fix: use dynamic auth by default

### DIFF
--- a/auth/print_access_token.go
+++ b/auth/print_access_token.go
@@ -10,6 +10,6 @@ import (
 type PrintAccessTokenCmd struct{}
 
 func (o *PrintAccessTokenCmd) Run(ctx context.Context, client *api.Client) error {
-	fmt.Println(client.Token())
+	fmt.Println(client.Token(ctx))
 	return nil
 }

--- a/auth/whoami.go
+++ b/auth/whoami.go
@@ -22,7 +22,7 @@ func (s *WhoAmICmd) Run(ctx context.Context, client *api.Client) error {
 		return err
 	}
 
-	userInfo, err := api.GetUserInfoFromToken(client.Token())
+	userInfo, err := api.GetUserInfoFromToken(client.Token(ctx))
 	if err != nil {
 		return err
 	}

--- a/create/application.go
+++ b/create/application.go
@@ -113,7 +113,7 @@ func (app *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 	if !app.SkipRepoAccessCheck {
 		validator := &validation.RepositoryValidator{
 			GitInformationServiceURL: app.GitInformationServiceURL,
-			Token:                    client.Token(),
+			Token:                    client.Token(ctx),
 			Debug:                    app.Debug,
 		}
 		if err := validator.Validate(ctx, &newApp.Spec.ForProvider.Git.GitTarget, auth); err != nil {

--- a/get/build.go
+++ b/get/build.go
@@ -92,7 +92,7 @@ func pullImage(ctx context.Context, apiClient *api.Client, build *apps.Build) er
 	registryAuth, err := registry.EncodeAuthConfig(registry.AuthConfig{
 		// technically the username does not matter, it just needs to be set to something
 		Username: "registry",
-		Password: apiClient.Token(),
+		Password: apiClient.Token(ctx),
 	})
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -76,7 +76,10 @@ func main() {
 		// call parse already. Note that this won't parse the flag for
 		// completion but it will work for the default and env.
 		_, _ = parser.Parse(os.Args[1:])
-		c, err := api.New(ctx, nctl.APICluster, nctl.Project)
+		// the client for the predictor requires a static token in the client config
+		// since dynamic exec config seems to break with some shells during completion.
+		// The exact reason for that is unknown.
+		c, err := api.New(ctx, nctl.APICluster, nctl.Project, api.StaticToken(ctx))
 		if err != nil {
 			return nil, err
 		}
@@ -134,7 +137,7 @@ func main() {
 		return
 	}
 
-	client, err := api.New(ctx, nctl.APICluster, nctl.Project, api.LogClient(nctl.LogAPIAddress, nctl.LogAPIInsecure))
+	client, err := api.New(ctx, nctl.APICluster, nctl.Project, api.LogClient(ctx, nctl.LogAPIAddress, nctl.LogAPIInsecure))
 	if err != nil {
 		fmt.Println(err)
 		fmt.Printf("\nUnable to get API client, are you logged in?\n\nUse `%s` to login.\n", format.Command().Login())

--- a/update/application.go
+++ b/update/application.go
@@ -119,7 +119,7 @@ func (cmd *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 		if !cmd.SkipRepoAccessCheck {
 			validator := &validation.RepositoryValidator{
 				GitInformationServiceURL: cmd.GitInformationServiceURL,
-				Token:                    client.Token(),
+				Token:                    client.Token(ctx),
 				Debug:                    cmd.Debug,
 			}
 


### PR DESCRIPTION
In a previous PR, we changed the client to initialize the token once during creation of the client. This is problematic for longer-running processes such as creating an app where the token might expire at runtime. The only reason for putting the token into the client config was an issue with the autocompletion where the dynamic exec config fails for some shells.