### PR TITLE
fix: stats output app project

### DIFF
--- a/get/application.go
+++ b/get/application.go
@@ -235,7 +235,7 @@ func (cmd *applicationsCmd) printStats(ctx context.Context, c *api.Client, appLi
 			}
 
 			get.writeTabRow(
-				w, c.Project, app.Name,
+				w, app.Namespace, app.Name,
 				replica.ReplicaName,
 				string(replica.Status),
 				cpuUsage,


### PR DESCRIPTION
The stats command was displaying the wrong project when requesting the stats output of cross-project, it always displayed the project of the client and not the app itself.