### PR TITLE
refactor: simplify command selection without API client

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -10,3 +10,5 @@ type Cmd struct {
 	Whoami           WhoAmICmd           `cmd:"" help:"Show who you are logged in as, your active organization and all your available organizations."`
 	PrintAccessToken PrintAccessTokenCmd `cmd:"" help:"Print short-lived access token to authenticate against the API to stdout and exit."`
 }
+
+const CmdName = "auth"

--- a/auth/login_test.go
+++ b/auth/login_test.go
@@ -8,7 +8,6 @@ import (
 	"path"
 	"testing"
 
-	"github.com/ninech/nctl/api"
 	"github.com/ninech/nctl/internal/test"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/clientcmd"
@@ -46,13 +45,13 @@ func TestLoginCmd(t *testing.T) {
 	os.Setenv(clientcmd.RecommendedConfigPathEnvVar, kubeconfig.Name())
 
 	apiHost := "api.example.org"
-	tk := &fakeTokenGetter{}
 	cmd := &LoginCmd{
 		APIURL:                      "https://" + apiHost,
 		IssuerURL:                   "https://auth.example.org",
 		ForceInteractiveEnvOverride: true,
+		tk:                          &fakeTokenGetter{},
 	}
-	if err := cmd.Run(context.Background(), "", tk); err != nil {
+	if err := cmd.Run(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -76,21 +75,18 @@ func TestLoginStaticToken(t *testing.T) {
 	tests := []struct {
 		name           string
 		cmd            *LoginCmd
-		tk             api.TokenGetter
 		wantToken      string
 		wantErr        bool
 		wantErrMessage string
 	}{
 		{
 			name:      "interactive environment with token",
-			cmd:       &LoginCmd{APIURL: "https://" + apiHost, APIToken: test.FakeJWTToken, Organization: "test", ForceInteractiveEnvOverride: true},
-			tk:        &fakeTokenGetter{},
+			cmd:       &LoginCmd{APIURL: "https://" + apiHost, APIToken: test.FakeJWTToken, Organization: "test", ForceInteractiveEnvOverride: true, tk: &fakeTokenGetter{}},
 			wantToken: test.FakeJWTToken,
 		},
 		{
 			name:      "non-interactive environment with token",
-			cmd:       &LoginCmd{APIURL: "https://" + apiHost, APIToken: test.FakeJWTToken, Organization: "test", ForceInteractiveEnvOverride: false},
-			tk:        &fakeTokenGetter{},
+			cmd:       &LoginCmd{APIURL: "https://" + apiHost, APIToken: test.FakeJWTToken, Organization: "test", ForceInteractiveEnvOverride: false, tk: &fakeTokenGetter{}},
 			wantToken: test.FakeJWTToken,
 		},
 		{
@@ -110,7 +106,7 @@ func TestLoginStaticToken(t *testing.T) {
 			defer os.Remove(kubeconfig.Name())
 			os.Setenv(clientcmd.RecommendedConfigPathEnvVar, kubeconfig.Name())
 
-			err = tt.cmd.Run(context.Background(), "", tt.tk)
+			err = tt.cmd.Run(context.Background())
 			checkErrorRequire(t, err, tt.wantErr, tt.wantErrMessage)
 
 			if tt.wantErr {
@@ -156,9 +152,9 @@ func TestLoginCmdWithoutExistingKubeconfig(t *testing.T) {
 		APIURL:                      "https://" + apiHost,
 		IssuerURL:                   "https://auth.example.org",
 		ForceInteractiveEnvOverride: true,
+		tk:                          &fakeTokenGetter{},
 	}
-	tk := &fakeTokenGetter{}
-	if err := cmd.Run(context.Background(), "", tk); err != nil {
+	if err := cmd.Run(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -2,8 +2,8 @@ package auth
 
 import (
 	"context"
-	"io"
 	"net/url"
+	"os"
 
 	"github.com/ninech/nctl/api"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -15,10 +15,10 @@ type OIDCCmd struct {
 	UsePKCE   bool
 }
 
-const OIDCCmdName = "auth oidc"
+const OIDCCmdName = "oidc"
 
-func (o *OIDCCmd) Run(ctx context.Context, out io.Writer) error {
-	return api.GetToken(ctx, o.IssuerURL, o.ClientID, o.UsePKCE, out)
+func (o *OIDCCmd) Run(ctx context.Context) error {
+	return api.GetToken(ctx, o.IssuerURL, o.ClientID, o.UsePKCE, os.Stdout)
 }
 
 // execConfig returns an *clientcmdapi.ExecConfig that can be used to login to
@@ -28,8 +28,8 @@ func execConfig(command, clientID string, issuerURL *url.URL) *clientcmdapi.Exec
 		APIVersion: "client.authentication.k8s.io/v1beta1",
 		Command:    command,
 		Args: []string{
-			"auth",
-			"oidc",
+			CmdName,
+			OIDCCmdName,
 			api.IssuerURLArg + issuerURL.String(),
 			api.ClientIDArg + clientID,
 			api.UsePKCEArg,

--- a/internal/format/command.go
+++ b/internal/format/command.go
@@ -10,9 +10,8 @@ import (
 )
 
 const (
-	LoginCommand          = "auth login"
-	LogoutCommand         = "auth logout"
-	SetOrgCommand         = "auth set-org"
+	LoginCommand          = "login"
+	LogoutCommand         = "logout"
 	getApplicationCommand = "get application"
 )
 


### PR DESCRIPTION
This simplifies registering commands that don't need an API client.