### PR TITLE
do not show --api-cluster and --log-api-address

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,8 +31,8 @@ import (
 
 type flags struct {
 	Project        string           `predictor:"resource_name" help:"Limit commands to a specific project." short:"p"`
-	APICluster     string           `help:"Context name of the API cluster." default:"${api_cluster}" env:"NCTL_API_CLUSTER"`
-	LogAPIAddress  string           `help:"Address of the deplo.io logging API server." default:"https://logs.deplo.io" env:"NCTL_LOG_ADDR"`
+	APICluster     string           `help:"Context name of the API cluster." default:"${api_cluster}" env:"NCTL_API_CLUSTER" hidden:""`
+	LogAPIAddress  string           `help:"Address of the deplo.io logging API server." default:"https://logs.deplo.io" env:"NCTL_LOG_ADDR" hidden:""`
 	LogAPIInsecure bool             `help:"Don't verify TLS connection to the logging API server." hidden:"" default:"false" env:"NCTL_LOG_INSECURE"`
 	Version        kong.VersionFlag `name:"version" help:"Print version information and quit."`
 }


### PR DESCRIPTION
As these flags are only used internally during development, we hide them from the normal help output.