### PR TITLE
Parallelize fetching resource for all projects

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -242,6 +242,8 @@ func loadConfigWithContext(apiServerURL string, loader clientcmd.ClientConfigLoa
 	}
 
 	cfg, err := clientConfig.ClientConfig()
+	cfg.QPS = 50
+	cfg.Burst = 100
 	return cfg, ns, err
 }
 

--- a/api/client.go
+++ b/api/client.go
@@ -242,8 +242,8 @@ func loadConfigWithContext(apiServerURL string, loader clientcmd.ClientConfigLoa
 	}
 
 	cfg, err := clientConfig.ClientConfig()
-	cfg.QPS = 50
-	cfg.Burst = 100
+	cfg.QPS = 25
+	cfg.Burst = 50
 	return cfg, ns, err
 }
 

--- a/api/list.go
+++ b/api/list.go
@@ -9,9 +9,9 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"log"
 
 	management "github.com/ninech/apis/management/v1alpha1"
+	"github.com/ninech/nctl/internal/format"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/conversion"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -148,7 +148,7 @@ func (c *Client) ListObjects(ctx context.Context, list runtimeclient.ObjectList,
 			tempList := reflect.New(reflect.TypeOf(list).Elem()).Interface().(runtimeclient.ObjectList)
 			tempList.GetObjectKind().SetGroupVersionKind(list.GetObjectKind().GroupVersionKind())
 			if err := c.List(ctx, tempList, append(tempOpts, runtimeclient.InNamespace(proj.Name))...); err != nil {
-				log.Printf("error when searching in project %s: %s", proj.Name, err)
+				format.PrintWarningf("error when searching in project %s: %s", proj.Name, err)
 				return
 			}
 			tempListItems := reflect.ValueOf(tempList).Elem().FieldByName("Items")


### PR DESCRIPTION
This improves fetching all applications for our organization by a factor of ~14:
```
% hyperfine --warmup 1 "./nctl get applications -A" "nctl get applications -A"
Benchmark 1: ./nctl get applications -A
  Time (mean ± σ):     243.6 ms ±  27.1 ms    [User: 128.8 ms, System: 59.8 ms]
  Range (min … max):   216.0 ms … 292.8 ms    11 runs

Benchmark 2: nctl get applications -A
  Time (mean ± σ):      3.389 s ±  0.012 s    [User: 0.144 s, System: 0.067 s]
  Range (min … max):    3.374 s …  3.409 s    10 runs

Summary
  ./nctl get applications -A ran
   13.91 ± 1.55 times faster than nctl get applications -A
```

The same holds for getting all `postgres` databases:
```
% hyperfine --warmup 1 "./nctl get postgres -A" "nctl get postgres -A"
Benchmark 1: ./nctl get postgres -A
  Time (mean ± σ):     248.7 ms ±  30.3 ms    [User: 158.9 ms, System: 61.3 ms]
  Range (min … max):   213.0 ms … 300.5 ms    10 runs

Benchmark 2: nctl get postgres -A
  Time (mean ± σ):      3.433 s ±  0.064 s    [User: 0.150 s, System: 0.060 s]
  Range (min … max):    3.389 s …  3.602 s    10 runs

Summary
  ./nctl get postgres -A ran
   13.81 ± 1.70 times faster than nctl get postgres -A
```