### PR TITLE
use an absolute path for the launcher binary

### DIFF
--- a/exec/application.go
+++ b/exec/application.go
@@ -20,9 +20,11 @@ import (
 const (
 	appBuildTypeBuildpack  appBuildType = "buildpack"
 	appBuildTypeDockerfile appBuildType = "dockerfile"
-	buildpackEntrypoint                 = "launcher"
-	defaultShellBuildpack               = "/bin/bash"
-	defaultShellDockerfile              = "/bin/sh"
+	// the launcher binary helps in setting up the application expected
+	// environment
+	buildpackEntrypoint    = "/cnb/lifecycle/launcher"
+	defaultShellBuildpack  = "/bin/bash"
+	defaultShellDockerfile = "/bin/sh"
 )
 
 // appBuildType describes the way how the app was build (buildpack/dockerfile)


### PR DESCRIPTION
When using a custom (non-default) PATH environment variable, we need to make sure to always being able to launch the `launcher` binary.