### PR TITLE
 feat: add worker jobs

### DIFF
--- a/api/log/output.go
+++ b/api/log/output.go
@@ -1,0 +1,44 @@
+package log
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/grafana/loki/pkg/logcli/output"
+	"github.com/grafana/loki/pkg/loghttp"
+)
+
+type filteredOutput struct {
+	out    output.LogOutput
+	labels map[string]struct{}
+}
+
+func (o *filteredOutput) FormatAndPrintln(ts time.Time, lbls loghttp.LabelSet, maxLabelsLen int, line string) {
+	for k := range lbls {
+		if _, ok := o.labels[k]; !ok {
+			delete(lbls, k)
+		}
+	}
+	o.out.FormatAndPrintln(ts, lbls, maxLabelsLen, line)
+}
+
+func (o filteredOutput) WithWriter(w io.Writer) output.LogOutput {
+	return o.out.WithWriter(w)
+}
+
+func NewStdOut(mode string, noLabels bool, labels ...string) (output.LogOutput, error) {
+	out, err := output.NewLogOutput(os.Stdout, mode, &output.LogOutputOptions{
+		NoLabels: noLabels, ColoredOutput: true, Timezone: time.Local,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to create log output: %s", err)
+	}
+
+	keys := map[string]struct{}{}
+	for _, label := range labels {
+		keys[label] = struct{}{}
+	}
+	return &filteredOutput{out: out, labels: keys}, nil
+}

--- a/api/util/apps.go
+++ b/api/util/apps.go
@@ -325,15 +325,6 @@ func ApplicationLatestAvailableRelease(ctx context.Context, client *api.Client, 
 	return release, nil
 }
 
-func ApplicationReplicas(ctx context.Context, client *api.Client, app types.NamespacedName) ([]apps.ReplicaObservation, error) {
-	release, err := ApplicationLatestAvailableRelease(ctx, client, app)
-	if err != nil {
-		return nil, err
-	}
-
-	return release.Status.AtProvider.ReplicaObservation, nil
-}
-
 func latestAvailableRelease(releases *apps.ReleaseList) *apps.Release {
 	OrderReleaseList(releases, false)
 	for _, release := range releases.Items {

--- a/get/releases.go
+++ b/get/releases.go
@@ -63,6 +63,7 @@ func (cmd *releasesCmd) printReleases(releases []apps.Release, get *Cmd, header 
 			"APPLICATION",
 			"SIZE",
 			"REPLICAS",
+			"WORKERJOBS",
 			"STATUS",
 			"AGE",
 		)
@@ -76,6 +77,7 @@ func (cmd *releasesCmd) printReleases(releases []apps.Release, get *Cmd, header 
 		if r.Spec.ForProvider.Config.Replicas != nil {
 			replicas = strconv.Itoa(int(*r.Spec.ForProvider.Config.Replicas))
 		}
+		workerJobs := strconv.Itoa(len(r.Spec.ForProvider.Config.WorkerJobs))
 
 		get.writeTabRow(
 			w,
@@ -85,6 +87,7 @@ func (cmd *releasesCmd) printReleases(releases []apps.Release, get *Cmd, header 
 			r.ObjectMeta.Labels[util.ApplicationNameLabel],
 			string(r.Spec.ForProvider.Config.Size),
 			replicas,
+			workerJobs,
 			string(r.Status.AtProvider.ReleaseStatus),
 			duration.HumanDuration(time.Since(r.ObjectMeta.CreationTimestamp.Time)),
 		)

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/moby/moby v27.1.1+incompatible
 	github.com/moby/term v0.5.0
-	github.com/ninech/apis v0.0.0-20241014111010-322e555390a0
+	github.com/ninech/apis v0.0.0-20241023072837-ff94192f11d1
 	github.com/posener/complete v1.2.3
 	github.com/prometheus/common v0.55.0
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -592,8 +592,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/ninech/apis v0.0.0-20241014111010-322e555390a0 h1:ADBcd12IyQtoDWK7DHqQHWWrwo+yrJuWnj9EvEIwc8c=
-github.com/ninech/apis v0.0.0-20241014111010-322e555390a0/go.mod h1:hrhn1IP1wHHyWfE8xvDAl39yVcT1RDr9qJOv1FYpDAU=
+github.com/ninech/apis v0.0.0-20241023072837-ff94192f11d1 h1:EgvNzSWbl/6wri3qTedw9SnLfI2STsM+XyW7uMqVnJE=
+github.com/ninech/apis v0.0.0-20241023072837-ff94192f11d1/go.mod h1:hrhn1IP1wHHyWfE8xvDAl39yVcT1RDr9qJOv1FYpDAU=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=

--- a/logs/application.go
+++ b/logs/application.go
@@ -2,24 +2,70 @@ package logs
 
 import (
 	"context"
+	"errors"
 
+	apps "github.com/ninech/apis/apps/v1alpha1"
 	"github.com/ninech/nctl/api"
 )
 
 type applicationCmd struct {
 	resourceCmd
 	logsCmd
+	Type appLogType `short:"t" help:"Which type of app logs to output. ${enum}" enum:"all,app,build,worker_job,deploy_job" default:"all"`
 }
 
 func (cmd *applicationCmd) Run(ctx context.Context, client *api.Client) error {
-	return cmd.logsCmd.Run(ctx, client, ApplicationQuery(cmd.Name, client.Project))
+	if cmd.Name == "" {
+		return errors.New("please specify an application name")
+	}
+
+	app := &apps.Application{}
+	if err := client.Get(ctx, api.NamespacedName(cmd.Name, client.Project), app); err != nil {
+		return err
+	}
+
+	return cmd.logsCmd.Run(ctx, client, buildQuery(append(
+		cmd.Type.queryExpressions(),
+		inProject(client.Project),
+		queryExpr(opEquals, apps.LogLabelApplication, app.Name))...),
+		apps.LogLabelBuild, apps.LogLabelReplica, apps.LogLabelWorkerJob, apps.LogLabelDeployJob,
+	)
 }
 
+func ApplicationQuery(name, project string) string {
+	return buildQuery(
+		inProject(project),
+		queryExpr(opEquals, apps.LogLabelApplication, name),
+		queryExpr(opEquals, apps.LogLabelBuild, ""),
+	)
+}
+
+type appLogType string
+
 const (
-	appLabel     = "app"
-	runtimePhase = "runtime"
+	logTypeAll       appLogType = "all"
+	logTypeApp       appLogType = "app"
+	logTypeBuild     appLogType = "build"
+	logTypeDeployJob appLogType = "deploy_job"
+	logTypeWorkerJob appLogType = "worker_job"
 )
 
-func ApplicationQuery(name, project string) string {
-	return queryString(map[string]string{appLabel: name, phaseLabel: runtimePhase}, project)
+func (a appLogType) queryExpressions() []string {
+	expr := []string{}
+	switch a {
+	case logTypeAll:
+		return expr
+	case logTypeApp:
+		expr = append(expr,
+			queryExpr(opEquals, apps.LogLabelDeployJob, ""),
+			queryExpr(opEquals, apps.LogLabelWorkerJob, ""),
+			queryExpr(opEquals, apps.LogLabelBuild, ""))
+	case logTypeBuild:
+		expr = append(expr, queryExpr(opNotEquals, apps.LogLabelBuild, ""))
+	case logTypeDeployJob:
+		expr = append(expr, queryExpr(opNotEquals, apps.LogLabelDeployJob, ""))
+	case logTypeWorkerJob:
+		expr = append(expr, queryExpr(opNotEquals, apps.LogLabelWorkerJob, ""))
+	}
+	return expr
 }

--- a/logs/build.go
+++ b/logs/build.go
@@ -29,24 +29,20 @@ func (cmd *buildCmd) Run(ctx context.Context, client *api.Client) error {
 
 	query := BuildQuery(cmd.Name, client.Project)
 	if len(cmd.ApplicationName) != 0 {
-		query = queryString(map[string]string{
-			appLabel:   cmd.ApplicationName,
-			phaseLabel: buildPhase,
-		}, client.Project)
+		query = BuildsOfAppQuery(cmd.ApplicationName, client.Project)
 	}
 
-	return cmd.logsCmd.Run(ctx, client, query)
+	return cmd.logsCmd.Run(ctx, client, query, apps.LogLabelBuild)
 }
 
-const (
-	buildLabel = "build"
-	buildPhase = "build"
-)
-
 func BuildQuery(name, project string) string {
-	return queryString(map[string]string{buildLabel: name, phaseLabel: buildPhase}, project)
+	return buildQuery(inProject(project), queryExpr(opEquals, apps.LogLabelBuild, name))
 }
 
 func BuildsOfAppQuery(name, project string) string {
-	return queryString(map[string]string{appLabel: name, phaseLabel: buildPhase}, project)
+	return buildQuery(
+		inProject(project),
+		queryExpr(opEquals, apps.LogLabelApplication, name),
+		queryExpr(opNotEquals, apps.LogLabelBuild, ""),
+	)
 }

--- a/logs/logs_test.go
+++ b/logs/logs_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/grafana/loki/pkg/logcli/output"
+	apps "github.com/ninech/apis/apps/v1alpha1"
 	"github.com/ninech/nctl/api"
 	"github.com/ninech/nctl/api/log"
 	"github.com/ninech/nctl/internal/test"
@@ -105,9 +106,9 @@ func TestRun(t *testing.T) {
 	}
 }
 
-func TestQueryString(t *testing.T) {
+func TestMatchLabels(t *testing.T) {
 	assert.Equal(t,
-		queryString(map[string]string{appLabel: "some-app", phaseLabel: "some-phase"}, "default"),
-		`{app="some-app",namespace="default",phase="some-phase"}`,
+		buildQuery(queryExpr(opEquals, apps.LogLabelApplication, "some-app"), inProject("default")),
+		`{app="some-app",namespace="default"}`,
 	)
 }


### PR DESCRIPTION
This adds worker jobs to the app create/update commands. As a limitation
of CLI flags, it only allows to define one worker job on creation. With
update, you can add/remove as many as possible.