### PR TITLE
build: add docker image build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -125,4 +125,17 @@ publishers:
     dir: "{{ dir .ArtifactPath }}"
     cmd: curl -F package=@{{ .ArtifactName }} https://{{ .Env.FURY_TOKEN }}@push.fury.io/ninedev/
 
+env:
+  - KO_DOCKER_REPO=ghcr.io/{{ .Env.GITHUB_REPOSITORY }}
+kos:
+  - base_image: alpine
+    bare: true
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    tags:
+      - latest
+      - "{{.Tag}}"
+    creation_time: "{{.CommitTimestamp}}"
+
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json


### PR DESCRIPTION
This MR adds configuration to `goreleaser` so a docker image will be built and pushed to the Github container registry.
It utilizes `ko`, so no Docker runtime is necessary: https://goreleaser.com/customization/ko/ 