### PR TITLE
feat: warn when setting project/org

### DIFF
--- a/api/util/authentication.go
+++ b/api/util/authentication.go
@@ -6,7 +6,6 @@ import (
 
 	meta "github.com/ninech/apis/meta/v1alpha1"
 	"github.com/ninech/nctl/api"
-	"github.com/ninech/nctl/internal/format"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -42,14 +41,4 @@ func NewBasicAuthFromSecret(ctx context.Context, secret meta.Reference, client *
 		string(basicAuthSecret.Data[BasicAuthUsernameKey]),
 		string(basicAuthSecret.Data[BasicAuthPasswordKey]),
 	}, nil
-}
-
-// ReloginNeeded returns an error which outputs the given err with a message
-// saying that a re-login is needed.
-func ReloginNeeded(err error) error {
-	return fmt.Errorf(
-		"%w, please re-login by executing %q",
-		err,
-		format.Command().Login(),
-	)
 }

--- a/auth/set_project.go
+++ b/auth/set_project.go
@@ -2,9 +2,14 @@ package auth
 
 import (
 	"context"
+	"fmt"
 
+	management "github.com/ninech/apis/management/v1alpha1"
 	"github.com/ninech/nctl/api"
 	"github.com/ninech/nctl/api/config"
+	"github.com/ninech/nctl/internal/format"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type SetProjectCmd struct {
@@ -12,5 +17,29 @@ type SetProjectCmd struct {
 }
 
 func (s *SetProjectCmd) Run(ctx context.Context, client *api.Client) error {
-	return config.SetContextProject(client.KubeconfigPath, client.KubeconfigContext, s.Name)
+	org, err := client.Organization()
+	if err != nil {
+		return err
+	}
+
+	// we get the project without using the result to be sure it exists and the
+	// user has access.
+	if err := client.Get(ctx, types.NamespacedName{Name: s.Name, Namespace: org}, &management.Project{}); err != nil {
+		if !errors.IsNotFound(err) && !errors.IsForbidden(err) {
+			return err
+		}
+		if errors.IsNotFound(err) {
+			format.PrintWarningf("did not find Project %s in your Organization %s.\n", s.Name, org)
+		}
+		if errors.IsForbidden(err) {
+			format.PrintWarningf("you are not allowed to get the Project %s, you might not have access to all resources.\n", s.Name)
+		}
+	}
+
+	if err := config.SetContextProject(client.KubeconfigPath, client.KubeconfigContext, s.Name); err != nil {
+		return err
+	}
+
+	fmt.Println(format.SuccessMessagef("📝", "set active Project to %s", s.Name))
+	return nil
 }

--- a/auth/whoami.go
+++ b/auth/whoami.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 
 	"github.com/ninech/nctl/api"
-	"github.com/ninech/nctl/api/config"
-	"github.com/ninech/nctl/api/util"
 )
 
 type WhoAmICmd struct {
@@ -16,11 +14,8 @@ type WhoAmICmd struct {
 }
 
 func (s *WhoAmICmd) Run(ctx context.Context, client *api.Client) error {
-	cfg, err := config.ReadExtension(client.KubeconfigPath, client.KubeconfigContext)
+	org, err := client.Organization()
 	if err != nil {
-		if config.IsExtensionNotFoundError(err) {
-			return util.ReloginNeeded(err)
-		}
 		return err
 	}
 
@@ -29,18 +24,18 @@ func (s *WhoAmICmd) Run(ctx context.Context, client *api.Client) error {
 		return err
 	}
 
-	printUserInfo(userInfo, cfg)
+	printUserInfo(userInfo, org)
 
 	return nil
 }
 
-func printUserInfo(userInfo *api.UserInfo, cfg *config.Extension) {
+func printUserInfo(userInfo *api.UserInfo, org string) {
 	fmt.Printf("You are currently logged in the with the following account: %q\n", userInfo.User)
 
-	fmt.Printf("Your current organization: %q\n", cfg.Organization)
+	fmt.Printf("Your current organization: %q\n", org)
 
 	if len(userInfo.Orgs) > 0 {
-		printAvailableOrgsString(cfg.Organization, userInfo.Orgs)
+		printAvailableOrgsString(org, userInfo.Orgs)
 	}
 }
 

--- a/create/project.go
+++ b/create/project.go
@@ -7,8 +7,6 @@ import (
 
 	management "github.com/ninech/apis/management/v1alpha1"
 	"github.com/ninech/nctl/api"
-	"github.com/ninech/nctl/api/config"
-	"github.com/ninech/nctl/api/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -18,16 +16,13 @@ type projectCmd struct {
 }
 
 func (proj *projectCmd) Run(ctx context.Context, client *api.Client) error {
-	cfg, err := config.ReadExtension(client.KubeconfigPath, client.KubeconfigContext)
+	org, err := client.Organization()
 	if err != nil {
-		if config.IsExtensionNotFoundError(err) {
-			return util.ReloginNeeded(err)
-		}
 		return err
 	}
 
-	p := newProject(proj.Name, cfg.Organization, proj.DisplayName)
-	fmt.Printf("Creating new project %s for organization %s\n", p.Name, cfg.Organization)
+	p := newProject(proj.Name, org, proj.DisplayName)
+	fmt.Printf("Creating new project %s for organization %s\n", p.Name, org)
 	c := newCreator(client, p, strings.ToLower(management.ProjectKind))
 	ctx, cancel := context.WithTimeout(ctx, proj.WaitTimeout)
 	defer cancel()

--- a/get/get.go
+++ b/get/get.go
@@ -14,8 +14,6 @@ import (
 	"github.com/gobuffalo/flect"
 	management "github.com/ninech/apis/management/v1alpha1"
 	"github.com/ninech/nctl/api"
-	"github.com/ninech/nctl/api/config"
-	"github.com/ninech/nctl/api/util"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/conversion"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -256,15 +254,12 @@ func defaultOut(out io.Writer) io.Writer {
 // projects returns either all existing projects or only the specific project
 // identified by the "onlyName" parameter
 func projects(ctx context.Context, client *api.Client, onlyName string) ([]management.Project, error) {
-	cfg, err := config.ReadExtension(client.KubeconfigPath, client.KubeconfigContext)
+	org, err := client.Organization()
 	if err != nil {
-		if config.IsExtensionNotFoundError(err) {
-			return nil, util.ReloginNeeded(err)
-		}
 		return nil, err
 	}
 	opts := []runtimeclient.ListOption{
-		runtimeclient.InNamespace(cfg.Organization),
+		runtimeclient.InNamespace(org),
 	}
 	if onlyName != "" {
 		opts = append(opts, runtimeclient.MatchingFields(

--- a/predictor/predictor.go
+++ b/predictor/predictor.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gobuffalo/flect"
 	"github.com/ninech/apis/management/v1alpha1"
 	"github.com/ninech/nctl/api"
-	"github.com/ninech/nctl/api/config"
 	"github.com/posener/complete"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -61,11 +60,11 @@ func (r *Resource) Predict(args complete.Args) []string {
 	ns := r.client.Project
 	// if we're looking for projects, we need to use the org as the namespace
 	if u.GetObjectKind().GroupVersionKind().Kind == reflect.TypeOf(v1alpha1.ProjectList{}).Name() {
-		cfg, err := config.ReadExtension(r.client.KubeconfigPath, r.client.KubeconfigContext)
+		org, err := r.client.Organization()
 		if err != nil {
 			return []string{}
 		}
-		ns = cfg.Organization
+		ns = org
 	}
 
 	if err := r.client.List(ctx, u, client.InNamespace(ns)); err != nil {

--- a/update/project.go
+++ b/update/project.go
@@ -7,8 +7,6 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	management "github.com/ninech/apis/management/v1alpha1"
 	"github.com/ninech/nctl/api"
-	"github.com/ninech/nctl/api/config"
-	"github.com/ninech/nctl/api/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -18,18 +16,15 @@ type projectCmd struct {
 }
 
 func (cmd *projectCmd) Run(ctx context.Context, client *api.Client) error {
-	cfg, err := config.ReadExtension(client.KubeconfigPath, client.KubeconfigContext)
+	org, err := client.Organization()
 	if err != nil {
-		if config.IsExtensionNotFoundError(err) {
-			return util.ReloginNeeded(err)
-		}
 		return err
 	}
 
 	project := &management.Project{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmd.Name,
-			Namespace: cfg.Organization,
+			Namespace: org,
 		},
 	}
 


### PR DESCRIPTION
When setting the project or organization, it will now warn you if the
project does not exist, your current user does not have access to it or
if the organization is not in the list of available organizations. We
don't error out to still support some use-cases where a user might not
have the permission to get a project or might not be fully part of an
org but might still have access to some resource in it.

The first commit just refactors some code I had to touch for this.