### PR TITLE
update ninech API definitions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/moby/moby v27.1.1+incompatible
 	github.com/moby/term v0.5.0
-	github.com/ninech/apis v0.0.0-20250422123651-106683d37e60
+	github.com/ninech/apis v0.0.0-20250520090952-5150591585c0
 	github.com/posener/complete v1.2.3
 	github.com/prometheus/common v0.55.0
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -591,6 +591,8 @@ github.com/ninech/apis v0.0.0-20250414123537-0c072cefe5dc h1:ORI0kIZI0IzlrxRKVQU
 github.com/ninech/apis v0.0.0-20250414123537-0c072cefe5dc/go.mod h1:6srtlYi3nj8GRxQkbhvSbanIBc9vsoPLFOp5VQzNNhM=
 github.com/ninech/apis v0.0.0-20250422123651-106683d37e60 h1:XnH0Xlt5VLPx3N4CSNh7Uo55jj3dscICxsvlL1WUEuY=
 github.com/ninech/apis v0.0.0-20250422123651-106683d37e60/go.mod h1:6srtlYi3nj8GRxQkbhvSbanIBc9vsoPLFOp5VQzNNhM=
+github.com/ninech/apis v0.0.0-20250520090952-5150591585c0 h1:BwC0XVg89DudYm9LGfE3t3pDYRZINI3az3e5nCXoO24=
+github.com/ninech/apis v0.0.0-20250520090952-5150591585c0/go.mod h1:6srtlYi3nj8GRxQkbhvSbanIBc9vsoPLFOp5VQzNNhM=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=


### PR DESCRIPTION
This will fix a bug which disabled all networking connections for newly created KVS instances.