### PR TITLE
adding flags and new funcions for the sensitive fields

### DIFF
--- a/api/util/apps_test.go
+++ b/api/util/apps_test.go
@@ -25,7 +25,7 @@ func TestEnvUpdate(t *testing.T) {
 	}
 	up := map[string]string{"old2": "val2"}
 	del := []string{"old3"}
-	new := UpdateEnvVars(old, up, del)
+	new := UpdateEnvVars(old, up, nil, del)
 	expected := apps.EnvVars{
 		{
 			Name:  "old1",

--- a/get/project_config_test.go
+++ b/get/project_config_test.go
@@ -68,6 +68,58 @@ func TestProjectConfigs(t *testing.T) {
 			project:            "ns-3",
 			expectExactMessage: ptr.To("no ProjectConfigs found in project ns-3\n"),
 		},
+		"sensitive env var is masked": {
+			get: &Cmd{
+				output: output{
+					Format: full,
+				},
+			},
+			project: "ns-4",
+			createdConfigs: []client.Object{
+				&apps.ProjectConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ns-4",
+						Namespace: "ns-4",
+					},
+					Spec: apps.ProjectConfigSpec{
+						ForProvider: apps.ProjectConfigParameters{
+							Config: apps.Config{
+								Env: util.EnvVarsFromMap(map[string]string{"poo": "orange"}, util.Sensitive()),
+							},
+						},
+					},
+				},
+			},
+			expectExactMessage: ptr.To(
+				"PROJECT    NAME    SIZE    REPLICAS    PORT    ENVIRONMENT_VARIABLES    BASIC_AUTH    DEPLOY_JOB    AGE\nns-4       ns-4                                poo=*****                false         <none>        292y\n",
+			),
+		},
+		"non-sensitive env var is shown": {
+			get: &Cmd{
+				output: output{
+					Format: full,
+				},
+			},
+			project: "ns-5",
+			createdConfigs: []client.Object{
+				&apps.ProjectConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ns-5",
+						Namespace: "ns-5",
+					},
+					Spec: apps.ProjectConfigSpec{
+						ForProvider: apps.ProjectConfigParameters{
+							Config: apps.Config{
+								Env: util.EnvVarsFromMap(map[string]string{"goo": "banana"}),
+							},
+						},
+					},
+				},
+			},
+			expectExactMessage: ptr.To(
+				"PROJECT    NAME    SIZE    REPLICAS    PORT    ENVIRONMENT_VARIABLES    BASIC_AUTH    DEPLOY_JOB    AGE\nns-5       ns-5                                goo=banana               false         <none>        292y\n",
+			),
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
We've added new flags (--sensitive-env and --sensitive-build-env) to the create and update commands. These flags allow users to mark variables as sensitive.

Masking logic were created to redact their values (*****) in the command output.

```
./nctl get configs
PROJECT    NAME    SIZE    REPLICAS    PORT    ENVIRONMENT_VARIABLES    BASIC_AUTH    DEPLOY_JOB    AGE
test             test                                                  env_test=*****           false         <none>        14m
```

Note: We didn't apply masking for YAML or JSON output. This is by design because these formats are used by automation tools etc