### PR TITLE
refactor: replace ObjectsBucket usage with Bucket

### DIFF
--- a/get/opensearch.go
+++ b/get/opensearch.go
@@ -123,12 +123,12 @@ func (cmd *openSearchCmd) printSnapshotBucket(ctx context.Context, client *api.C
 		return fmt.Errorf("no snapshot bucket configured for OpenSearch instance %s", openSearch.Name)
 	}
 
-	bucket := &storage.ObjectsBucket{}
+	bucket := &storage.Bucket{}
 	if err := client.Get(ctx, types.NamespacedName{Name: bucketName, Namespace: client.Project}, bucket); err != nil {
 		return err
 	}
 
-	bucketURL := bucket.Status.AtProvider.URL
+	bucketURL := bucket.Status.AtProvider.PublicURL
 	if bucketURL == "" {
 		return fmt.Errorf("no URL found in ObjectsBucket %s status", bucketName)
 	}

--- a/get/opensearch_test.go
+++ b/get/opensearch_test.go
@@ -203,23 +203,23 @@ func TestOpenSearch(t *testing.T) {
 					created.Status.AtProvider.SnapshotsBucket = meta.LocalReference{Name: instance.snapshotBucket}
 
 					// Add the ObjectsBucket resource to the fake client
-					objectsBucket := &storage.ObjectsBucket{
+					bucket := &storage.Bucket{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      instance.snapshotBucket,
 							Namespace: instance.project,
 						},
-						Spec: storage.ObjectsBucketSpec{
-							ForProvider: storage.ObjectsBucketParameters{
+						Spec: storage.BucketSpec{
+							ForProvider: storage.BucketParameters{
 								Location: meta.LocationNineCZ42,
 							},
 						},
-						Status: storage.ObjectsBucketStatus{
-							AtProvider: storage.ObjectsBucketObservation{
-								URL: strings.TrimSpace(fmt.Sprintf("https://%s.objects.nineapis.ch/%s", meta.LocationNineES34, instance.snapshotBucket)),
+						Status: storage.BucketStatus{
+							AtProvider: storage.BucketObservation{
+								PublicURL: strings.TrimSpace(fmt.Sprintf("https://%s.objects.nineapis.ch/%s", meta.LocationNineES34, instance.snapshotBucket)),
 							},
 						},
 					}
-					objects = append(objects, objectsBucket)
+					objects = append(objects, bucket)
 				}
 
 				objects = append(objects, created, &corev1.Secret{


### PR DESCRIPTION
Remove unnecessary usage of ObjectsBucket types in the OpenSearch-related logic and tests. These references were only used in a few test scenarios and do not provide any benefit over the standard Bucket type.