### PR TITLE
feat: add watch flag to get commands

### DIFF
--- a/api/watch.go
+++ b/api/watch.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type WatchFunc func(list runtimeclient.ObjectList) error
+
+// TODO: all-projects/all-namespaces options don't work as expected. The initial
+// list call is correct but the watch call just happens in the current project.
+// All namespaces is easy to solve but all projects would mean a goroutine/watch
+// per project.
+func (c *Client) watch(ctx context.Context, list runtimeclient.ObjectList, options ...ListOpt) error {
+	// this is a bit awkward: we need to extract some functional options. We do
+	// this by executing each opt and checking the result.
+	var watchFunc WatchFunc
+	var clientListOptions []runtimeclient.ListOption
+	for _, opt := range options {
+		opts := &ListOpts{}
+		opt(opts)
+		if opts.watchFunc != nil {
+			watchFunc = opts.watchFunc
+		}
+		if opts.clientListOptions != nil {
+			clientListOptions = opts.clientListOptions
+		}
+	}
+
+	wa, err := c.Watch(ctx, list, append(clientListOptions, &runtimeclient.ListOptions{
+		Namespace: c.Project,
+	})...)
+	if err != nil {
+		return fmt.Errorf("watching resources: %w", err)
+	}
+
+	for {
+		select {
+		case res := <-wa.ResultChan():
+			if res.Type == watch.Error || res.Type == "" {
+				return fmt.Errorf("watching: %s", res.Object.GetObjectKind())
+			}
+			if err := meta.SetList(list, []runtime.Object{res.Object}); err != nil {
+				return err
+			}
+			if err := watchFunc(list); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			wa.Stop()
+			return nil
+		}
+	}
+}

