### PR TITLE
feat: add app stats output

### DIFF
--- a/get/get.go
+++ b/get/get.go
@@ -22,7 +22,7 @@ import (
 )
 
 type Cmd struct {
-	Output              output                `help:"Configures list output. ${enum}" short:"o" enum:"full,no-header,contexts,yaml" default:"full"`
+	Output              output                `help:"Configures list output. ${enum}" short:"o" enum:"full,no-header,contexts,yaml,stats" default:"full"`
 	AllProjects         bool                  `help:"apply the get over all projects." short:"A"`
 	Clusters            clustersCmd           `cmd:"" group:"infrastructure.nine.ch" aliases:"cluster,vcluster" help:"Get Kubernetes Clusters."`
 	APIServiceAccounts  apiServiceAccountsCmd `cmd:"" group:"iam.nine.ch" name:"apiserviceaccounts" aliases:"asa" help:"Get API Service Accounts."`
@@ -51,6 +51,7 @@ const (
 	noHeader output = "no-header"
 	contexts output = "contexts"
 	yamlOut  output = "yaml"
+	stats    output = "stats"
 )
 
 type listOpt func(cmd *Cmd)

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/moby/moby v27.1.1+incompatible
 	github.com/moby/term v0.5.0
-	github.com/ninech/apis v0.0.0-20240918081833-57655d99d868
+	github.com/ninech/apis v0.0.0-20241014111010-322e555390a0
 	github.com/posener/complete v1.2.3
 	github.com/prometheus/common v0.55.0
 	github.com/stretchr/testify v1.9.0
@@ -38,6 +38,7 @@ require (
 	k8s.io/apimachinery v0.31.0
 	k8s.io/client-go v0.30.1
 	k8s.io/kubectl v0.29.0
+	k8s.io/metrics v0.29.0
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/controller-runtime v0.18.4
 )

--- a/go.sum
+++ b/go.sum
@@ -592,8 +592,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/ninech/apis v0.0.0-20240918081833-57655d99d868 h1:thQBwQjpYq6AjQGtVK2JFZ+iJFKFbUFhAjFuCgSZHUo=
-github.com/ninech/apis v0.0.0-20240918081833-57655d99d868/go.mod h1:hrhn1IP1wHHyWfE8xvDAl39yVcT1RDr9qJOv1FYpDAU=
+github.com/ninech/apis v0.0.0-20241014111010-322e555390a0 h1:ADBcd12IyQtoDWK7DHqQHWWrwo+yrJuWnj9EvEIwc8c=
+github.com/ninech/apis v0.0.0-20241014111010-322e555390a0/go.mod h1:hrhn1IP1wHHyWfE8xvDAl39yVcT1RDr9qJOv1FYpDAU=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
@@ -1230,6 +1230,8 @@ k8s.io/kube-openapi v0.0.0-20240403164606-bc84c2ddaf99 h1:w6nThEmGo9zcL+xH1Tu6pj
 k8s.io/kube-openapi v0.0.0-20240403164606-bc84c2ddaf99/go.mod h1:yD4MZYeKMBwQKVht279WycxKyM84kkAx2DPrTXaeb98=
 k8s.io/kubectl v0.29.0 h1:Oqi48gXjikDhrBF67AYuZRTcJV4lg2l42GmvsP7FmYI=
 k8s.io/kubectl v0.29.0/go.mod h1:0jMjGWIcMIQzmUaMgAzhSELv5WtHo2a8pq67DtviAJs=
+k8s.io/metrics v0.29.0 h1:a6dWcNM+EEowMzMZ8trka6wZtSRIfEA/9oLjuhBksGc=
+k8s.io/metrics v0.29.0/go.mod h1:UCuTT4dC/x/x6ODSk87IWIZQnuAfcwxOjb1gjWJdjMA=
 k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 h1:pUdcCO1Lk/tbT5ztQWOBi5HBgbBP1J8+AsQnQCKsi8A=
 k8s.io/utils v0.0.0-20240711033017-18e509b52bc8/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=


### PR DESCRIPTION
This adds a new `stats` output format for the `get app` command. It prints status information about the app replicas and also some very basic metrics. The `get app` help has been extended to explain all the columns of the stats output.

Here's what the output looks like:

```
$ nctl get apps -o stats
PROJECT        NAME    REPLICA                  STATUS   CPU   CPU%   MEMORY   MEMORY%   RESTARTS   LASTEXITCODE
nine-staging   rails   rails-9f6bdb676-crlrf    ready    1m    0.8%   121MiB   47.4%     0          <none>
nine-staging   rails   rails-9f6bdb676-2pfps    ready    1m    0.8%   123MiB   48.4%     0          <none>
nine-staging   rails   rails-9f6bdb676-sd9mm    ready    1m    0.8%   122MiB   48.0%     1          137 (Out of memory)
```