### PR TITLE
feat: improve predictor

### DIFF
--- a/auth/set_project.go
+++ b/auth/set_project.go
@@ -13,7 +13,7 @@ import (
 )
 
 type SetProjectCmd struct {
-	Name string `arg:"" predictor:"resource_name" help:"Name of the default project to be used."`
+	Name string `arg:"" help:"Name of the default project to be used." predictor:"project_name"`
 }
 
 func (s *SetProjectCmd) Run(ctx context.Context, client *api.Client) error {


### PR DESCRIPTION
This adds a new predictor that works on a fixed kind and does not need to resolve the kind by the last argument name. The client creation function has been moved out of main since there is no reason for it to be there.