### PR TITLE
feat: add optional health probe configuration

### DIFF
--- a/api/util/probe.go
+++ b/api/util/probe.go
@@ -1,0 +1,87 @@
+package util
+
+import (
+	apps "github.com/ninech/apis/apps/v1alpha1"
+)
+
+// SetState describes how a field should be applied.
+type SetState int
+
+const (
+	// leave as-is
+	Unset SetState = iota
+	// set to value
+	Set
+	// explicitly remove/unset
+	Clear
+)
+
+// OptString is an "Optional string field" wrapper.
+// It carries both a string value and a state (Unset / Set / Clear).
+type OptString struct {
+	State SetState
+	Val   string
+}
+
+// OptInt32 is an "Optional int32 field" wrapper.
+// It works the same way as OptString, but for numeric fields.
+// Again, this lets us distinguish Unset (no flag) vs Set (positive value)
+// vs Clear (explicitly reset to nil/default).
+type OptInt32 struct {
+	State SetState
+	Val   int32
+}
+
+// ProbePatch is the normalized type used by both create and update paths.
+type ProbePatch struct {
+	Path          OptString
+	PeriodSeconds OptInt32
+}
+
+// Patcher is implemented by command-specific flag structs to produce a ProbePatch.
+type Patcher interface {
+	ToProbePatch() ProbePatch
+}
+
+// ApplyProbePatch mutates cfg.
+func ApplyProbePatch(cfg *apps.Config, pp ProbePatch) {
+	switch pp.Path.State {
+	case Set:
+		ensureProbe(cfg)
+		ensureHTTPGet(cfg)
+		cfg.HealthProbe.HTTPGet.Path = pp.Path.Val
+	case Clear:
+		if cfg.HealthProbe != nil {
+			cfg.HealthProbe.HTTPGet = nil
+		}
+	}
+
+	switch pp.PeriodSeconds.State {
+	case Set:
+		ensureProbe(cfg)
+		v := pp.PeriodSeconds.Val
+		cfg.HealthProbe.PeriodSeconds = &v
+	case Clear:
+		if cfg.HealthProbe != nil {
+			cfg.HealthProbe.PeriodSeconds = nil
+		}
+	}
+
+	if cfg.HealthProbe != nil &&
+		cfg.HealthProbe.HTTPGet == nil &&
+		cfg.HealthProbe.PeriodSeconds == nil {
+		cfg.HealthProbe = nil
+	}
+}
+
+func ensureProbe(cfg *apps.Config) {
+	if cfg.HealthProbe == nil {
+		cfg.HealthProbe = &apps.Probe{}
+	}
+}
+
+func ensureHTTPGet(cfg *apps.Config) {
+	if cfg.HealthProbe.HTTPGet == nil {
+		cfg.HealthProbe.HTTPGet = &apps.HTTPGetAction{}
+	}
+}

