### PR TITLE
fix: improve create error logs

### DIFF
--- a/api/log/client.go
+++ b/api/log/client.go
@@ -17,8 +17,6 @@ import (
 	"github.com/grafana/loki/pkg/logqlmodel"
 	"github.com/grafana/loki/pkg/util/unmarshal"
 	"github.com/prometheus/common/config"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
 )
 
 type tokenFunc func(ctx context.Context) string
@@ -109,38 +107,6 @@ func (c *Client) QueryRange(ctx context.Context, out output.LogOutput, q Query) 
 func (c *Client) QueryRangeResponse(ctx context.Context, q Query) (*loghttp.QueryResponse, error) {
 	c.refreshToken(ctx)
 	return c.Client.QueryRange(q.QueryString, q.Limit, q.Start, q.End, q.Direction, q.Step, q.Interval, q.Quiet)
-}
-
-// QueryRangeWithRetry queries logs within a specific time range with a retry
-// in case of an error or not finding any logs.
-func (c *Client) QueryRangeWithRetry(ctx context.Context, out output.LogOutput, q Query) error {
-	return retry.OnError(
-		wait.Backoff{
-			Steps:    5,
-			Duration: 200 * time.Millisecond,
-			Factor:   2.0,
-			Jitter:   0.1,
-			Cap:      10 * time.Second,
-		},
-		func(err error) bool {
-			// retry regardless of the error
-			return true
-		},
-		func() error {
-			resp, err := c.QueryRangeResponse(ctx, q)
-			if err != nil {
-				return err
-			}
-
-			switch streams := resp.Data.Result.(type) {
-			case loghttp.Streams:
-				if len(streams) == 0 {
-					return fmt.Errorf("received no log streams")
-				}
-			}
-
-			return printResult(resp.Data.Result, out)
-		})
 }
 
 // LiveTailQueryConn does a live tailing with a specific query.

--- a/api/log/client.go
+++ b/api/log/client.go
@@ -76,7 +76,7 @@ func Mode(m string) string {
 // StdOut sets up an stdout log output with the specified mode.
 func StdOut(mode string) (output.LogOutput, error) {
 	out, err := output.NewLogOutput(os.Stdout, mode, &output.LogOutputOptions{
-		NoLabels: false, ColoredOutput: true, Timezone: time.Local,
+		NoLabels: true, ColoredOutput: true, Timezone: time.Local,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to create log output: %s", err)

--- a/create/application.go
+++ b/create/application.go
@@ -539,15 +539,19 @@ func printUnverifiedHostsMessage(app *apps.Application) {
 }
 
 func printBuildLogs(ctx context.Context, client *api.Client, build *apps.Build) error {
-	return client.Log.QueryRangeWithRetry(
-		ctx, client.Log.StdOut,
+	tailCtx, cancel := context.WithTimeout(ctx, errorTailTimeout)
+	defer cancel()
+	return client.Log.TailQuery(
+		tailCtx, 0, client.Log.StdOut,
 		errorLogQuery(logs.BuildQuery(build.Name, build.Namespace)),
 	)
 }
 
 func printReleaseLogs(ctx context.Context, client *api.Client, release *apps.Release) error {
-	return client.Log.QueryRangeWithRetry(
-		ctx, client.Log.StdOut,
+	tailCtx, cancel := context.WithTimeout(ctx, errorTailTimeout)
+	defer cancel()
+	return client.Log.TailQuery(
+		tailCtx, 0, client.Log.StdOut,
 		errorLogQuery(logs.ApplicationQuery(release.Labels[util.ApplicationNameLabel], release.Namespace)),
 	)
 }
@@ -561,10 +565,14 @@ func printCredentials(basicAuth *util.BasicAuth) {
 	)
 }
 
-// we print the last 20 lines of the log. In most cases this should be
+// we print the last 40 lines of the log. In most cases this should be
 // enough to give a hint about the problem but we might need to tweak this
 // value a bit in the future.
-const errorLogLines = 20
+const errorLogLines = 40
+
+// when we print error logs, we want to tail the log for a bit as new data might
+// still be coming in even after the build/release already has failed.
+const errorTailTimeout = 5 * time.Second
 
 func errorLogQuery(queryString string) log.Query {
 	return log.Query{

--- a/create/application.go
+++ b/create/application.go
@@ -449,6 +449,7 @@ func waitForBuildFinish(ctx context.Context, app *apps.Application, logClient *l
 			case buildStatusError:
 				fallthrough
 			case buildStatusUnknown:
+				p.Send(logbox.Msg{Done: true})
 				return false, buildError{build: build}
 			}
 


### PR DESCRIPTION
* Removes labels on the create error logs
* Makes logbox quit when outputting error logs to avoid duplicate logs on the screen
* Relevant logs should now be shown a bit more reliably by tailing for a few seconds