### PR TITLE
Improve Completion

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,6 +66,14 @@ brews:
     description: "Interact with Nine API resources."
     license: "Apache 2.0"
 
+    post_install: |
+      File.write "nctl.bash", system("nctl", "completions", "-c", "bash")
+      File.write "nctl.zsh", system("nctl", "completions", "-c", "zsh")
+      File.write "nctl.fish", system("nctl", "completions", "-c", "fish")
+      bash_completion.install "nctl.bash"
+      zsh_completion.install "nctl.zsh"
+      fish_completion.install "nctl.fish"
+
     # Setting this will prevent goreleaser to actually try to commit the updated
     # formula - instead, the formula file will be stored on the dist folder only,
     # leaving the responsibility of publishing it to the user.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,6 +30,11 @@ release:
   draft: true
   replace_existing_draft: true
 
+archives:
+  - format_overrides:
+      - goos: windows
+        format: zip
+
 brews:
   - name: nctl
 

--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/grafana/gomemcache v0.0.0-20240229205252-cd6a66d6fb56 // indirect
 	github.com/grafana/loki/pkg/push v0.0.0-20240404095218-2c878c830179 // indirect
-	github.com/grafana/pyroscope-go/godeltaprof v0.1.7 // indirect
+	github.com/grafana/pyroscope-go/godeltaprof v0.1.8 // indirect
 	github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/hashicorp/consul/api v1.28.2 // indirect
