### PR TITLE
feat: add app release retry

### DIFF
--- a/update/application_test.go
+++ b/update/application_test.go
@@ -142,7 +142,8 @@ func TestApplication(t *testing.T) {
 				assert.Equal(t, *cmd.DeployJob.Name, updated.Spec.ForProvider.Config.DeployJob.Name)
 				assert.Equal(t, *cmd.DeployJob.Timeout, updated.Spec.ForProvider.Config.DeployJob.Timeout.Duration)
 				assert.Equal(t, *cmd.DeployJob.Retries, *updated.Spec.ForProvider.Config.DeployJob.Retries)
-				// RetryBuild should be not set by default:
+				// Retry Release/Build should be not set by default:
+				assert.Nil(t, util.EnvVarByName(updated.Spec.ForProvider.Config.Env, ReleaseTrigger))
 				assert.Nil(t, util.EnvVarByName(updated.Spec.ForProvider.BuildEnv, BuildTrigger))
 			},
 		},
@@ -357,6 +358,30 @@ func TestApplication(t *testing.T) {
 			},
 			checkApp: func(t *testing.T, cmd applicationCmd, orig, updated *apps.Application) {
 				assert.Nil(t, updated.Spec.ForProvider.Config.DeployJob)
+			},
+		},
+		"retry release": {
+			orig: existingApp,
+			cmd: applicationCmd{
+				resourceCmd: resourceCmd{
+					Name: existingApp.Name,
+				},
+				RetryRelease: ptr.To(true),
+			},
+			checkApp: func(t *testing.T, cmd applicationCmd, orig, updated *apps.Application) {
+				assert.NotNil(t, util.EnvVarByName(updated.Spec.ForProvider.Config.Env, ReleaseTrigger))
+			},
+		},
+		"do not retry release": {
+			orig: existingApp,
+			cmd: applicationCmd{
+				resourceCmd: resourceCmd{
+					Name: existingApp.Name,
+				},
+				RetryRelease: ptr.To(false),
+			},
+			checkApp: func(t *testing.T, cmd applicationCmd, orig, updated *apps.Application) {
+				assert.Nil(t, util.EnvVarByName(updated.Spec.ForProvider.Config.Env, ReleaseTrigger))
 			},
 		},
 		"retry build": {


### PR DESCRIPTION
Currently, Deploio only supports a "Retry Build" trigger. However, there are niche cases where also triggering a new release independently is useful. For example, after a successful build but failed release due to a broken DB migration, you might resolve the issue at the DB level without code changes, requiring only a manual release retry.