--- a/get/all_test.go
+++ b/get/all_test.go
@@ -28,7 +28,7 @@ func TestAllContent(t *testing.T) {
 		projects             []client.Object
 		objects              []client.Object
 		projectName          string
-		outputFormat         output
+		outputFormat         outputFormat
 		allProjects          bool
 		includeNineResources bool
 		kinds                []string
@@ -290,9 +290,13 @@ dev        pear      Release        apps.nine.ch
 		t.Run(name, func(t *testing.T) {
 			testCase := testCase
 
+			outputBuffer := &bytes.Buffer{}
 			get := &Cmd{
-				Output:      testCase.outputFormat,
-				AllProjects: testCase.allProjects,
+				output: output{
+					Format:      testCase.outputFormat,
+					AllProjects: testCase.allProjects,
+					writer:      outputBuffer,
+				},
 			}
 
 			scheme, err := api.NewScheme()
@@ -312,9 +316,7 @@ dev        pear      Release        apps.nine.ch
 			require.NoError(t, err)
 			defer os.Remove(kubeconfig)
 
-			outputBuffer := &bytes.Buffer{}
 			cmd := allCmd{
-				out:                  outputBuffer,
 				IncludeNineResources: testCase.includeNineResources,
 				Kinds:                testCase.kinds,
 			}

--- a/get/application_test.go
+++ b/get/application_test.go
@@ -32,8 +32,9 @@ func TestApplication(t *testing.T) {
 	app3.Name = app.Name + "-3"
 	app3.Namespace = otherProject
 
+	buf := &bytes.Buffer{}
 	get := &Cmd{
-		Output: full,
+		output: output{writer: buf, Format: full},
 	}
 
 	apiClient, err := test.SetupClient(
@@ -45,9 +46,7 @@ func TestApplication(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	buf := &bytes.Buffer{}
 	cmd := applicationsCmd{
-		out:                  buf,
 		BasicAuthCredentials: false,
 	}
 
@@ -66,7 +65,7 @@ func TestApplication(t *testing.T) {
 	assert.Equal(t, 2, test.CountLines(buf.String()))
 	buf.Reset()
 
-	get.Output = noHeader
+	get.Format = noHeader
 	if err := cmd.Run(ctx, apiClient, get); err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +90,7 @@ func TestApplicationCredentials(t *testing.T) {
 	for name, testCase := range map[string]struct {
 		resources     []client.Object
 		name          string
-		outputFormat  output
+		outputFormat  outputFormat
 		project       string
 		output        string
 		errorExpected bool
@@ -295,9 +294,13 @@ dev        dev-second    dev-second    sample-second
 	} {
 		t.Run(name, func(t *testing.T) {
 			testCase := testCase
+			buf := &bytes.Buffer{}
 			get := &Cmd{
-				Output:      testCase.outputFormat,
-				AllProjects: testCase.project == "",
+				output: output{
+					Format:      testCase.outputFormat,
+					AllProjects: testCase.project == "",
+					writer:      buf,
+				},
 			}
 
 			apiClient, err := test.SetupClient(
@@ -309,12 +312,10 @@ dev        dev-second    dev-second    sample-second
 			)
 			require.NoError(t, err)
 
-			buf := &bytes.Buffer{}
 			cmd := applicationsCmd{
 				resourceCmd: resourceCmd{
 					Name: testCase.name,
 				},
-				out:                  buf,
 				BasicAuthCredentials: true,
 			}
 
@@ -337,7 +338,7 @@ func TestApplicationDNS(t *testing.T) {
 	for name, testCase := range map[string]struct {
 		apps          []client.Object
 		name          string
-		outputFormat  output
+		outputFormat  outputFormat
 		project       string
 		output        string
 		errorExpected bool
@@ -470,9 +471,13 @@ Visit https://docs.nine.ch/a/myshbw3EY1 to see instructions on how to setup cust
 	} {
 		t.Run(name, func(t *testing.T) {
 			testCase := testCase
+			buf := &bytes.Buffer{}
 			get := &Cmd{
-				Output:      testCase.outputFormat,
-				AllProjects: testCase.project == "",
+				output: output{
+					Format:      testCase.outputFormat,
+					AllProjects: testCase.project == "",
+					writer:      buf,
+				},
 			}
 			apiClient, err := test.SetupClient(
 				test.WithProjectsFromResources(testCase.apps...),
@@ -482,12 +487,10 @@ Visit https://docs.nine.ch/a/myshbw3EY1 to see instructions on how to setup cust
 			)
 			require.NoError(t, err)
 
-			buf := &bytes.Buffer{}
 			cmd := applicationsCmd{
 				resourceCmd: resourceCmd{
 					Name: testCase.name,
 				},
-				out:                  buf,
 				BasicAuthCredentials: false,
 				DNS:                  true,
 			}

--- a/get/build_test.go
+++ b/get/build_test.go
@@ -28,8 +28,9 @@ func TestBuild(t *testing.T) {
 	build2 := build
 	build2.Name = build2.Name + "-2"
 
+	buf := &bytes.Buffer{}
 	get := &Cmd{
-		Output: full,
+		output: output{Format: full, writer: buf},
 	}
 
 	apiClient, err := test.SetupClient(
@@ -38,11 +39,7 @@ func TestBuild(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	buf := &bytes.Buffer{}
-	cmd := buildCmd{
-		out: buf,
-	}
-
+	cmd := buildCmd{}
 	if err := cmd.Run(ctx, apiClient, get); err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +55,7 @@ func TestBuild(t *testing.T) {
 	assert.Equal(t, 2, test.CountLines(buf.String()))
 	buf.Reset()
 
-	get.Output = noHeader
+	get.Format = noHeader
 	if err := cmd.Run(ctx, apiClient, get); err != nil {
 		t.Fatal(err)
 	}

--- a/get/cloudvm_test.go
+++ b/get/cloudvm_test.go
@@ -23,7 +23,7 @@ func TestCloudVM(t *testing.T) {
 		name          string
 		instances     []cvmInstance
 		get           cloudVMCmd
-		out           output
+		out           outputFormat
 		inAllProjects bool
 		wantContain   []string
 		wantLines     int
@@ -111,9 +111,6 @@ func TestCloudVM(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf := &bytes.Buffer{}
-			tt.get.out = buf
-
 			objects := []client.Object{}
 			for _, cvm := range tt.instances {
 				created := test.CloudVirtualMachine(cvm.name, cvm.project, "nine-es34", cvm.powerState)
@@ -128,7 +125,8 @@ func TestCloudVM(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			if err := tt.get.Run(ctx, apiClient, &Cmd{Output: tt.out, AllProjects: tt.inAllProjects}); (err != nil) != tt.wantErr {
+			buf := &bytes.Buffer{}
+			if err := tt.get.Run(ctx, apiClient, &Cmd{output: output{Format: tt.out, AllProjects: tt.inAllProjects, writer: buf}}); (err != nil) != tt.wantErr {
 				t.Errorf("cloudVMCmd.Run() error = %v, wantErr %v", err, tt.wantErr)
 				t.Log(buf.String())
 			}

--- a/get/clusters.go
+++ b/get/clusters.go
@@ -3,46 +3,49 @@ package get
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
-	"text/tabwriter"
 
 	infrastructure "github.com/ninech/apis/infrastructure/v1alpha1"
 	"github.com/ninech/nctl/api"
 	"github.com/ninech/nctl/api/config"
 	"github.com/ninech/nctl/internal/format"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type clustersCmd struct {
 	resourceCmd
 }
 
-func (l *clustersCmd) Run(ctx context.Context, client *api.Client, get *Cmd) error {
-	clusterList := &infrastructure.KubernetesClusterList{}
+func (cmd *clustersCmd) Run(ctx context.Context, client *api.Client, get *Cmd) error {
+	return get.listPrint(ctx, client, cmd, api.MatchName(cmd.Name))
+}
 
-	if err := get.list(ctx, client, clusterList, api.MatchName(l.Name)); err != nil {
-		return err
-	}
+func (cmd *clustersCmd) list() client.ObjectList {
+	return &infrastructure.KubernetesClusterList{}
+}
 
+func (cmd *clustersCmd) print(ctx context.Context, client *api.Client, list client.ObjectList, out *output) error {
+	clusterList := list.(*infrastructure.KubernetesClusterList)
 	if len(clusterList.Items) == 0 {
-		get.printEmptyMessage(os.Stdout, infrastructure.KubernetesClusterKind, client.Project)
+		out.printEmptyMessage(infrastructure.KubernetesClusterKind, client.Project)
 		return nil
 	}
 
-	switch get.Output {
+	switch out.Format {
 	case full:
-		return printClusters(clusterList.Items, get, true)
+		return printClusters(clusterList.Items, out, true)
 	case noHeader:
-		return printClusters(clusterList.Items, get, false)
+		return printClusters(clusterList.Items, out, false)
 	case yamlOut:
-		return format.PrettyPrintObjects(clusterList.GetItems(), format.PrintOpts{})
+		return format.PrettyPrintObjects(clusterList.GetItems(), format.PrintOpts{Out: out.writer})
 	case jsonOut:
 		return format.PrettyPrintObjects(
 			clusterList.GetItems(),
 			format.PrintOpts{
+				Out:    out.writer,
 				Format: format.OutputFormatTypeJSON,
 				JSONOpts: format.JSONOutputOptions{
-					PrintSingleItem: l.Name != "",
+					PrintSingleItem: cmd.Name != "",
 				},
 			})
 	case contexts:
@@ -54,11 +57,9 @@ func (l *clustersCmd) Run(ctx context.Context, client *api.Client, get *Cmd) err
 	return nil
 }
 
-func printClusters(clusters []infrastructure.KubernetesCluster, get *Cmd, header bool) error {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
-
+func printClusters(clusters []infrastructure.KubernetesCluster, out *output, header bool) error {
 	if header {
-		get.writeHeader(w, "NAME", "PROVIDER", "NUM_NODES")
+		out.writeHeader("NAME", "PROVIDER", "NUM_NODES")
 	}
 
 	for _, cluster := range clusters {
@@ -75,8 +76,8 @@ func printClusters(clusters []infrastructure.KubernetesCluster, get *Cmd, header
 		if cluster.Spec.ForProvider.VCluster != nil {
 			provider = "vcluster"
 		}
-		get.writeTabRow(w, cluster.Namespace, cluster.Name, provider, strconv.Itoa(numNodes))
+		out.writeTabRow(cluster.Namespace, cluster.Name, provider, strconv.Itoa(numNodes))
 	}
 
-	return w.Flush()
+	return out.tabWriter.Flush()
 }

--- a/get/database.go
+++ b/get/database.go
@@ -2,13 +2,10 @@ package get
 
 import (
 	"context"
-	"io"
-	"text/tabwriter"
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/ninech/nctl/api"
 	"github.com/ninech/nctl/internal/format"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Database struct {
@@ -20,23 +17,15 @@ type databaseCmd struct {
 	PrintPassword         bool `help:"Print the password of the database. Requires name to be set." xor:"print"`
 	PrintDatabaseUser     bool `help:"Print the database name and user of the database. Requires name to be set." xor:"print"`
 	PrintConnectionString bool `help:"Print the connection string of the database. Requires name to be set." xor:"print"`
-
-	out io.Writer
 }
 
-func (cmd *databaseCmd) runDatabaseCmd(ctx context.Context, client *api.Client, get *Cmd,
-	databaseList runtimeclient.ObjectList, databaseResources []resource.Managed, databaseKind string,
+func (cmd *databaseCmd) runDatabaseCmd(ctx context.Context, client *api.Client,
+	out *output, databaseResources []resource.Managed, databaseKind string,
 	connectionStringHandler func(context.Context, *api.Client, resource.Managed) error,
-	databasesHandler func([]resource.Managed, *Cmd, bool) error,
+	databasesHandler func([]resource.Managed, *output, bool) error,
 ) error {
-	cmd.out = defaultOut(cmd.out)
-
-	if err := get.list(ctx, client, databaseList, api.MatchName(cmd.Name)); err != nil {
-		return err
-	}
-
 	if len(databaseResources) == 0 {
-		get.printEmptyMessage(cmd.out, databaseKind, client.Project)
+		out.printEmptyMessage(databaseKind, client.Project)
 		return nil
 	}
 
@@ -45,18 +34,18 @@ func (cmd *databaseCmd) runDatabaseCmd(ctx context.Context, client *api.Client, 
 	}
 
 	if cmd.Name != "" && cmd.PrintDatabaseUser {
-		return cmd.printSecret(cmd.out, ctx, client, databaseResources[0], func(db, _ string) string { return db })
+		return cmd.printSecret(out.writer, ctx, client, databaseResources[0], func(db, _ string) string { return db })
 	}
 
 	if cmd.Name != "" && cmd.PrintPassword {
-		return cmd.printSecret(cmd.out, ctx, client, databaseResources[0], func(_, pw string) string { return pw })
+		return cmd.printSecret(out.writer, ctx, client, databaseResources[0], func(_, pw string) string { return pw })
 	}
 
-	switch get.Output {
+	switch out.Format {
 	case full:
-		return databasesHandler(databaseResources, get, true)
+		return databasesHandler(databaseResources, out, true)
 	case noHeader:
-		return databasesHandler(databaseResources, get, false)
+		return databasesHandler(databaseResources, out, false)
 	case yamlOut:
 		return format.PrettyPrintObjects(databaseResources, format.PrintOpts{})
 	case jsonOut:
@@ -73,15 +62,13 @@ func (cmd *databaseCmd) runDatabaseCmd(ctx context.Context, client *api.Client, 
 	return nil
 }
 
-func printDatabases(out io.Writer, get *Cmd, databases []Database, header bool) error {
-	w := tabwriter.NewWriter(out, 0, 0, 5, ' ', 0)
-
+func printDatabases(out *output, databases []Database, header bool) error {
 	if header {
-		get.writeHeader(w, "NAME", "FQDN", "LOCATION", "SIZE", "CONNECTIONS")
+		out.writeHeader("NAME", "FQDN", "LOCATION", "SIZE", "CONNECTIONS")
 	}
 
 	for _, db := range databases {
-		get.writeTabRow(w,
+		out.writeTabRow(
 			db.Namespace,
 			db.Name,
 			db.FQDN,
@@ -91,5 +78,5 @@ func printDatabases(out io.Writer, get *Cmd, databases []Database, header bool) 
 		)
 	}
 
-	return w.Flush()
+	return out.tabWriter.Flush()
 }

--- a/get/database_test.go
+++ b/get/database_test.go
@@ -31,7 +31,7 @@ func TestDatabase(t *testing.T) {
 		get       postgresDatabaseCmd
 		// out defines the output format and will bet set to "full" if
 		// not given
-		out           output
+		out           outputFormat
 		wantContain   []string
 		wantLines     int
 		inAllProjects bool
@@ -138,8 +138,6 @@ func TestDatabase(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf := &bytes.Buffer{}
-			tt.get.out = buf
 
 			objects := []client.Object{}
 			for _, database := range tt.databases {
@@ -164,7 +162,8 @@ func TestDatabase(t *testing.T) {
 			if tt.out == "" {
 				tt.out = full
 			}
-			if err := tt.get.Run(ctx, apiClient, &Cmd{Output: tt.out, AllProjects: tt.inAllProjects}); (err != nil) != tt.wantErr {
+			buf := &bytes.Buffer{}
+			if err := tt.get.Run(ctx, apiClient, &Cmd{output: output{Format: tt.out, AllProjects: tt.inAllProjects, writer: buf}}); (err != nil) != tt.wantErr {
 				t.Errorf("postgresDatabaseCmd.Run() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.wantErr {

--- a/get/get_test.go
+++ b/get/get_test.go
@@ -1,0 +1,110 @@
+package get
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	infrastructure "github.com/ninech/apis/infrastructure/v1alpha1"
+	"github.com/ninech/nctl/internal/test"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestListPrint(t *testing.T) {
+	tests := map[string]struct {
+		out               outputFormat
+		inAllProjects     bool
+		existingResources []client.Object
+		toCreate          []client.Object
+		watch             bool
+		wantContain       []string
+		wantLines         int
+		wantErr           bool
+	}{
+		"watch disabled": {
+			out: full,
+			existingResources: []client.Object{
+				test.CloudVirtualMachine("foo", test.DefaultProject, "nine-es34", infrastructure.VirtualMachinePowerState("on")),
+			},
+			toCreate:    []client.Object{test.CloudVirtualMachine("new", test.DefaultProject, "nine-es34", infrastructure.VirtualMachinePowerState("on"))},
+			wantContain: []string{"foo"},
+			wantLines:   2,
+		},
+		"watch": {
+			out:               full,
+			existingResources: []client.Object{},
+			toCreate: []client.Object{
+				test.CloudVirtualMachine("new", test.DefaultProject, "nine-es34", infrastructure.VirtualMachinePowerState("on")),
+				test.CloudVirtualMachine("new2", test.DefaultProject, "nine-es34", infrastructure.VirtualMachinePowerState("on")),
+				test.CloudVirtualMachine("new3", "other-project", "nine-es34", infrastructure.VirtualMachinePowerState("on")),
+			},
+			wantContain: []string{"new", "new2"},
+			wantLines:   3,
+			watch:       true,
+		},
+		// TODO: watch currently does not support the all-projects or
+		// all-namespaces flags. This test should pass once that's implemented.
+		//
+		// "watch all projects": {
+		// 	out: full,
+		// 	existingResources: []client.Object{
+		// 		test.CloudVirtualMachine("foo", test.DefaultProject, "nine-es34", infrastructure.VirtualMachinePowerState("on")),
+		// 	},
+		// 	toCreate: []client.Object{
+		// 		test.CloudVirtualMachine("new", test.DefaultProject, "nine-es34", infrastructure.VirtualMachinePowerState("on")),
+		// 		test.CloudVirtualMachine("new2", "default-project", "nine-es34", infrastructure.VirtualMachinePowerState("on")),
+		// 	},
+		// 	wantContain:   []string{"foo", "new2"},
+		// 	wantLines:     4,
+		// 	inAllProjects: true,
+		// 	watch:         true,
+		// },
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			apiClient, err := test.SetupClient(
+				test.WithDefaultProject(test.DefaultProject),
+				test.WithProjectsFromResources(append(tc.existingResources, tc.toCreate...)...),
+				test.WithObjects(tc.existingResources...),
+				test.WithKubeconfig(t),
+			)
+			require.NoError(t, err)
+
+			buf := &bytes.Buffer{}
+			cmd := &Cmd{output: output{Format: tc.out, AllProjects: tc.inAllProjects, writer: buf, Watch: tc.watch}}
+			ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+			defer cancel()
+
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			go func() {
+				if err := cmd.listPrint(ctx, apiClient, &cloudVMCmd{}); (err != nil) != tc.wantErr {
+					t.Errorf("cmd.list error = %v, wantErr %v", err, tc.wantErr)
+					t.Log(buf.String())
+				}
+				wg.Done()
+			}()
+			// delay the creation so watch is running
+			time.Sleep(time.Millisecond * 10)
+			for _, res := range tc.toCreate {
+				require.NoError(t, apiClient.Create(ctx, res))
+			}
+			wg.Wait()
+			if tc.wantErr {
+				return
+			}
+			for _, substr := range tc.wantContain {
+				if !strings.Contains(buf.String(), substr) {
+					t.Errorf("cmd.list did not contain %q, out = %q", tc.wantContain, buf.String())
+				}
+			}
+			if test.CountLines(buf.String()) != tc.wantLines {
+				t.Errorf("expected the output to have %d lines, but found %d", tc.wantLines, test.CountLines(buf.String()))
+			}
+		})
+	}
+}

--- a/get/keyvaluestore_test.go
+++ b/get/keyvaluestore_test.go
@@ -28,7 +28,7 @@ func TestKeyValueStore(t *testing.T) {
 		name          string
 		instances     []kvsInstance
 		get           keyValueStoreCmd
-		out           output
+		out           outputFormat
 		inAllProjects bool
 		wantContain   []string
 		wantLines     int
@@ -145,9 +145,6 @@ func TestKeyValueStore(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf := &bytes.Buffer{}
-			tt.get.out = buf
-
 			objects := []client.Object{}
 			for _, instance := range tt.instances {
 				created := test.KeyValueStore(instance.name, instance.project, "nine-es34")
@@ -169,7 +166,8 @@ func TestKeyValueStore(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			if err := tt.get.Run(ctx, apiClient, &Cmd{Output: tt.out, AllProjects: tt.inAllProjects}); (err != nil) != tt.wantErr {
+			buf := &bytes.Buffer{}
+			if err := tt.get.Run(ctx, apiClient, &Cmd{output: output{Format: tt.out, AllProjects: tt.inAllProjects, writer: buf}}); (err != nil) != tt.wantErr {
 				t.Errorf("keyValueStoreCmd.Run() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.wantErr {

--- a/get/mysql_test.go
+++ b/get/mysql_test.go
@@ -30,7 +30,7 @@ func TestMySQL(t *testing.T) {
 		get       mySQLCmd
 		// out defines the output format and will bet set to "full" if
 		// not given
-		out           output
+		out           outputFormat
 		inAllProjects bool
 		wantContain   []string
 		wantLines     int
@@ -137,9 +137,6 @@ func TestMySQL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf := &bytes.Buffer{}
-			tt.get.out = buf
-
 			objects := []client.Object{}
 			for _, instance := range tt.instances {
 				created := test.MySQL(instance.name, instance.project, "nine-es34")
@@ -164,7 +161,8 @@ func TestMySQL(t *testing.T) {
 			if tt.out == "" {
 				tt.out = full
 			}
-			if err := tt.get.Run(ctx, apiClient, &Cmd{Output: tt.out, AllProjects: tt.inAllProjects}); (err != nil) != tt.wantErr {
+			buf := &bytes.Buffer{}
+			if err := tt.get.Run(ctx, apiClient, &Cmd{output: output{Format: tt.out, AllProjects: tt.inAllProjects, writer: buf}}); (err != nil) != tt.wantErr {
 				t.Errorf("mySQLCmd.Run() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.wantErr {

--- a/get/mysqldatabase.go
+++ b/get/mysqldatabase.go
@@ -7,6 +7,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	storage "github.com/ninech/apis/storage/v1alpha1"
 	"github.com/ninech/nctl/api"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type mysqlDatabaseCmd struct {
@@ -15,38 +16,41 @@ type mysqlDatabaseCmd struct {
 }
 
 func (cmd *mysqlDatabaseCmd) Run(ctx context.Context, client *api.Client, get *Cmd) error {
-	databaseList := &storage.MySQLDatabaseList{}
-	databaseResources := make([]resource.Managed, 0)
+	return get.listPrint(ctx, client, cmd, api.MatchName(cmd.Name))
+}
 
-	if err := get.list(ctx, client, databaseList, api.MatchName(cmd.Name)); err != nil {
-		return err
-	}
+func (cmd *mysqlDatabaseCmd) list() runtimeclient.ObjectList {
+	return &storage.MySQLDatabaseList{}
+}
 
+func (cmd *mysqlDatabaseCmd) print(ctx context.Context, client *api.Client, list runtimeclient.ObjectList, out *output) error {
+	databaseList := list.(*storage.MySQLDatabaseList)
+	databaseResources := make([]resource.Managed, 0, len(databaseList.Items))
 	for i := range databaseList.Items {
 		databaseResources = append(databaseResources, &databaseList.Items[i])
 	}
 
 	if cmd.Name != "" && cmd.PrintCharacterSet {
-		return cmd.printMySQLCharacterSet(databaseResources[0].(*storage.MySQLDatabase))
+		return cmd.printMySQLCharacterSet(databaseResources[0].(*storage.MySQLDatabase), out)
 	}
 
-	return cmd.runDatabaseCmd(ctx, client, get,
-		databaseList, databaseResources, storage.MySQLDatabaseKind,
+	return cmd.runDatabaseCmd(ctx, client, out,
+		databaseResources, storage.MySQLDatabaseKind,
 		func(ctx context.Context, client *api.Client, mg resource.Managed) error {
-			return cmd.printConnectionString(ctx, client, mg.(*storage.MySQLDatabase))
+			return cmd.printConnectionString(ctx, client, mg.(*storage.MySQLDatabase), out)
 		},
-		func(res []resource.Managed, get *Cmd, header bool) error {
+		func(res []resource.Managed, out *output, header bool) error {
 			dbs := make([]storage.MySQLDatabase, len(res))
 			for i, r := range res {
 				dbs[i] = *r.(*storage.MySQLDatabase)
 			}
 
-			return cmd.printMySQLDatabases(dbs, get, header)
+			return cmd.printMySQLDatabases(dbs, out, header)
 		},
 	)
 }
 
-func (cmd *mysqlDatabaseCmd) printMySQLDatabases(list []storage.MySQLDatabase, get *Cmd, header bool) error {
+func (cmd *mysqlDatabaseCmd) printMySQLDatabases(list []storage.MySQLDatabase, out *output, header bool) error {
 	databases := make([]Database, len(list))
 	for i, db := range list {
 		databases[i] = Database{
@@ -59,19 +63,19 @@ func (cmd *mysqlDatabaseCmd) printMySQLDatabases(list []storage.MySQLDatabase, g
 		}
 	}
 
-	return printDatabases(cmd.out, get, databases, header)
+	return printDatabases(out, databases, header)
 }
 
 // printConnectionString according to the MySQL documentation:
 // https://dev.mysql.com/doc/refman/8.4/en/connecting-using-uri-or-key-value-pairs.html#connecting-using-uri
-func (cmd *mysqlDatabaseCmd) printConnectionString(ctx context.Context, client *api.Client, mdb *storage.MySQLDatabase) error {
+func (cmd *mysqlDatabaseCmd) printConnectionString(ctx context.Context, client *api.Client, mdb *storage.MySQLDatabase, out *output) error {
 	secrets, err := getConnectionSecretMap(ctx, client, mdb)
 	if err != nil {
 		return err
 	}
 
 	for db, pw := range secrets {
-		fmt.Fprintf(cmd.out, "mysql://%s:%s@%s/%s\n",
+		fmt.Fprintf(out.writer, "mysql://%s:%s@%s/%s\n",
 			db,
 			pw,
 			mdb.Status.AtProvider.FQDN,
@@ -83,8 +87,8 @@ func (cmd *mysqlDatabaseCmd) printConnectionString(ctx context.Context, client *
 	return nil
 }
 
-func (cmd *mysqlDatabaseCmd) printMySQLCharacterSet(mdb *storage.MySQLDatabase) error {
-	fmt.Fprintln(defaultOut(cmd.out), mdb.Spec.ForProvider.CharacterSet.Name)
+func (cmd *mysqlDatabaseCmd) printMySQLCharacterSet(mdb *storage.MySQLDatabase, out *output) error {
+	fmt.Fprintln(out.writer, mdb.Spec.ForProvider.CharacterSet.Name)
 
 	return nil
 }

--- a/get/mysqldatabase_test.go
+++ b/get/mysqldatabase_test.go
@@ -31,7 +31,7 @@ func TestMySQLDatabase(t *testing.T) {
 		get       mysqlDatabaseCmd
 		// out defines the output format and will bet set to "full" if
 		// not given
-		out           output
+		out           outputFormat
 		wantContain   []string
 		wantLines     int
 		inAllProjects bool
@@ -85,9 +85,6 @@ func TestMySQLDatabase(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf := &bytes.Buffer{}
-			tt.get.out = buf
-
 			objects := []client.Object{}
 			for _, database := range tt.databases {
 				created := test.MySQLDatabase(database.name, database.project, "nine-es34")
@@ -112,7 +109,9 @@ func TestMySQLDatabase(t *testing.T) {
 			if tt.out == "" {
 				tt.out = full
 			}
-			if err := tt.get.Run(ctx, apiClient, &Cmd{Output: tt.out, AllProjects: tt.inAllProjects}); (err != nil) != tt.wantErr {
+
+			buf := &bytes.Buffer{}
+			if err := tt.get.Run(ctx, apiClient, &Cmd{output: output{Format: tt.out, AllProjects: tt.inAllProjects, writer: buf}}); (err != nil) != tt.wantErr {
 				t.Errorf("mysqlDatabaseCmd.Run() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.wantErr {

--- a/get/postgres_test.go
+++ b/get/postgres_test.go
@@ -30,7 +30,7 @@ func TestPostgres(t *testing.T) {
 		get       postgresCmd
 		// out defines the output format and will bet set to "full" if
 		// not given
-		out           output
+		out           outputFormat
 		wantContain   []string
 		wantLines     int
 		inAllProjects bool
@@ -137,9 +137,6 @@ func TestPostgres(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf := &bytes.Buffer{}
-			tt.get.out = buf
-
 			objects := []client.Object{}
 			for _, instance := range tt.instances {
 				created := test.Postgres(instance.name, instance.project, "nine-es34")
@@ -163,7 +160,8 @@ func TestPostgres(t *testing.T) {
 			if tt.out == "" {
 				tt.out = full
 			}
-			if err := tt.get.Run(ctx, apiClient, &Cmd{Output: tt.out, AllProjects: tt.inAllProjects}); (err != nil) != tt.wantErr {
+			buf := &bytes.Buffer{}
+			if err := tt.get.Run(ctx, apiClient, &Cmd{output: output{Format: tt.out, AllProjects: tt.inAllProjects, writer: buf}}); (err != nil) != tt.wantErr {
 				t.Errorf("postgresCmd.Run() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.wantErr {

--- a/get/postgresdatabase.go
+++ b/get/postgresdatabase.go
@@ -7,6 +7,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	storage "github.com/ninech/apis/storage/v1alpha1"
 	"github.com/ninech/nctl/api"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type postgresDatabaseCmd struct {
@@ -14,34 +15,37 @@ type postgresDatabaseCmd struct {
 }
 
 func (cmd *postgresDatabaseCmd) Run(ctx context.Context, client *api.Client, get *Cmd) error {
-	databaseList := &storage.PostgresDatabaseList{}
-	databaseResources := make([]resource.Managed, 0)
+	return get.listPrint(ctx, client, cmd, api.MatchName(cmd.Name))
+}
 
-	if err := get.list(ctx, client, databaseList, api.MatchName(cmd.Name)); err != nil {
-		return err
-	}
+func (cmd *postgresDatabaseCmd) list() runtimeclient.ObjectList {
+	return &storage.PostgresDatabaseList{}
+}
 
+func (cmd *postgresDatabaseCmd) print(ctx context.Context, client *api.Client, list runtimeclient.ObjectList, out *output) error {
+	databaseList := list.(*storage.PostgresDatabaseList)
+	databaseResources := make([]resource.Managed, 0, len(databaseList.Items))
 	for i := range databaseList.Items {
 		databaseResources = append(databaseResources, &databaseList.Items[i])
 	}
 
-	return cmd.runDatabaseCmd(ctx, client, get,
-		databaseList, databaseResources, storage.PostgresDatabaseKind,
+	return cmd.runDatabaseCmd(ctx, client, out,
+		databaseResources, storage.PostgresDatabaseKind,
 		func(ctx context.Context, client *api.Client, mg resource.Managed) error {
-			return cmd.printConnectionString(ctx, client, mg.(*storage.PostgresDatabase))
+			return cmd.printConnectionString(ctx, client, mg.(*storage.PostgresDatabase), out)
 		},
-		func(res []resource.Managed, get *Cmd, header bool) error {
+		func(res []resource.Managed, out *output, header bool) error {
 			dbs := make([]storage.PostgresDatabase, len(res))
 			for i, r := range res {
 				dbs[i] = *r.(*storage.PostgresDatabase)
 			}
 
-			return cmd.printPostgresDatabases(dbs, get, header)
+			return cmd.printPostgresDatabases(dbs, out, header)
 		},
 	)
 }
 
-func (cmd *postgresDatabaseCmd) printPostgresDatabases(list []storage.PostgresDatabase, get *Cmd, header bool) error {
+func (cmd *postgresDatabaseCmd) printPostgresDatabases(list []storage.PostgresDatabase, out *output, header bool) error {
 	databases := make([]Database, len(list))
 	for i, db := range list {
 		databases[i] = Database{
@@ -54,19 +58,19 @@ func (cmd *postgresDatabaseCmd) printPostgresDatabases(list []storage.PostgresDa
 		}
 	}
 
-	return printDatabases(cmd.out, get, databases, header)
+	return printDatabases(out, databases, header)
 }
 
 // printConnectionString according to the PostgreSQL documentation:
 // https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-func (cmd *postgresDatabaseCmd) printConnectionString(ctx context.Context, client *api.Client, pgd *storage.PostgresDatabase) error {
+func (cmd *postgresDatabaseCmd) printConnectionString(ctx context.Context, client *api.Client, pgd *storage.PostgresDatabase, out *output) error {
 	secrets, err := getConnectionSecretMap(ctx, client, pgd)
 	if err != nil {
 		return err
 	}
 
 	for db, pw := range secrets {
-		fmt.Fprintf(cmd.out, "postgres://%s:%s@%s/%s\n",
+		fmt.Fprintf(out.writer, "postgres://%s:%s@%s/%s\n",
 			db,
 			pw,
 			pgd.Status.AtProvider.FQDN,

--- a/get/postgresdatabase_test.go
+++ b/get/postgresdatabase_test.go
@@ -30,7 +30,7 @@ func TestPostgresDatabase(t *testing.T) {
 		get       postgresDatabaseCmd
 		// out defines the output format and will bet set to "full" if
 		// not given
-		out           output
+		out           outputFormat
 		wantContain   []string
 		wantLines     int
 		inAllProjects bool
@@ -64,9 +64,6 @@ func TestPostgresDatabase(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf := &bytes.Buffer{}
-			tt.get.out = buf
-
 			objects := []client.Object{}
 			for _, database := range tt.databases {
 				created := test.PostgresDatabase(database.name, database.project, "nine-es34")
@@ -90,7 +87,8 @@ func TestPostgresDatabase(t *testing.T) {
 			if tt.out == "" {
 				tt.out = full
 			}
-			if err := tt.get.Run(ctx, apiClient, &Cmd{Output: tt.out, AllProjects: tt.inAllProjects}); (err != nil) != tt.wantErr {
+			buf := &bytes.Buffer{}
+			if err := tt.get.Run(ctx, apiClient, &Cmd{output: output{Format: tt.out, AllProjects: tt.inAllProjects, writer: buf}}); (err != nil) != tt.wantErr {
 				t.Errorf("postgresDatabaseCmd.Run() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.wantErr {

--- a/get/project_config_test.go
+++ b/get/project_config_test.go
@@ -28,8 +28,10 @@ func TestProjectConfigs(t *testing.T) {
 	}{
 		"get configs for all projects": {
 			get: &Cmd{
-				Output:      full,
-				AllProjects: true,
+				output: output{
+					Format:      full,
+					AllProjects: true,
+				},
 			},
 			project: "ns-1",
 			createdConfigs: []client.Object{
@@ -42,7 +44,9 @@ func TestProjectConfigs(t *testing.T) {
 		},
 		"get config for current project": {
 			get: &Cmd{
-				Output: full,
+				output: output{
+					Format: full,
+				},
 			},
 			project: "ns-2",
 			createdConfigs: []client.Object{
@@ -57,7 +61,9 @@ func TestProjectConfigs(t *testing.T) {
 		},
 		"no configs existing": {
 			get: &Cmd{
-				Output: full,
+				output: output{
+					Format: full,
+				},
 			},
 			project:            "ns-3",
 			expectExactMessage: ptr.To("no ProjectConfigs found in project ns-3\n"),
@@ -76,8 +82,8 @@ func TestProjectConfigs(t *testing.T) {
 			require.NoError(t, err)
 
 			buf := &bytes.Buffer{}
+			tc.get.writer = buf
 			cmd := configsCmd{}
-			cmd.out = buf
 
 			if err := cmd.Run(ctx, apiClient, tc.get); err != nil {
 				t.Fatal(err)

--- a/get/project_test.go
+++ b/get/project_test.go
@@ -23,7 +23,7 @@ func TestProject(t *testing.T) {
 		projects     []client.Object
 		displayNames []string
 		name         string
-		outputFormat output
+		outputFormat outputFormat
 		allProjects  bool
 		output       string
 	}{
@@ -147,9 +147,13 @@ dev        <none>
 		t.Run(name, func(t *testing.T) {
 			testCase := testCase
 
+			buf := &bytes.Buffer{}
 			get := &Cmd{
-				Output:      testCase.outputFormat,
-				AllProjects: testCase.allProjects,
+				output: output{
+					Format:      testCase.outputFormat,
+					AllProjects: testCase.allProjects,
+					writer:      buf,
+				},
 			}
 
 			projects := testCase.projects
@@ -167,12 +171,10 @@ dev        <none>
 			)
 			require.NoError(t, err)
 
-			buf := &bytes.Buffer{}
 			cmd := projectCmd{
 				resourceCmd: resourceCmd{
 					Name: testCase.name,
 				},
-				out: buf,
 			}
 
 			if err := cmd.Run(ctx, apiClient, get); err != nil {
@@ -196,7 +198,7 @@ func TestProjectsConfigErrors(t *testing.T) {
 		},
 	}
 	get := &Cmd{
-		Output: full,
+		output: output{Format: full},
 	}
 	// there is no kubeconfig so we expect to fail
 	require.Error(t, cmd.Run(ctx, apiClient, get))

--- a/get/releases_test.go
+++ b/get/releases_test.go
@@ -33,7 +33,7 @@ func TestReleases(t *testing.T) {
 		releases      []client.Object
 		inAllProjects bool
 		// output will be full if not set
-		output      output
+		output      outputFormat
 		wantErr     bool
 		wantContain []string
 		wantLines   int
@@ -174,12 +174,14 @@ func TestReleases(t *testing.T) {
 			if tc.output == "" {
 				tc.output = full
 			}
-			get := &Cmd{
-				Output:      tc.output,
-				AllProjects: tc.inAllProjects,
-			}
 			buf := &bytes.Buffer{}
-			tc.cmd.out = buf
+			get := &Cmd{
+				output: output{
+					Format:      tc.output,
+					AllProjects: tc.inAllProjects,
+					writer:      buf,
+				},
+			}
 
 			if err := tc.cmd.Run(ctx, apiClient, get); (err != nil) != tc.wantErr {
 				t.Errorf("releasesCmd.Run() error = %v, wantErr %v", err, tc.wantErr)

--- a/get/serviceconnection_test.go
+++ b/get/serviceconnection_test.go
@@ -28,7 +28,7 @@ func TestServiceConnection(t *testing.T) {
 		get       serviceConnectionCmd
 		// out defines the output format and will bet set to "full" if
 		// not given
-		out           output
+		out           outputFormat
 		wantContain   []string
 		wantLines     int
 		inAllProjects bool
@@ -104,9 +104,6 @@ func TestServiceConnection(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf := &bytes.Buffer{}
-			tt.get.out = buf
-
 			objects := []client.Object{}
 			for _, instance := range tt.instances {
 				created := test.ServiceConnection(instance.name, instance.project)
@@ -126,7 +123,8 @@ func TestServiceConnection(t *testing.T) {
 			if tt.out == "" {
 				tt.out = full
 			}
-			if err := tt.get.Run(ctx, apiClient, &Cmd{Output: tt.out, AllProjects: tt.inAllProjects}); (err != nil) != tt.wantErr {
+			buf := &bytes.Buffer{}
+			if err := tt.get.Run(ctx, apiClient, &Cmd{output: output{Format: tt.out, AllProjects: tt.inAllProjects, writer: buf}}); (err != nil) != tt.wantErr {
 				t.Errorf("serviceConnectionCmd.Run() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.wantErr {


### PR DESCRIPTION
This adds a new `--watch` flag that works on most get commands. It does a normal get and then keeps nctl running while watching the specified resource for changes. This also works in combination with output options such as yaml, json etc.

As long as the resource is using the `get.list()` API, watch will automatically work. To accomplish this, the get commands need to implement a common interface `listPrinter`. For now, watch does not work in combination with the --all-projects and --all-namespaces flags.