### PR TITLE
fix: initial watch list formatting

### DIFF
--- a/api/list.go
+++ b/api/list.go
@@ -99,18 +99,7 @@ func (c *Client) ListObjects(ctx context.Context, list runtimeclient.ObjectList,
 		return nil
 	}
 
-	// we now need a bit of reflection code from the apimachinery package
-	// as the ObjectList interface provides no way to get or set the list
-	// items directly.
-
-	// we need to get a pointer to the items field of the list and turn it
-	// into a reflect value so that we can change the items in case we want
-	// to search in all projects.
-	itemsPtr, err := meta.GetItemsPtr(list)
-	if err != nil {
-		return err
-	}
-	items, err := conversion.EnforcePtr(itemsPtr)
+	items, err := itemsFromObjectList(list)
 	if err != nil {
 		return err
 	}
@@ -260,4 +249,17 @@ func (c *Client) Projects(ctx context.Context, onlyName string) ([]management.Pr
 		return nil, err
 	}
 	return projectList.Items, nil
+}
+
+func itemsFromObjectList(list runtimeclient.ObjectList) (reflect.Value, error) {
+	// we need a bit of reflection code from the apimachinery package as the
+	// ObjectList interface provides no way to get or set the list items
+	// directly. We need to get a pointer to the items field of the list and
+	// turn it into a reflect value so that we can change the items in case we
+	// want to search in all projects.
+	itemsPtr, err := meta.GetItemsPtr(list)
+	if err != nil {
+		return reflect.Value{}, err
+	}
+	return conversion.EnforcePtr(itemsPtr)
 }

--- a/api/watch.go
+++ b/api/watch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,13 +18,19 @@ type WatchFunc func(list runtimeclient.ObjectList) error
 // All namespaces is easy to solve but all projects would mean a goroutine/watch
 // per project.
 func (c *Client) watch(ctx context.Context, list runtimeclient.ObjectList, options ...ListOpt) error {
-	// this is a bit awkward: we need to extract some functional options. We do
-	// this by executing each opt and checking the result.
+	// this is a bit awkward: we need to extract some functional options and
+	// make sure we don't pass the watch option down to c.ListObjects as that
+	// will cause infinite recursion. We do this by executing each opt and
+	// checking the result.
+	newOptions := []ListOpt{}
 	var watchFunc WatchFunc
 	var clientListOptions []runtimeclient.ListOption
 	for _, opt := range options {
 		opts := &ListOpts{}
 		opt(opts)
+		if !opts.watch {
+			newOptions = append(newOptions, opt)
+		}
 		if opts.watchFunc != nil {
 			watchFunc = opts.watchFunc
 		}
@@ -31,9 +38,32 @@ func (c *Client) watch(ctx context.Context, list runtimeclient.ObjectList, optio
 			clientListOptions = opts.clientListOptions
 		}
 	}
+	// do an initial list call, this is to get immediate output of the current
+	// list if it has any items. After that updates will be streamed in by the
+	// watch. If we would just call watch immediately, the list wouldn't be
+	// properly formatted as the tab writer and sort logic would not have the
+	// full list to work with.
+	if err := c.ListObjects(ctx, list, newOptions...); err != nil {
+		return err
+	}
+	items, err := itemsFromObjectList(list)
+	if err != nil {
+		return err
+	}
+	if items.Len() > 0 {
+		if err := watchFunc(list); err != nil {
+			return err
+		}
+	}
 
 	wa, err := c.Watch(ctx, list, append(clientListOptions, &runtimeclient.ListOptions{
 		Namespace: c.Project,
+		Raw: &metav1.ListOptions{
+			// in order to get around the initial list of items, we make a
+			// previous list call and then set the resource version of the
+			// returned list.
+			ResourceVersion: list.GetResourceVersion(),
+		},
 	})...)
 	if err != nil {
 		return fmt.Errorf("watching resources: %w", err)

--- a/get/get_test.go
+++ b/get/get_test.go
@@ -35,15 +35,17 @@ func TestListPrint(t *testing.T) {
 			wantLines:   2,
 		},
 		"watch": {
-			out:               full,
-			existingResources: []client.Object{},
+			out: full,
+			existingResources: []client.Object{
+				test.CloudVirtualMachine("foo", test.DefaultProject, "nine-es34", infrastructure.VirtualMachinePowerState("on")),
+			},
 			toCreate: []client.Object{
 				test.CloudVirtualMachine("new", test.DefaultProject, "nine-es34", infrastructure.VirtualMachinePowerState("on")),
 				test.CloudVirtualMachine("new2", test.DefaultProject, "nine-es34", infrastructure.VirtualMachinePowerState("on")),
 				test.CloudVirtualMachine("new3", "other-project", "nine-es34", infrastructure.VirtualMachinePowerState("on")),
 			},
 			wantContain: []string{"new", "new2"},
-			wantLines:   3,
+			wantLines:   4,
 			watch:       true,
 		},
 		// TODO: watch currently does not support the all-projects or


### PR DESCRIPTION
We need to do an initial list call before the watch to get a properly formatted list. This was in the watch branch for quite a while but I removed it later as I though it was not needed.

If we don't do the initial list, the output can look like this:

```
PROJECT                NAME                    BUILDNAME      APPLICATION
nine-staging-cyrill    eternal-azazel-qwhlr    go-build-12    go
nine-staging-cyrill    full-komodo-d6w95       go-build-13    go
nine-staging-cyrill    known-quicksilver-6hb9b    go-build-14    go
nine-staging-cyrill    loved-warbound-4kgmq       go-build-11    go
```

This is fixed with this commit:

```
PROJECT                NAME                       BUILDNAME      APPLICATION
nine-staging-cyrill    loved-warbound-4kgmq       go-build-11    go
nine-staging-cyrill    eternal-azazel-qwhlr       go-build-12    go
nine-staging-cyrill    full-komodo-d6w95          go-build-13    go
nine-staging-cyrill    known-quicksilver-6hb9b    go-build-14    go
```

This is because the third element is wider but the tabwriter is spaced out based on the first item if we do a watch without an initial list. Of course if our watch would later result in a new but wider item, the table would be misaligned again but that is unavoidable. As a secondary benefit, the initial list will be correctly sorted.