### PR TITLE
feat: remove app git auth inline fields

### DIFF
--- a/api/util/apps.go
+++ b/api/util/apps.go
@@ -146,18 +146,6 @@ func GitAuthFromApp(ctx context.Context, client *api.Client, app *apps.Applicati
 		return auth, nil
 	}
 
-	if len(app.Spec.ForProvider.Git.Auth.Username) != 0 {
-		auth.Username = &app.Spec.ForProvider.Git.Auth.Username
-	}
-
-	if len(app.Spec.ForProvider.Git.Auth.Password) != 0 {
-		auth.Password = &app.Spec.ForProvider.Git.Auth.Password
-	}
-
-	if len(app.Spec.ForProvider.Git.Auth.SSHPrivateKey) != 0 {
-		auth.SSHPrivateKey = &app.Spec.ForProvider.Git.Auth.SSHPrivateKey
-	}
-
 	if app.Spec.ForProvider.Git.Auth.FromSecret == nil {
 		return auth, nil
 	}


### PR DESCRIPTION
Deploio apps currently support two methods for Git authentication:

* `spec.forProvider.git.auth.username` and `password` for inline credentials
* `spec.forProvider.git.auth.fromSecret` to reference a Kubernetes secret

In practice, `nctl` exclusively use the `fromSecret` method. Maintaining both options adds unnecessary complexity, and it looks like the inline method is not used at the moment.