### PR TITLE
feat: add OrganizationAccess flag to ASA

### DIFF
--- a/create/apiserviceaccount.go
+++ b/create/apiserviceaccount.go
@@ -11,6 +11,7 @@ import (
 
 type apiServiceAccountCmd struct {
 	resourceCmd
+	OrganizationAccess bool `help:"When enabled, this service account has access to all projects in the organization. Only valid for service accounts in the organization project."`
 }
 
 func (asa *apiServiceAccountCmd) Run(ctx context.Context, client *api.Client) error {
@@ -40,6 +41,9 @@ func (asa *apiServiceAccountCmd) newAPIServiceAccount(project string) *iam.APISe
 			Namespace: project,
 		},
 		Spec: iam.APIServiceAccountSpec{
+			ForProvider: iam.APIServiceAccountParameters{
+				OrganizationAccess: asa.OrganizationAccess,
+			},
 			ResourceSpec: runtimev1.ResourceSpec{
 				WriteConnectionSecretToReference: &runtimev1.SecretReference{
 					Name:      name,

--- a/create/apiserviceaccount_test.go
+++ b/create/apiserviceaccount_test.go
@@ -1,36 +1,55 @@
 package create
 
 import (
-	"context"
 	"testing"
-	"time"
 
+	iam "github.com/ninech/apis/iam/v1alpha1"
 	"github.com/ninech/nctl/api"
 	"github.com/ninech/nctl/internal/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestAPIServiceAccount(t *testing.T) {
-	ctx := context.Background()
-	cmd := apiServiceAccountCmd{
-		resourceCmd: resourceCmd{
-			Name:        "test",
-			Wait:        false,
-			WaitTimeout: time.Second,
-		},
-	}
-
-	asa := cmd.newAPIServiceAccount("default")
-	asa.Name = "test"
-
 	apiClient, err := test.SetupClient()
 	require.NoError(t, err)
 
-	if err := cmd.Run(ctx, apiClient); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := apiClient.Get(ctx, api.ObjectName(asa), asa); err != nil {
-		t.Fatalf("expected asa to exist, got: %s", err)
+	for name, tc := range map[string]struct {
+		cmd                    apiServiceAccountCmd
+		checkAPIServiceAccount func(t *testing.T, cmd apiServiceAccountCmd, asa *iam.APIServiceAccount)
+	}{
+		"no org access": {
+			cmd: apiServiceAccountCmd{
+				resourceCmd: resourceCmd{Name: "no-org-access"},
+			},
+			checkAPIServiceAccount: func(t *testing.T, cmd apiServiceAccountCmd, asa *iam.APIServiceAccount) {
+				assert.Equal(t, false, asa.Spec.ForProvider.OrganizationAccess)
+			},
+		},
+		"org access": {
+			cmd: apiServiceAccountCmd{
+				resourceCmd:        resourceCmd{Name: "org-access"},
+				OrganizationAccess: true,
+			},
+			checkAPIServiceAccount: func(t *testing.T, cmd apiServiceAccountCmd, asa *iam.APIServiceAccount) {
+				assert.Equal(t, true, asa.Spec.ForProvider.OrganizationAccess)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := tc.cmd.Run(t.Context(), apiClient); err != nil {
+				t.Fatal(err)
+			}
+			created := &iam.APIServiceAccount{}
+			if err := apiClient.Get(t.Context(), api.NamespacedName(tc.cmd.Name, apiClient.Project), created); err != nil {
+				t.Fatal(err)
+			}
+			if tc.checkAPIServiceAccount != nil {
+				tc.checkAPIServiceAccount(t, tc.cmd, created)
+			}
+		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/moby/moby v28.3.3+incompatible
 	github.com/moby/term v0.5.2
-	github.com/ninech/apis v0.0.0-20250731150359-821fc9ecc6ab
+	github.com/ninech/apis v0.0.0-20250829092213-a169c6254250
 	github.com/posener/complete v1.2.3
 	github.com/prometheus/common v0.65.1-0.20250703115700-7f8b2a0d32d3
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -579,8 +579,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/ninech/apis v0.0.0-20250731150359-821fc9ecc6ab h1:ZviUxA/bVrF0iJgWZvQz8GosKnkbjtG+79SyjmbZVsE=
-github.com/ninech/apis v0.0.0-20250731150359-821fc9ecc6ab/go.mod h1:v9N/4IvFju6G/Qp6BPanKG+V6VYsTFiytZs2hktr3Yk=
+github.com/ninech/apis v0.0.0-20250829092213-a169c6254250 h1:YzzpJpA1rwiVvkSfjeLaXqTw/5xhfSOyC/cWUqWw5Ak=
+github.com/ninech/apis v0.0.0-20250829092213-a169c6254250/go.mod h1:v9N/4IvFju6G/Qp6BPanKG+V6VYsTFiytZs2hktr3Yk=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=

--- a/update/apiserviceaccount.go
+++ b/update/apiserviceaccount.go
@@ -1,0 +1,39 @@
+package update
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	iam "github.com/ninech/apis/iam/v1alpha1"
+	"github.com/ninech/nctl/api"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type apiServiceAccountCmd struct {
+	resourceCmd
+	OrganizationAccess *bool `help:"When enabled, this service account has access to all projects in the organization. Only valid for service accounts in the organization project."`
+}
+
+func (cmd *apiServiceAccountCmd) Run(ctx context.Context, client *api.Client) error {
+	asa := &iam.APIServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmd.Name,
+			Namespace: client.Project,
+		},
+	}
+	return newUpdater(client, asa, iam.APIServiceAccountKind, func(current resource.Managed) error {
+		asa, ok := current.(*iam.APIServiceAccount)
+		if !ok {
+			return fmt.Errorf("resource is of type %T, expected %T", current, iam.APIServiceAccount{})
+		}
+		cmd.applyUpdates(asa)
+		return nil
+	}).Update(ctx)
+}
+
+func (cmd *apiServiceAccountCmd) applyUpdates(asa *iam.APIServiceAccount) {
+	if cmd.OrganizationAccess != nil {
+		asa.Spec.ForProvider.OrganizationAccess = *cmd.OrganizationAccess
+	}
+}

--- a/update/apiserviceaccount_test.go
+++ b/update/apiserviceaccount_test.go
@@ -1,0 +1,67 @@
+package update
+
+import (
+	"testing"
+
+	iam "github.com/ninech/apis/iam/v1alpha1"
+	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/internal/test"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestAPIServiceAccount(t *testing.T) {
+	const (
+		asaName      = "some-asa"
+		organization = "org"
+	)
+
+	for name, tc := range map[string]struct {
+		orig                   *iam.APIServiceAccount
+		cmd                    apiServiceAccountCmd
+		checkAPIServiceAccount func(t *testing.T, cmd apiServiceAccountCmd, orig, updated *iam.APIServiceAccount)
+	}{
+		"all fields update": {
+			orig: &iam.APIServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      asaName,
+					Namespace: organization,
+				},
+				Spec: iam.APIServiceAccountSpec{},
+			},
+			cmd: apiServiceAccountCmd{
+				resourceCmd:        resourceCmd{Name: asaName},
+				OrganizationAccess: ptr.To(true),
+			},
+			checkAPIServiceAccount: func(t *testing.T, cmd apiServiceAccountCmd, orig, updated *iam.APIServiceAccount) {
+				assert.Equal(t, *cmd.OrganizationAccess, updated.Spec.ForProvider.OrganizationAccess)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			apiClient, err := test.SetupClient(
+				test.WithObjects(tc.orig),
+				test.WithOrganization(organization),
+				test.WithDefaultProject(organization),
+				test.WithKubeconfig(t),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := tc.cmd.Run(t.Context(), apiClient); err != nil {
+				t.Fatal(err)
+			}
+
+			updated := &iam.APIServiceAccount{}
+			if err := apiClient.Get(t.Context(), api.ObjectName(tc.orig), updated); err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.checkAPIServiceAccount != nil {
+				tc.checkAPIServiceAccount(t, tc.cmd, tc.orig, updated)
+			}
+		})
+	}
+}

--- a/update/update.go
+++ b/update/update.go
@@ -10,6 +10,7 @@ import (
 
 type Cmd struct {
 	Application         applicationCmd       `cmd:"" group:"deplo.io" name:"application" aliases:"app,application" help:"Update an existing deplo.io Application."`
+	APIServiceAccount   apiServiceAccountCmd `cmd:"" group:"iam.nine.ch" name:"apiserviceaccount" aliases:"asa" help:"Update an API Service Account."`
 	Config              configCmd            `cmd:"" group:"deplo.io" name:"config"  help:"Update an existing deplo.io Project Configuration."`
 	Project             projectCmd           `cmd:"" group:"management.nine.ch" name:"project"  help:"Update an existing Project."`
 	MySQL               mySQLCmd             `cmd:"" group:"storage.nine.ch" name:"mysql" help:"Update an existing MySQL instance."`


### PR DESCRIPTION
This adds a new flag to the APIServiceAccount to enable organization wide access. As this is the first updatable field of an ASA it also adds a new update command.