@@ -147,7 +147,7 @@ require (
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
-	github.com/klauspost/compress v1.17.7 // indirect
+	github.com/klauspost/compress v1.17.8 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/grafana/loki v1.6.2-0.20240110103520-24fa648893d1
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/int128/kubelogin v1.28.1
+	github.com/jotaen/kong-completion v0.0.6
 	github.com/lucasepe/codename v0.2.1-0.20230220151621-5e31bf1e775f
 	github.com/mattn/go-isatty v0.0.20
 	github.com/moby/moby v27.1.1+incompatible
@@ -30,7 +31,6 @@ require (
 	github.com/prometheus/common v0.55.0
 	github.com/stretchr/testify v1.9.0
 	github.com/theckman/yacspin v0.13.12
-	github.com/willabides/kongplete v0.4.0
 	golang.org/x/crypto v0.25.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 	gotest.tools v2.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -389,8 +389,8 @@ github.com/grafana/loki v1.6.2-0.20240110103520-24fa648893d1 h1:26g2nmclQkJl7107
 github.com/grafana/loki v1.6.2-0.20240110103520-24fa648893d1/go.mod h1:JB99J9+GQWS7HqDxTYRrxDlJ+ZCxtm+vy+7DCFt4Jdg=
 github.com/grafana/loki/pkg/push v0.0.0-20240404095218-2c878c830179 h1:hgrKYTHE/e0/TlfCbTj0TyuLuIm6EdLEir/g4lcSdNw=
 github.com/grafana/loki/pkg/push v0.0.0-20240404095218-2c878c830179/go.mod h1:b0fwVw1GvQyuAoxHa/cywhhl2pn5JYM6zHGex/tshd8=
-github.com/grafana/pyroscope-go/godeltaprof v0.1.7 h1:C11j63y7gymiW8VugJ9ZW0pWfxTZugdSJyC48olk5KY=
-github.com/grafana/pyroscope-go/godeltaprof v0.1.7/go.mod h1:Tk376Nbldo4Cha9RgiU7ik8WKFkNpfds98aUzS8omLE=
+github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=
+github.com/grafana/pyroscope-go/godeltaprof v0.1.8/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd h1:PpuIBO5P3e9hpqBD0O/HjhShYuM6XE0i/lbE6J94kww=
 github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
@@ -499,9 +499,8 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.17.3/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
-github.com/klauspost/compress v1.17.7 h1:ehO88t2UGzQK66LMdE8tibEd1ErmzZjNEqWkjLAKQQg=
-github.com/klauspost/compress v1.17.7/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
+github.com/klauspost/compress v1.17.8 h1:YcnTYrq7MikUT7k0Yb5eceMmALQPYBW/Xltxn0NAMnU=
+github.com/klauspost/compress v1.17.8/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kolo/xmlrpc v0.0.0-20220921171641-a4b6fa1dd06b h1:udzkj9S/zlT5X367kqJis0QP7YMxobob6zhzq6Yre00=
 github.com/kolo/xmlrpc v0.0.0-20220921171641-a4b6fa1dd06b/go.mod h1:pcaDhQK0/NJZEvtCO0qQPPropqV0sJOJ6YW7X+9kRwM=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/go.sum
+++ b/go.sum
@@ -483,6 +483,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jotaen/kong-completion v0.0.6 h1:VP1KGvXPeB7MytYR+zZQoWw1gf/HIV1/EvWC38BHZN4=
+github.com/jotaen/kong-completion v0.0.6/go.mod h1:fuWw9snL6joY5mXbI0Dd5FWEZODaWXAeqaRxo6dAvLk=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -749,8 +751,6 @@ github.com/vmware-tanzu/velero v1.13.1 h1:CDEikGxZOjz4sxhrad6oMo5IW9xf+SdC5rwRWI
 github.com/vmware-tanzu/velero v1.13.1/go.mod h1:87DH9gnd/uTRmsjLk7wc2JWsK+RjIqX4VEt6z5qkAfA=
 github.com/vultr/govultr/v2 v2.17.2 h1:gej/rwr91Puc/tgh+j33p/BLR16UrIPnSr+AIwYWZQs=
 github.com/vultr/govultr/v2 v2.17.2/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
-github.com/willabides/kongplete v0.4.0 h1:eivXxkp5ud5+4+NVN9e4goxC5mSh3n1RHov+gsblM2g=
-github.com/willabides/kongplete v0.4.0/go.mod h1:0P0jtWD9aTsqPSUAl4de35DLghrr57XcayPyvqSi2X8=
 github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/willf/bloom v2.0.3+incompatible h1:QDacWdqcAUI1MPOwIQZRy9kOR7yxfyEmxX8Wdm2/JPA=

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/alecthomas/kong"
 
+	completion "github.com/jotaen/kong-completion"
 	"github.com/ninech/nctl/api"
 	"github.com/ninech/nctl/api/util"
 	"github.com/ninech/nctl/apply"
@@ -25,7 +26,6 @@ import (
 	"github.com/ninech/nctl/predictor"
 	"github.com/ninech/nctl/update"
 	"github.com/posener/complete"
-	"github.com/willabides/kongplete"
 )
 
 type flags struct {
@@ -38,15 +38,15 @@ type flags struct {
 
 type rootCommand struct {
 	flags
-	Get         get.Cmd                      `cmd:"" help:"Get resource."`
-	Auth        auth.Cmd                     `cmd:"" help:"Authenticate with resource."`
-	Completions kongplete.InstallCompletions `cmd:"" help:"Print shell completions."`
-	Create      create.Cmd                   `cmd:"" help:"Create resource."`
-	Apply       apply.Cmd                    `cmd:"" help:"Apply resource."`
-	Delete      delete.Cmd                   `cmd:"" help:"Delete resource."`
-	Logs        logs.Cmd                     `cmd:"" help:"Get logs of resource."`
-	Update      update.Cmd                   `cmd:"" help:"Update resource."`
-	Exec        exec.Cmd                     `cmd:"" help:"Execute a command."`
+	Get         get.Cmd               `cmd:"" help:"Get resource."`
+	Auth        auth.Cmd              `cmd:"" help:"Authenticate with resource."`
+	Completions completion.Completion `cmd:"" help:"Print shell completions."`
+	Create      create.Cmd            `cmd:"" help:"Create resource."`
+	Apply       apply.Cmd             `cmd:"" help:"Apply resource."`
+	Delete      delete.Cmd            `cmd:"" help:"Delete resource."`
+	Logs        logs.Cmd              `cmd:"" help:"Get logs of resource."`
+	Update      update.Cmd            `cmd:"" help:"Update resource."`
+	Exec        exec.Cmd              `cmd:"" help:"Execute a command."`
 }
 
 const (
@@ -91,9 +91,10 @@ func main() {
 	})
 
 	// completion handling
-	kongplete.Complete(parser,
-		kongplete.WithPredictor("file", complete.PredictFiles("*")),
-		kongplete.WithPredictor("resource_name", resourceNamePredictor),
+	completion.Register(
+		parser,
+		completion.WithPredictor("file", complete.PredictFiles("*")),
+		completion.WithPredictor("resource_name", resourceNamePredictor),
 	)
 
 	kongCtx, err := parser.Parse(os.Args[1:])


### PR DESCRIPTION
This MR replaces [github.com/willabides/kongplete](https://github.com/willabides/kongplete) with [github.com/jotaen/kong-completion](https://github.com/jotaen/kong-completion). 

Both libraries are fairly similar, as kong-completion's [README](https://github.com/jotaen/kong-completion/blob/main/README.md) even states:
> This library was originally based on [kongplete](https://github.com/WillAbides/kongplete).

The main difference is that the new library allows to pass the shell for shell completions. Which allows to install completions when installing a package.