### PR TITLE
feat: implement copy app command

### DIFF
--- a/copy/application.go
+++ b/copy/application.go
@@ -1,0 +1,106 @@
+package copy
+
+import (
+	"context"
+	"fmt"
+
+	apps "github.com/ninech/apis/apps/v1alpha1"
+	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/api/util"
+	"github.com/ninech/nctl/internal/format"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type applicationCmd struct {
+	resourceCmd
+	Start     bool `help:"Automatically start copied app."`
+	CopyHosts bool `help:"Also copy hosts of the old app."`
+}
+
+func (app *applicationCmd) Run(ctx context.Context, client *api.Client) error {
+	newApp, err := app.newCopy(ctx, client)
+	if err != nil {
+		return fmt.Errorf("unable to copy app: %w", err)
+	}
+
+	if err := client.Create(ctx, newApp); err != nil {
+		return fmt.Errorf("unable to create Application %q: %w", newApp.GetName(), err)
+	}
+
+	app.printCopyMessage(client, newApp)
+	return nil
+}
+
+func (app *applicationCmd) targetNamespace(client *api.Client) string {
+	if app.TargetProject != "" {
+		return app.TargetProject
+	}
+	return client.Project
+}
+
+func (app *applicationCmd) newCopy(ctx context.Context, client *api.Client) (*apps.Application, error) {
+	oldApp := &apps.Application{}
+	if err := client.Get(ctx, client.Name(app.Name), oldApp); err != nil {
+		return nil, err
+	}
+	newApp := &apps.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getName(app.TargetName),
+			Namespace: app.targetNamespace(client),
+		},
+		Spec: oldApp.Spec,
+	}
+	newApp.Spec.ForProvider.Paused = !app.Start
+	if !app.CopyHosts {
+		newApp.Spec.ForProvider.Hosts = []string{}
+	}
+	if err := app.copyGitAuth(ctx, client, oldApp, newApp); err != nil {
+		return nil, err
+	}
+	return newApp, nil
+}
+
+func (app *applicationCmd) printCopyMessage(client *api.Client, newApp *apps.Application) {
+	format.PrintSuccessf("🏗", "Application %q in project %q has been copied to %q in project %q.",
+		app.Name, client.Project, newApp.Name, app.targetNamespace(client))
+	msg := ""
+	if !app.CopyHosts {
+		msg += "\nCustom hosts have not been copied and need to be migrated manually.\n"
+	}
+	if !app.Start {
+		msg += "\nNote that the app is paused and you need to unpause it to make it available.\n"
+	}
+	if msg != "" {
+		fmt.Println(msg)
+	}
+}
+
+func (app *applicationCmd) copyGitAuth(ctx context.Context, client *api.Client, oldApp, newApp *apps.Application) error {
+	if oldApp.Spec.ForProvider.Git.Auth == nil || oldApp.Spec.ForProvider.Git.Auth.FromSecret == nil {
+		return nil
+	}
+
+	secret := &corev1.Secret{}
+	if err := client.Get(ctx, client.Name(oldApp.Spec.ForProvider.Git.Auth.FromSecret.Name), secret); err != nil {
+		return err
+	}
+	newSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.GitAuthSecretName(newApp),
+			Namespace: newApp.Namespace,
+			Annotations: map[string]string{
+				util.ManagedByAnnotation: util.NctlName,
+			},
+		},
+		Data: secret.Data,
+	}
+	if err := client.Create(ctx, newSecret); err != nil {
+		if !kerrors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/copy/application_test.go
+++ b/copy/application_test.go
@@ -1,0 +1,178 @@
+package copy
+
+import (
+	"context"
+	"testing"
+
+	apps "github.com/ninech/apis/apps/v1alpha1"
+	meta "github.com/ninech/apis/meta/v1alpha1"
+	"github.com/ninech/nctl/api/util"
+	"github.com/ninech/nctl/internal/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestApplication(t *testing.T) {
+	ctx := context.Background()
+
+	tests := map[string]struct {
+		source              *apps.Application
+		sourceGitAuthSecret *corev1.Secret
+		cmd                 applicationCmd
+		expectedErr         string
+	}{
+		"same project": {
+			source: newApp("source", apps.ApplicationSpec{}),
+			cmd: applicationCmd{
+				resourceCmd: resourceCmd{
+					Name:       "source",
+					TargetName: "target",
+				},
+			},
+		},
+		"to different project": {
+			source: newApp("source", apps.ApplicationSpec{}),
+			cmd: applicationCmd{
+				resourceCmd: resourceCmd{
+					Name:          "source",
+					TargetName:    "target",
+					TargetProject: "project-2",
+				},
+			},
+		},
+		"hosts are not copied": {
+			source: newApp("source", apps.ApplicationSpec{
+				ForProvider: apps.ApplicationParameters{
+					Hosts: []string{"foo.example.org"},
+				},
+			}),
+			cmd: applicationCmd{
+				resourceCmd: resourceCmd{
+					Name:       "source",
+					TargetName: "target",
+				},
+			},
+		},
+		"hosts are copied": {
+			source: newApp("source", apps.ApplicationSpec{
+				ForProvider: apps.ApplicationParameters{
+					Hosts: []string{"foo.example.org"},
+				},
+			}),
+			cmd: applicationCmd{
+				CopyHosts: true,
+				resourceCmd: resourceCmd{
+					Name:       "source",
+					TargetName: "target",
+				},
+			},
+		},
+		"spec fields are copied": {
+			source: newApp("source", apps.ApplicationSpec{
+				ForProvider: apps.ApplicationParameters{
+					Language: "No",
+					BuildEnv: []apps.EnvVar{{Name: "SOME_VAR", Value: "some val"}},
+				},
+			}),
+			cmd: applicationCmd{
+				resourceCmd: resourceCmd{
+					Name:       "source",
+					TargetName: "target",
+				},
+			},
+		},
+		"source does not exist": {
+			source: newApp("source", apps.ApplicationSpec{}),
+			cmd: applicationCmd{
+				resourceCmd: resourceCmd{
+					Name:       "does-not-exist",
+					TargetName: "target",
+				},
+			},
+			expectedErr: "unable to copy app",
+		},
+		"start app": {
+			source: newApp("source", apps.ApplicationSpec{}),
+			cmd: applicationCmd{
+				Start: true,
+				resourceCmd: resourceCmd{
+					Name:       "source",
+					TargetName: "target",
+				},
+			},
+		},
+		"git auth secret": {
+			source: newApp("source", apps.ApplicationSpec{
+				ForProvider: apps.ApplicationParameters{
+					Git: apps.ApplicationGitConfig{
+						Auth: &apps.GitAuth{
+							FromSecret: &meta.LocalReference{
+								Name: "source",
+							},
+						},
+					},
+				},
+			}),
+			sourceGitAuthSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "source", Namespace: "default"},
+				Data:       map[string][]byte{"foo": []byte("bar")},
+			},
+			cmd: applicationCmd{
+				resourceCmd: resourceCmd{
+					Name:       "source",
+					TargetName: "target",
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			objs := []client.Object{tc.source}
+			if tc.sourceGitAuthSecret != nil {
+				objs = append(objs, tc.sourceGitAuthSecret)
+			}
+			apiClient, err := test.SetupClient(test.WithObjects(objs...))
+			require.NoError(t, err)
+
+			err = tc.cmd.Run(ctx, apiClient)
+			if tc.expectedErr != "" {
+				assert.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+
+			copiedApp := &apps.Application{}
+			newName := types.NamespacedName{Name: tc.cmd.TargetName, Namespace: tc.cmd.targetNamespace(apiClient)}
+			assert.NoError(t, apiClient.Get(ctx, newName, copiedApp))
+			// expect copied app to be paused and hosts to be empty
+			tc.source.Spec.ForProvider.Paused = !tc.cmd.Start
+			if !tc.cmd.CopyHosts {
+				tc.source.Spec.ForProvider.Hosts = nil
+			}
+			assert.Equal(t, tc.source.Spec, copiedApp.Spec)
+
+			// check if git auth has been copied if there's a source
+			if tc.sourceGitAuthSecret != nil {
+				copiedSecret := &corev1.Secret{}
+				newSecretName := types.NamespacedName{Name: util.GitAuthSecretName(copiedApp), Namespace: tc.cmd.targetNamespace(apiClient)}
+				assert.NoError(t, apiClient.Get(ctx, newSecretName, copiedSecret))
+				assert.Equal(t, tc.sourceGitAuthSecret.Data, copiedSecret.Data)
+			}
+		})
+	}
+}
+
+func newApp(name string, spec apps.ApplicationSpec) *apps.Application {
+	return &apps.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: spec,
+	}
+}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -1,0 +1,26 @@
+package copy
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/lucasepe/codename"
+)
+
+type Cmd struct {
+	Application applicationCmd `cmd:"" aliases:"app"`
+}
+
+type resourceCmd struct {
+	Name          string `arg:"" help:"Name of the resource to copy." default:"" predictor:"resource_name"`
+	TargetName    string `help:"Target name of the new resource. A random name is generated if omitted." default:""`
+	TargetProject string `help:"Target project of the new resource. The current project is used if omitted." default:"" predictor:"project_name"`
+}
+
+func getName(name string) string {
+	if len(name) != 0 {
+		return name
+	}
+
+	return codename.Generate(rand.New(rand.NewSource(time.Now().UnixNano())), 0)
+}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ninech/nctl/api/util"
 	"github.com/ninech/nctl/apply"
 	"github.com/ninech/nctl/auth"
+	"github.com/ninech/nctl/copy"
 	"github.com/ninech/nctl/create"
 	"github.com/ninech/nctl/delete"
 	"github.com/ninech/nctl/exec"
@@ -46,6 +47,7 @@ type rootCommand struct {
 	Auth        auth.Cmd              `cmd:"" help:"Authenticate with resource."`
 	Completions completion.Completion `cmd:"" help:"Print shell completions."`
 	Create      create.Cmd            `cmd:"" help:"Create resource."`
+	Copy        copy.Cmd              `cmd:"" help:"Copy resource"`
 	Apply       apply.Cmd             `cmd:"" help:"Apply resource."`
 	Delete      delete.Cmd            `cmd:"" help:"Delete resource."`
 	Logs        logs.Cmd              `cmd:"" help:"Get logs of resource."`


### PR DESCRIPTION
This implements a simple copy app command. The whole spec is copied with
some exceptions:

* Hosts are not copied to avoid conflicts with the old app unless
  explicitly forced with the `--copy-hosts` flag
* The new app is in paused state unless explicitly forced with the
  `--start` flag

The new app can be copied into a different project if desired.