### PR TITLE
allow the pipeline token to push docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 env:
   GOPRIVATE: github.com/ninech/apis


### PR DESCRIPTION
We forgot to add the permission of packages pushing to the pipeline token.