### PR TITLE
fix: machinetype create/update for DBs

### DIFF
--- a/create/mysql.go
+++ b/create/mysql.go
@@ -21,7 +21,7 @@ import (
 type mySQLCmd struct {
 	resourceCmd
 	Location              string                                 `placeholder:"${mysql_location_default}" help:"Location where the MySQL instance is created. Available locations are: ${mysql_location_options}"`
-	MachineType           infra.MachineType                      `placeholder:"${mysql_machine_default}" help:"Defines the sizing for a particular MySQL instance. Available types: ${mysql_machine_types}"`
+	MachineType           string                                 `placeholder:"${mysql_machine_default}" help:"Defines the sizing for a particular MySQL instance. Available types: ${mysql_machine_types}"`
 	AllowedCidrs          []meta.IPv4CIDR                        `placeholder:"203.0.113.1/32" help:"Specifies the IP addresses allowed to connect to the instance." `
 	SSHKeys               []storage.SSHKey                       `help:"Contains a list of SSH public keys, allowed to connect to the db server, in order to up-/download and directly restore database backups."`
 	SSHKeysFile           string                                 `help:"Path to a file containing a list of SSH public keys (see above), separated by newlines."`
@@ -85,7 +85,7 @@ func (cmd *mySQLCmd) newMySQL(namespace string) *storage.MySQL {
 			},
 			ForProvider: storage.MySQLParameters{
 				Location:     meta.LocationName(cmd.Location),
-				MachineType:  cmd.MachineType,
+				MachineType:  infra.NewMachineType(cmd.MachineType),
 				AllowedCIDRs: []meta.IPv4CIDR{},  // avoid missing parameter error
 				SSHKeys:      []storage.SSHKey{}, // avoid missing parameter error
 				SQLMode:      cmd.SQLMode,

--- a/create/mysql_test.go
+++ b/create/mysql_test.go
@@ -45,7 +45,7 @@ func TestMySQL(t *testing.T) {
 		},
 		{
 			name:   "machineType",
-			create: mySQLCmd{MachineType: storage.MySQLMachineTypeDefault},
+			create: mySQLCmd{MachineType: storage.MySQLMachineTypeDefault.String()},
 			want:   storage.MySQLParameters{MachineType: storage.MySQLMachineTypeDefault},
 		},
 		{

--- a/create/postgres.go
+++ b/create/postgres.go
@@ -21,7 +21,7 @@ import (
 type postgresCmd struct {
 	resourceCmd
 	Location         string                  `placeholder:"${postgres_location_default}" help:"Location where the PostgreSQL instance is created. Available locations are: ${postgres_location_options}"`
-	MachineType      infra.MachineType       `placeholder:"${postgres_machine_default}" help:"Defines the sizing for a particular PostgreSQL instance. Available types: ${postgres_machine_types}"`
+	MachineType      string                  `placeholder:"${postgres_machine_default}" help:"Defines the sizing for a particular PostgreSQL instance. Available types: ${postgres_machine_types}"`
 	AllowedCidrs     []meta.IPv4CIDR         `placeholder:"203.0.113.1/32" help:"Specifies the IP addresses allowed to connect to the instance." `
 	SSHKeys          []storage.SSHKey        `help:"Contains a list of SSH public keys, allowed to connect to the db server, in order to up-/download and directly restore database backups."`
 	SSHKeysFile      string                  `help:"Path to a file containing a list of SSH public keys (see above), separated by newlines."`
@@ -80,7 +80,7 @@ func (cmd *postgresCmd) newPostgres(namespace string) *storage.Postgres {
 			},
 			ForProvider: storage.PostgresParameters{
 				Location:         meta.LocationName(cmd.Location),
-				MachineType:      cmd.MachineType,
+				MachineType:      infra.NewMachineType(cmd.MachineType),
 				AllowedCIDRs:     []meta.IPv4CIDR{},  // avoid missing parameter error
 				SSHKeys:          []storage.SSHKey{}, // avoid missing parameter error
 				Version:          cmd.PostgresVersion,

--- a/create/postgres_test.go
+++ b/create/postgres_test.go
@@ -45,7 +45,7 @@ func TestPostgres(t *testing.T) {
 		},
 		{
 			name:   "machineType",
-			create: postgresCmd{MachineType: storage.PostgresMachineTypeDefault},
+			create: postgresCmd{MachineType: storage.PostgresMachineTypeDefault.String()},
 			want:   storage.PostgresParameters{MachineType: storage.PostgresMachineTypeDefault},
 		},
 		{

--- a/update/mysql.go
+++ b/update/mysql.go
@@ -15,7 +15,7 @@ import (
 
 type mySQLCmd struct {
 	resourceCmd
-	MachineType           *infra.MachineType                      `placeholder:"${mysql_machine_default}" help:"Defines the sizing for a particular MySQL instance. Available types: ${mysql_machine_types}"`
+	MachineType           *string                                 `placeholder:"${mysql_machine_default}" help:"Defines the sizing for a particular MySQL instance. Available types: ${mysql_machine_types}"`
 	AllowedCidrs          *[]meta.IPv4CIDR                        `placeholder:"203.0.113.1/32" help:"Specifies the IP addresses allowed to connect to the instance." `
 	SSHKeys               []storage.SSHKey                        `help:"Contains a list of SSH public keys, allowed to connect to the db server, in order to up-/download and directly restore database backups."`
 	SSHKeysFile           string                                  `help:"Path to a file containing a list of SSH public keys (see above), separated by newlines."`
@@ -57,8 +57,7 @@ func (cmd *mySQLCmd) Run(ctx context.Context, client *api.Client) error {
 
 func (cmd *mySQLCmd) applyUpdates(mysql *storage.MySQL) {
 	if cmd.MachineType != nil {
-		fmt.Println("updating to", cmd.MachineType.String())
-		mysql.Spec.ForProvider.MachineType = *cmd.MachineType
+		mysql.Spec.ForProvider.MachineType = infra.NewMachineType(*cmd.MachineType)
 	}
 	if cmd.AllowedCidrs != nil {
 		mysql.Spec.ForProvider.AllowedCIDRs = *cmd.AllowedCidrs

--- a/update/mysql_test.go
+++ b/update/mysql_test.go
@@ -28,13 +28,13 @@ func TestMySQL(t *testing.T) {
 		},
 		{
 			name:   "increase-machineType",
-			update: mySQLCmd{MachineType: ptr.To(infra.MachineTypeNineDBM)},
+			update: mySQLCmd{MachineType: ptr.To(infra.MachineTypeNineDBM.String())},
 			want:   storage.MySQLParameters{MachineType: infra.MachineTypeNineDBM},
 		},
 		{
 			name:   "decrease-machineType",
 			create: storage.MySQLParameters{MachineType: infra.MachineTypeNineDBM},
-			update: mySQLCmd{MachineType: ptr.To(infra.MachineTypeNineDBS)},
+			update: mySQLCmd{MachineType: ptr.To(infra.MachineTypeNineDBS.String())},
 			want:   storage.MySQLParameters{MachineType: infra.MachineTypeNineDBS},
 		},
 		{
@@ -92,7 +92,7 @@ func TestMySQL(t *testing.T) {
 		{
 			name:   "multi-update",
 			create: storage.MySQLParameters{AllowedCIDRs: []meta.IPv4CIDR{"0.0.0.0/0"}},
-			update: mySQLCmd{MachineType: ptr.To(infra.MachineTypeNineDBS)},
+			update: mySQLCmd{MachineType: ptr.To(infra.MachineTypeNineDBS.String())},
 			want:   storage.MySQLParameters{MachineType: infra.MachineTypeNineDBS, AllowedCIDRs: []meta.IPv4CIDR{meta.IPv4CIDR("0.0.0.0/0")}},
 		},
 	}

--- a/update/postgres.go
+++ b/update/postgres.go
@@ -15,11 +15,11 @@ import (
 
 type postgresCmd struct {
 	resourceCmd
-	MachineType      *infra.MachineType `placeholder:"${postgres_machine_default}" help:"Defines the sizing for a particular PostgreSQL instance. Available types: ${postgres_machine_types}"`
-	AllowedCidrs     *[]meta.IPv4CIDR   `placeholder:"203.0.113.1/32" help:"Specifies the IP addresses allowed to connect to the instance." `
-	SSHKeys          []storage.SSHKey   `help:"Contains a list of SSH public keys, allowed to connect to the db server, in order to up-/download and directly restore database backups."`
-	SSHKeysFile      string             `help:"Path to a file containing a list of SSH public keys (see above), separated by newlines."`
-	KeepDailyBackups *int               `placeholder:"${postgres_backup_retention_days}" help:"Number of daily database backups to keep. Note that setting this to 0, backup will be disabled and existing dumps deleted immediately."`
+	MachineType      *string          `placeholder:"${postgres_machine_default}" help:"Defines the sizing for a particular PostgreSQL instance. Available types: ${postgres_machine_types}"`
+	AllowedCidrs     *[]meta.IPv4CIDR `placeholder:"203.0.113.1/32" help:"Specifies the IP addresses allowed to connect to the instance." `
+	SSHKeys          []storage.SSHKey `help:"Contains a list of SSH public keys, allowed to connect to the db server, in order to up-/download and directly restore database backups."`
+	SSHKeysFile      string           `help:"Path to a file containing a list of SSH public keys (see above), separated by newlines."`
+	KeepDailyBackups *int             `placeholder:"${postgres_backup_retention_days}" help:"Number of daily database backups to keep. Note that setting this to 0, backup will be disabled and existing dumps deleted immediately."`
 }
 
 func (cmd *postgresCmd) Run(ctx context.Context, client *api.Client) error {
@@ -51,7 +51,7 @@ func (cmd *postgresCmd) Run(ctx context.Context, client *api.Client) error {
 
 func (cmd *postgresCmd) applyUpdates(postgres *storage.Postgres) {
 	if cmd.MachineType != nil {
-		postgres.Spec.ForProvider.MachineType = *cmd.MachineType
+		postgres.Spec.ForProvider.MachineType = infra.NewMachineType(*cmd.MachineType)
 	}
 	if cmd.AllowedCidrs != nil {
 		postgres.Spec.ForProvider.AllowedCIDRs = *cmd.AllowedCidrs

--- a/update/postgres_test.go
+++ b/update/postgres_test.go
@@ -28,13 +28,13 @@ func TestPostgres(t *testing.T) {
 		},
 		{
 			name:   "increase-machineType",
-			update: postgresCmd{MachineType: ptr.To(infra.MachineTypeNineDBS)},
+			update: postgresCmd{MachineType: ptr.To(infra.MachineTypeNineDBS.String())},
 			want:   storage.PostgresParameters{MachineType: infra.MachineTypeNineDBS},
 		},
 		{
 			name:   "decrease-machineType",
 			create: storage.PostgresParameters{MachineType: infra.MachineTypeNineDBM},
-			update: postgresCmd{MachineType: ptr.To(infra.MachineTypeNineDBS)},
+			update: postgresCmd{MachineType: ptr.To(infra.MachineTypeNineDBS.String())},
 			want:   storage.PostgresParameters{MachineType: infra.MachineTypeNineDBS},
 		},
 		{
@@ -69,7 +69,7 @@ func TestPostgres(t *testing.T) {
 		{
 			name:   "multi-update",
 			create: storage.PostgresParameters{AllowedCIDRs: []meta.IPv4CIDR{"0.0.0.0/0"}},
-			update: postgresCmd{MachineType: ptr.To(infra.MachineTypeNineDBS)},
+			update: postgresCmd{MachineType: ptr.To(infra.MachineTypeNineDBS.String())},
 			want: storage.PostgresParameters{
 				MachineType:  infra.MachineTypeNineDBS,
 				AllowedCIDRs: []meta.IPv4CIDR{meta.IPv4CIDR("0.0.0.0/0")},


### PR DESCRIPTION
PR #217 introduced the new machine type implementation but we missed that mysql/postgres used the type directly in the command struct which does not work anymore. The machinetype needs to be constructed first using NewMachineType.