--- a/api/util/probe_test.go
+++ b/api/util/probe_test.go
@@ -1,0 +1,160 @@
+package util
+
+import (
+	"testing"
+
+	apps "github.com/ninech/apis/apps/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+)
+
+func TestApplyProbePatch(t *testing.T) {
+	setPath := func(s string) OptString {
+		return OptString{State: Set, Val: s}
+	}
+	clearPath := func() OptString {
+		return OptString{State: Clear}
+	}
+	unsetPath := func() OptString {
+		return OptString{State: Unset}
+	}
+	setPer := func(n int32) OptInt32 {
+		return OptInt32{State: Set, Val: n}
+	}
+	clearPer := func() OptInt32 {
+		return OptInt32{State: Clear}
+	}
+	unsetPer := func() OptInt32 {
+		return OptInt32{State: Unset}
+	}
+
+	tests := []struct {
+		name string
+		cfg  apps.Config
+		pp   ProbePatch
+		want func(t *testing.T, got *apps.Config)
+	}{
+		{
+			name: "no-op when everything Unset and cfg nil",
+			cfg:  apps.Config{},
+			pp:   ProbePatch{Path: unsetPath(), PeriodSeconds: unsetPer()},
+			want: func(t *testing.T, got *apps.Config) {
+				assert.Nil(t, got.HealthProbe)
+			},
+		},
+		{
+			name: "set Path creates probe+httpget and assigns path",
+			cfg:  apps.Config{},
+			pp:   ProbePatch{Path: setPath("/healthz"), PeriodSeconds: unsetPer()},
+			want: func(t *testing.T, got *apps.Config) {
+				if assert.NotNil(t, got.HealthProbe) && assert.NotNil(t, got.HealthProbe.HTTPGet) {
+					assert.Equal(t, "/healthz", got.HealthProbe.HTTPGet.Path)
+				}
+				assert.Nil(t, got.HealthProbe.PeriodSeconds)
+			},
+		},
+		{
+			name: "set PeriodSeconds creates probe and sets value (owns memory)",
+			cfg:  apps.Config{},
+			pp:   ProbePatch{Path: unsetPath(), PeriodSeconds: setPer(7)},
+			want: func(t *testing.T, got *apps.Config) {
+				if assert.NotNil(t, got.HealthProbe) {
+					if assert.NotNil(t, got.HealthProbe.PeriodSeconds) {
+						assert.Equal(t, int32(7), *got.HealthProbe.PeriodSeconds)
+					}
+					assert.Nil(t, got.HealthProbe.HTTPGet)
+				}
+			},
+		},
+		{
+			name: "set both fields on existing probe updates both",
+			cfg: apps.Config{
+				HealthProbe: &apps.Probe{
+					ProbeHandler: apps.ProbeHandler{
+						HTTPGet: &apps.HTTPGetAction{Path: "/old"},
+					},
+					PeriodSeconds: ptr.To(int32(3)),
+				},
+			},
+			pp: ProbePatch{Path: setPath("/new"), PeriodSeconds: setPer(9)},
+			want: func(t *testing.T, got *apps.Config) {
+				if assert.NotNil(t, got.HealthProbe) && assert.NotNil(t, got.HealthProbe.HTTPGet) {
+					assert.Equal(t, "/new", got.HealthProbe.HTTPGet.Path)
+				}
+				if assert.NotNil(t, got.HealthProbe.PeriodSeconds) {
+					assert.Equal(t, int32(9), *got.HealthProbe.PeriodSeconds)
+				}
+			},
+		},
+		{
+			name: "clear Path removes HTTPGet but keeps probe if other fields remain",
+			cfg: apps.Config{
+				HealthProbe: &apps.Probe{
+					ProbeHandler: apps.ProbeHandler{
+						HTTPGet: &apps.HTTPGetAction{Path: "/keep-me?no"},
+					},
+					PeriodSeconds: ptr.To(int32(5)),
+				},
+			},
+			pp: ProbePatch{Path: clearPath(), PeriodSeconds: unsetPer()},
+			want: func(t *testing.T, got *apps.Config) {
+				if assert.NotNil(t, got.HealthProbe) {
+					assert.Nil(t, got.HealthProbe.HTTPGet)
+					if assert.NotNil(t, got.HealthProbe.PeriodSeconds) {
+						assert.Equal(t, int32(5), *got.HealthProbe.PeriodSeconds)
+					}
+				}
+			},
+		},
+		{
+			name: "clear PeriodSeconds sets it to nil but preserves HTTPGet",
+			cfg: apps.Config{
+				HealthProbe: &apps.Probe{
+					ProbeHandler: apps.ProbeHandler{
+						HTTPGet: &apps.HTTPGetAction{Path: "/ok"},
+					},
+					PeriodSeconds: ptr.To(int32(11)),
+				},
+			},
+			pp: ProbePatch{Path: unsetPath(), PeriodSeconds: clearPer()},
+			want: func(t *testing.T, got *apps.Config) {
+				if assert.NotNil(t, got.HealthProbe) {
+					assert.NotNil(t, got.HealthProbe.HTTPGet)
+					assert.Equal(t, "/ok", got.HealthProbe.HTTPGet.Path)
+					assert.Nil(t, got.HealthProbe.PeriodSeconds)
+				}
+			},
+		},
+		{
+			name: "clearing last fields removes the whole HealthProbe",
+			cfg: apps.Config{
+				HealthProbe: &apps.Probe{
+					ProbeHandler:  apps.ProbeHandler{HTTPGet: &apps.HTTPGetAction{Path: "/gone"}},
+					PeriodSeconds: nil,
+				},
+			},
+			pp: ProbePatch{Path: clearPath(), PeriodSeconds: unsetPer()},
+			want: func(t *testing.T, got *apps.Config) {
+				assert.Nil(t, got.HealthProbe)
+			},
+		},
+		{
+			name: "unset fields do not create or modify probe",
+			cfg: apps.Config{
+				HealthProbe: nil,
+			},
+			pp: ProbePatch{Path: unsetPath(), PeriodSeconds: unsetPer()},
+			want: func(t *testing.T, got *apps.Config) {
+				assert.Nil(t, got.HealthProbe)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.cfg
+			ApplyProbePatch(&cfg, tt.pp)
+			tt.want(t, &cfg)
+		})
+	}
+}

--- a/create/application.go
+++ b/create/application.go
@@ -38,6 +38,7 @@ type applicationCmd struct {
 	Git                      gitConfig         `embed:"" prefix:"git-"`
 	Size                     *string           `help:"Size of the application (defaults to \"${app_default_size}\")." placeholder:"${app_default_size}"`
 	Port                     *int32            `help:"Port the application is listening on (defaults to ${app_default_port})." placeholder:"${app_default_port}"`
+	HealthProbe              healthProbe       `embed:"" prefix:"health-probe-"`
 	Replicas                 *int32            `help:"Amount of replicas of the running application (defaults to ${app_default_replicas})." placeholder:"${app_default_replicas}"`
 	Hosts                    []string          `help:"Host names where the application can be accessed. If empty, the application will just be accessible on a generated host name on the deploio.app domain."`
 	BasicAuth                *bool             `help:"Enable/Disable basic authentication for the application (defaults to ${app_default_basic_auth})." placeholder:"${app_default_basic_auth}"`
@@ -63,6 +64,11 @@ type gitConfig struct {
 	Password              *string `help:"Password to use when authenticating to the git repository over HTTPS. In case of GitHub or GitLab, this can also be an access token." env:"GIT_PASSWORD"`
 	SSHPrivateKey         *string `help:"Private key in PEM format to connect to the git repository via SSH." env:"GIT_SSH_PRIVATE_KEY" xor:"SSH_KEY"`
 	SSHPrivateKeyFromFile *string `help:"Path to a file containing a private key in PEM format to connect to the git repository via SSH." env:"GIT_SSH_PRIVATE_KEY_FROM_FILE" xor:"SSH_KEY" predictor:"file"`
+}
+
+type healthProbe struct {
+	PeriodSeconds int32  `placeholder:"${app_default_health_probe_period_seconds}" help:"How often (in seconds) to perform the custom health probe. Default is ${app_default_health_probe_period_seconds}, minimum 1." default:"${app_default_health_probe_period_seconds}"`
+	Path          string `help:"URL path on the application's HTTP server used for the custom health probe. The platform performs an HTTP GET on this path to determine health."`
 }
 
 type deployJob struct {
@@ -343,7 +349,26 @@ func (app *applicationCmd) config() apps.Config {
 	if app.Replicas != nil {
 		config.Replicas = app.Replicas
 	}
+
+	app.HealthProbe.applyCreate(&config)
+
 	return config
+}
+
+func (h healthProbe) ToProbePatch() util.ProbePatch {
+	var pp util.ProbePatch
+
+	if p := strings.TrimSpace(h.Path); p != "" {
+		pp.Path = util.OptString{State: util.Set, Val: p}
+	}
+	if h.PeriodSeconds > 0 {
+		pp.PeriodSeconds = util.OptInt32{State: util.Set, Val: h.PeriodSeconds}
+	}
+	return pp
+}
+
+func (h healthProbe) applyCreate(cfg *apps.Config) {
+	util.ApplyProbePatch(cfg, h.ToProbePatch())
 }
 
 func (app *applicationCmd) newApplication(project string) *apps.Application {
@@ -659,6 +684,8 @@ func ApplicationKongVars() (kong.Vars, error) {
 		return nil, errors.New("no default application basic authentication settings found")
 	}
 	result["app_default_basic_auth"] = strconv.FormatBool(*apps.DefaultConfig.EnableBasicAuth)
+
+	result["app_default_health_probe_period_seconds"] = "10"
 
 	result["app_default_deploy_job_timeout"] = "5m"
 	result["app_default_deploy_job_retries"] = "3"

--- a/create/application_test.go
+++ b/create/application_test.go
@@ -88,6 +88,7 @@ func TestApplication(t *testing.T) {
 				Size:                ptr.To("mini"),
 				Hosts:               []string{"custom.example.org", "custom2.example.org"},
 				Port:                ptr.To(int32(1337)),
+				HealthProbe:         healthProbe{PeriodSeconds: int32(7), Path: "/he"},
 				Replicas:            ptr.To(int32(42)),
 				BasicAuth:           ptr.To(false),
 				Env:                 map[string]string{"hello": "world"},
@@ -103,6 +104,8 @@ func TestApplication(t *testing.T) {
 				assert.Equal(t, cmd.Hosts, app.Spec.ForProvider.Hosts)
 				assert.Equal(t, apps.ApplicationSize(*cmd.Size), app.Spec.ForProvider.Config.Size)
 				assert.Equal(t, *cmd.Port, *app.Spec.ForProvider.Config.Port)
+				assert.Equal(t, cmd.HealthProbe.PeriodSeconds, *app.Spec.ForProvider.Config.HealthProbe.PeriodSeconds)
+				assert.Equal(t, cmd.HealthProbe.Path, app.Spec.ForProvider.Config.HealthProbe.HTTPGet.Path)
 				assert.Equal(t, *cmd.Replicas, *app.Spec.ForProvider.Config.Replicas)
 				assert.Equal(t, *cmd.BasicAuth, *app.Spec.ForProvider.Config.EnableBasicAuth)
 				assert.Equal(t, util.EnvVarsFromMap(cmd.Env), app.Spec.ForProvider.Config.Env)

--- a/update/application.go
+++ b/update/application.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -30,6 +31,8 @@ type applicationCmd struct {
 	Git                     *gitConfig        `embed:"" prefix:"git-"`
 	Size                    *string           `help:"Size of the app."`
 	Port                    *int32            `help:"Port the app is listening on."`
+	HealthProbe             *healthProbe      `embed:"" prefix:"health-probe-"`
+	DeleteHealthProbe       *bool             `help:"Delete existing custom health probe."`
 	Replicas                *int32            `help:"Amount of replicas of the running app."`
 	Hosts                   *[]string         `help:"Host names where the application can be accessed. If empty, the application will just be accessible on a generated host name on the deploio.app domain."`
 	BasicAuth               *bool             `help:"Enable/Disable basic authentication for the application."`
@@ -90,6 +93,11 @@ func (g gitConfig) empty() bool {
 		g.Revision == nil && g.Username == nil &&
 		g.Password == nil && g.SSHPrivateKey == nil &&
 		g.SSHPrivateKeyFromFile == nil
+}
+
+type healthProbe struct {
+	PeriodSeconds *int32  `help:"How often (in seconds) to perform the custom health probe."`
+	Path          *string `help:"URL path on the application's HTTP server used for the custom health probe. The platform performs an HTTP GET on this path to determine health."`
 }
 
 type deployJob struct {
@@ -236,6 +244,12 @@ func (cmd *applicationCmd) applyUpdates(app *apps.Application) {
 	if cmd.Port != nil {
 		app.Spec.ForProvider.Config.Port = cmd.Port
 	}
+	if cmd.HealthProbe != nil {
+		cmd.HealthProbe.applyUpdates(&app.Spec.ForProvider.Config)
+	}
+	if cmd.DeleteHealthProbe != nil {
+		app.Spec.ForProvider.Config.HealthProbe = nil
+	}
 	if cmd.Replicas != nil {
 		app.Spec.ForProvider.Config.Replicas = cmd.Replicas
 	}
@@ -331,6 +345,30 @@ func (cmd *applicationCmd) applyUpdates(app *apps.Application) {
 
 func triggerTimestamp() string {
 	return time.Now().UTC().Format(time.RFC3339)
+}
+
+func (h healthProbe) ToProbePatch() util.ProbePatch {
+	var pp util.ProbePatch
+
+	if h.Path != nil {
+		if p := strings.TrimSpace(*h.Path); p == "" {
+			pp.Path = util.OptString{State: util.Clear}
+		} else {
+			pp.Path = util.OptString{State: util.Set, Val: p}
+		}
+	}
+	if h.PeriodSeconds != nil {
+		if ps := *h.PeriodSeconds; ps <= 0 {
+			pp.PeriodSeconds = util.OptInt32{State: util.Clear}
+		} else {
+			pp.PeriodSeconds = util.OptInt32{State: util.Set, Val: ps}
+		}
+	}
+	return pp
+}
+
+func (h healthProbe) applyUpdates(cfg *apps.Config) {
+	util.ApplyProbePatch(cfg, h.ToProbePatch())
 }
 
 func (job deployJob) applyUpdates(cfg *apps.Config) {

--- a/update/application_test.go
+++ b/update/application_test.go
@@ -116,6 +116,7 @@ func TestApplication(t *testing.T) {
 				},
 				Size:         ptr.To("newsize"),
 				Port:         ptr.To(int32(1234)),
+				HealthProbe:  &healthProbe{PeriodSeconds: ptr.To(int32(7)), Path: ptr.To("/he")},
 				Replicas:     ptr.To(int32(999)),
 				Hosts:        &[]string{"one.example.org", "two.example.org"},
 				Env:          map[string]string{"bar": "zoo"},
@@ -134,6 +135,8 @@ func TestApplication(t *testing.T) {
 				assert.Equal(t, *cmd.Git.Revision, updated.Spec.ForProvider.Git.Revision)
 				assert.Equal(t, apps.ApplicationSize(*cmd.Size), updated.Spec.ForProvider.Config.Size)
 				assert.Equal(t, *cmd.Port, *updated.Spec.ForProvider.Config.Port)
+				assert.Equal(t, cmd.HealthProbe.PeriodSeconds, updated.Spec.ForProvider.Config.HealthProbe.PeriodSeconds)
+				assert.Equal(t, *cmd.HealthProbe.Path, updated.Spec.ForProvider.Config.HealthProbe.HTTPGet.Path)
 				assert.Equal(t, *cmd.Replicas, *updated.Spec.ForProvider.Config.Replicas)
 				assert.Equal(t, *cmd.BasicAuth, *updated.Spec.ForProvider.Config.EnableBasicAuth)
 				assert.Equal(t, *cmd.Hosts, updated.Spec.ForProvider.Hosts)
@@ -153,6 +156,29 @@ func TestApplication(t *testing.T) {
 				// Retry Release/Build should be not set by default:
 				assert.Nil(t, util.EnvVarByName(updated.Spec.ForProvider.Config.Env, ReleaseTrigger))
 				assert.Nil(t, util.EnvVarByName(updated.Spec.ForProvider.BuildEnv, BuildTrigger))
+			},
+		},
+		"reset custom health probe": {
+			orig: func() *apps.Application {
+				a := existingApp
+				a.Spec.ForProvider.Config.HealthProbe = &apps.Probe{
+					ProbeHandler: apps.ProbeHandler{
+						HTTPGet: &apps.HTTPGetAction{
+							Path: "/healthz",
+						},
+					},
+					PeriodSeconds: ptr.To(int32(9)),
+				}
+				return a
+			}(),
+			cmd: applicationCmd{
+				resourceCmd: resourceCmd{
+					Name: existingApp.Name,
+				},
+				DeleteHealthProbe: ptr.To(true),
+			},
+			checkApp: func(t *testing.T, cmd applicationCmd, orig, updated *apps.Application) {
+				assert.Empty(t, updated.Spec.ForProvider.Config.HealthProbe)
 			},
 		},
 		"reset env variable": {


### PR DESCRIPTION
This change adds support for configuring a health probe in Deploio app. Users can now optionally define a custom health check endpoint for their applications. If no health probe is provided, the platform continues to use its default health check behavior.