### PR TITLE
auth login in non-interactive env should not block

### DIFF
--- a/auth/login_test.go
+++ b/auth/login_test.go
@@ -8,7 +8,9 @@ import (
 	"path"
 	"testing"
 
+	"github.com/ninech/nctl/api"
 	"github.com/ninech/nctl/internal/test"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -17,6 +19,16 @@ type fakeTokenGetter struct{}
 
 func (f *fakeTokenGetter) GetTokenString(ctx context.Context, issuerURL, clientID string, usePKCE bool) (string, error) {
 	return test.FakeJWTToken, nil
+}
+
+func checkErrorRequire(t *testing.T, err error, expectError bool, expectedErrMsg string) {
+	t.Helper()
+	if expectError {
+		require.Error(t, err, "expected an error but got none")
+		require.EqualError(t, err, expectedErrMsg, "unexpected error message")
+	} else {
+		require.NoError(t, err, "expected no error but got one")
+	}
 }
 
 func TestLoginCmd(t *testing.T) {
@@ -36,8 +48,9 @@ func TestLoginCmd(t *testing.T) {
 	apiHost := "api.example.org"
 	tk := &fakeTokenGetter{}
 	cmd := &LoginCmd{
-		APIURL:    "https://" + apiHost,
-		IssuerURL: "https://auth.example.org",
+		APIURL:                      "https://" + apiHost,
+		IssuerURL:                   "https://auth.example.org",
+		ForceInteractiveEnvOverride: true,
 	}
 	if err := cmd.Run(context.Background(), "", tk); err != nil {
 		t.Fatal(err)
@@ -58,42 +71,74 @@ func TestLoginCmd(t *testing.T) {
 }
 
 func TestLoginStaticToken(t *testing.T) {
-	kubeconfig, err := os.CreateTemp("", "*-kubeconfig.yaml")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer os.Remove(kubeconfig.Name())
-
-	os.Setenv(clientcmd.RecommendedConfigPathEnvVar, kubeconfig.Name())
-
 	apiHost := "api.example.org"
-	token := test.FakeJWTToken
 
-	cmd := &LoginCmd{APIURL: "https://" + apiHost, APIToken: token, Organization: "test"}
-	tk := &fakeTokenGetter{}
-	if err := cmd.Run(context.Background(), "", tk); err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name           string
+		cmd            *LoginCmd
+		tk             api.TokenGetter
+		wantToken      string
+		wantErr        bool
+		wantErrMessage string
+	}{
+		{
+			name:      "interactive environment with token",
+			cmd:       &LoginCmd{APIURL: "https://" + apiHost, APIToken: test.FakeJWTToken, Organization: "test", ForceInteractiveEnvOverride: true},
+			tk:        &fakeTokenGetter{},
+			wantToken: test.FakeJWTToken,
+		},
+		{
+			name:      "non-interactive environment with token",
+			cmd:       &LoginCmd{APIURL: "https://" + apiHost, APIToken: test.FakeJWTToken, Organization: "test", ForceInteractiveEnvOverride: false},
+			tk:        &fakeTokenGetter{},
+			wantToken: test.FakeJWTToken,
+		},
+		{
+			name:           "non-interactive environment with empty token",
+			cmd:            &LoginCmd{APIURL: "https://" + apiHost, APIToken: "", Organization: "test", ForceInteractiveEnvOverride: false},
+			wantErr:        true,
+			wantErrMessage: ErrNonInteractiveEnvironmentEmptyToken,
+		},
 	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			kubeconfig, err := os.CreateTemp("", "*-kubeconfig.yaml")
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer os.Remove(kubeconfig.Name())
+			os.Setenv(clientcmd.RecommendedConfigPathEnvVar, kubeconfig.Name())
 
-	// read out the kubeconfig again to test the contents
-	b, err := io.ReadAll(kubeconfig)
-	if err != nil {
-		t.Fatal(err)
-	}
+			err = tt.cmd.Run(context.Background(), "", tt.tk)
+			checkErrorRequire(t, err, tt.wantErr, tt.wantErrMessage)
 
-	kc, err := clientcmd.Load(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+			if tt.wantErr {
+				return
+			}
 
-	checkConfig(t, kc, 1, "")
+			// read out the kubeconfig again to test the contents
+			b, err := io.ReadAll(kubeconfig)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	if token != kc.AuthInfos[apiHost].Token {
-		t.Fatalf("expected token to be %s, got %s", token, kc.AuthInfos[apiHost].Token)
-	}
+			kc, err := clientcmd.Load(b)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	if kc.AuthInfos[apiHost].Exec != nil {
-		t.Fatalf("expected execConfig to be empty, got %v", kc.AuthInfos[apiHost].Exec)
+			checkConfig(t, kc, 1, "")
+
+			if tt.wantToken != kc.AuthInfos[apiHost].Token {
+				t.Fatalf("expected token to be %s, got %s", tt.wantToken, kc.AuthInfos[apiHost].Token)
+			}
+
+			if kc.AuthInfos[apiHost].Exec != nil {
+				t.Fatalf("expected execConfig to be empty, got %v", kc.AuthInfos[apiHost].Exec)
+			}
+		})
 	}
 }
 
@@ -109,8 +154,9 @@ func TestLoginCmdWithoutExistingKubeconfig(t *testing.T) {
 
 	apiHost := "api.example.org"
 	cmd := &LoginCmd{
-		APIURL:    "https://" + apiHost,
-		IssuerURL: "https://auth.example.org",
+		APIURL:                      "https://" + apiHost,
+		IssuerURL:                   "https://auth.example.org",
+		ForceInteractiveEnvOverride: true,
 	}
 	tk := &fakeTokenGetter{}
 	if err := cmd.Run(context.Background(), "", tk); err != nil {

--- a/internal/format/print.go
+++ b/internal/format/print.go
@@ -193,11 +193,7 @@ func getPrinter(out io.Writer) (printer.Printer, error) {
 	p := printer.Printer{
 		LineNumber: false,
 	}
-	f, isFile := out.(*os.File)
-	if !isFile {
-		return p, nil
-	}
-	if isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd()) {
+	if IsInteractiveEnvironment(out) {
 		p.Bool = printerProperty(&printer.Property{
 			Prefix: format(color.FgHiMagenta),
 			Suffix: format(color.Reset),
@@ -216,6 +212,14 @@ func getPrinter(out io.Writer) (printer.Printer, error) {
 		})
 	}
 	return p, nil
+}
+
+func IsInteractiveEnvironment(out io.Writer) bool {
+	f, isFile := out.(*os.File)
+	if !isFile {
+		return false
+	}
+	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
 }
 
 // stripObj removes some fields which simply add clutter to the yaml output.


### PR DESCRIPTION
If you execute `nctl auth login` in a non-interactive environment (e.g. CI/CD) and forget to set `--api-token`, the browser should not try to open - you should see an error message instead.