### PR TITLE
fix: cron placeholder

### DIFF
--- a/create/application.go
+++ b/create/application.go
@@ -91,7 +91,7 @@ type scheduledJob struct {
 	Command  string        `help:"Command to execute to start the scheduled job." placeholder:"\"bundle exec rails runner\""`
 	Name     string        `help:"Name of the scheduled job job to add." placeholder:"scheduled-1"`
 	Size     *string       `help:"Size (resources) of the scheduled job (defaults to \"${app_default_size}\")." placeholder:"${app_default_size}"`
-	Schedule string        `help:"Cron notation string for the scheduled job (defaults to \"* * * * *\")." placeholder:"* * * * *"`
+	Schedule string        `help:"Cron notation string for the scheduled job (defaults to \"* * * * *\")." placeholder:"\"* * * * *\""`
 	Retries  int32         `default:"${app_default_scheduled_job_retries}" help:"How many times the job will be restarted on failure. Default is ${app_default_scheduled_job_retries} and maximum 5."`
 	Timeout  time.Duration `default:"${app_default_scheduled_job_timeout}" help:"Timeout of the job. Default is ${app_default_scheduled_job_timeout}, minimum is 1 minute and maximum is 30 minutes."`
 }

--- a/update/application.go
+++ b/update/application.go
@@ -124,7 +124,7 @@ type scheduledJob struct {
 	Command  *string        `help:"Command to execute to start the scheduled job." placeholder:"\"bundle exec rails runner\""`
 	Name     *string        `help:"Name of the scheduled job job to add." placeholder:"scheduled-1"`
 	Size     *string        `help:"Size (resources) of the scheduled job (defaults to \"${app_default_size}\")." placeholder:"${app_default_size}"`
-	Schedule *string        `help:"Cron notation string for the scheduled job (defaults to \"* * * * *\")." placeholder:"* * * * *"`
+	Schedule *string        `help:"Cron notation string for the scheduled job (defaults to \"* * * * *\")." placeholder:"\"* * * * *\""`
 	Retries  *int32         `help:"How many times the job will be restarted on failure." placeholder:"${app_default_scheduled_job_retries}"`
 	Timeout  *time.Duration `help:"Timeout of the job." placeholder:"${app_default_scheduled_job_timeout}"`
 }


### PR DESCRIPTION
```shell
$ nctl create application
```

```diff
Usage: nctl create application (app,application) --git-url=STRING [<name>] [flags]

Create a new deplo.io Application.

Arguments:
  [<name>]    Name of the new resource. A random name is generated if omitted.

Flags:
  -h, --help                       Show context-sensitive help.
  -p, --project=STRING             Limit commands to a specific project.
      --verbose                    Show verbose messages.
      --version                    Print version information and quit.

  -f, --filename=FILENAME          Create any resource from a yaml or json file.

      --wait                       Wait until resource is fully created.
      --wait-timeout=30m           Duration to wait for resource getting ready.
                                   Only relevant if wait is set.
      --git-url=STRING             URL to the Git repository containing the
                                   application source. Both HTTPS and SSH
                                   formats are supported.
      --git-sub-path=STRING        SubPath is a path in the git repository which
                                   contains the application code. If not given,
                                   the root directory of the git repository will
                                   be used.
      --git-revision="main"        Revision defines the revision of the source
                                   to deploy the application to. This can be a
                                   commit, tag or branch.
      --git-username=GIT-USERNAME
                                   Username to use when authenticating to the
                                   git repository over HTTPS ($GIT_USERNAME).
      --git-password=GIT-PASSWORD
                                   Password to use when authenticating to the
                                   git repository over HTTPS. In case of GitHub
                                   or GitLab, this can also be an access token
                                   ($GIT_PASSWORD).
      --git-ssh-private-key=GIT-SSH-PRIVATE-KEY
                                   Private key in PEM format to connect
                                   to the git repository via SSH
                                   ($GIT_SSH_PRIVATE_KEY).
      --git-ssh-private-key-from-file=GIT-SSH-PRIVATE-KEY-FROM-FILE
                                   Path to a file containing a private key in
                                   PEM format to connect to the git repository
                                   via SSH ($GIT_SSH_PRIVATE_KEY_FROM_FILE).
      --size=micro                 Size of the application (defaults to
                                   "micro").
      --port=8080                  Port the application is listening on
                                   (defaults to 8080).
      --health-probe-period-seconds=10
                                   How often (in seconds) to perform the custom
                                   health probe. Minimum is 1.
      --health-probe-path=STRING
                                   URL path on the application's HTTP server
                                   used for the custom health probe. The
                                   platform performs an HTTP GET on this path
                                   to determine health. The app should return
                                   a non-success status during startup and
                                   once healthy, return a success HTTP status.
                                   Any code 200-399 indicates success; any other
                                   code indicates failure.
      --replicas=1                 Amount of replicas of the running application
                                   (defaults to 1).
      --hosts=HOSTS,...            Host names where the application can be
                                   accessed. If empty, the application will just
                                   be accessible on a generated host name on the
                                   deploio.app domain.
      --basic-auth                 Enable/Disable basic authentication for the
                                   application (defaults to false).
      --env=KEY=VALUE;...          Environment variables which are passed to the
                                   application at runtime.
      --sensitive-env=KEY=VALUE;...
                                   Sensitive environment variables which are
                                   passed to the application at runtime.
      --build-env=KEY=VALUE;...    Environment variables which are passed to the
                                   application build process.
      --sensitive-build-env=KEY=VALUE;...
                                   Sensitive environment variables which are
                                   passed to the application build process.
      --deploy-job-command="rake db:prepare"
                                   Command to execute before a new release gets
                                   deployed. No deploy job will be executed if
                                   this is not specified.
      --deploy-job-name="release"
                                   Name of the deploy job. The deployment
                                   will only continue if the job finished
                                   successfully.
      --deploy-job-retries=3       How many times the job will be restarted on
                                   failure. Default is 3 and maximum 5.
      --deploy-job-timeout=5m      Timeout of the job. Default is 5m, minimum is
                                   1 minute and maximum is 30 minutes.
      --worker-job-command="bundle exec sidekiq"
                                   Command to execute to start the worker job.
      --worker-job-name=worker-1
                                   Name of the worker job to add.
      --worker-job-size=micro      Size of the worker job (defaults to "micro").
      --scheduled-job-command="bundle exec rails runner"
                                   Command to execute to start the scheduled
                                   job.
      --scheduled-job-name=scheduled-1
                                   Name of the scheduled job job to add.
      --scheduled-job-size=micro
                                   Size (resources) of the scheduled job
                                   (defaults to "micro").
-      --scheduled-job-schedule=* * * * *
+      --scheduled-job-schedule="* * * * *"
                                   Cron notation string for the scheduled job
                                   (defaults to "* * * * *").
      --scheduled-job-retries=0    How many times the job will be restarted on
                                   failure. Default is 0 and maximum 5.
      --scheduled-job-timeout=5m
                                   Timeout of the job. Default is 5m, minimum is
                                   1 minute and maximum is 30 minutes.
      --skip-repo-access-check     Skip the git repository access check.
      --debug                      Enable debug messages.
      --language=""                Language specifies which language your app
                                   is. If left empty, deploio will detect the
                                   language automatically. Possible values:
                                   ruby,php,python,golang,nodejs,static,
      --dockerfile                 Enable Dockerfile build (Beta) instead of the
                                   automatic buildpack detection.
      --dockerfile-path=""         Specifies the path to the Dockerfile.
                                   If left empty a file named Dockerfile will
                                   be searched in the application code root
                                   directory..
      --dockerfile-build-context=""
                                   Defines the build context. If left empty,
                                   the application code root directory will be
                                   used as build context..
      --buildpack-stack=""         BuildpackStack sets the stack of buildpacks
                                   to use for building the application. If left
                                   empty, the default stack (paketo) will be
                                   used. Possible values: paketo,heroku,
```

---


```shell
$ nctl update application
```

```diff
Usage: nctl update application (app,application) <name> [flags]

Update an existing deplo.io Application.

Arguments:
  <name>    Name of the resource to update.

Flags:
  -h, --help                       Show context-sensitive help.
  -p, --project=STRING             Limit commands to a specific project.
      --verbose                    Show verbose messages.
      --version                    Print version information and quit.

      --git-url=GIT-URL            URL to the Git repository containing the
                                   application source. Both HTTPS and SSH
                                   formats are supported.
      --git-sub-path=GIT-SUB-PATH
                                   SubPath is a path in the git repo which
                                   contains the application code. If not given,
                                   the root directory of the git repo will be
                                   used.
      --git-revision=GIT-REVISION
                                   Revision defines the revision of the source
                                   to deploy the application to. This can be a
                                   commit, tag or branch.
      --git-username=GIT-USERNAME
                                   Username to use when authenticating to the
                                   git repository over HTTPS ($GIT_USERNAME).
      --git-password=GIT-PASSWORD
                                   Password to use when authenticating to the
                                   git repository over HTTPS. In case of GitHub
                                   or GitLab, this can also be an access token
                                   ($GIT_PASSWORD).
      --git-ssh-private-key=GIT-SSH-PRIVATE-KEY
                                   Private key in x509 format to
                                   connect to the git repository via SSH
                                   ($GIT_SSH_PRIVATE_KEY).
      --git-ssh-private-key-from-file=GIT-SSH-PRIVATE-KEY-FROM-FILE
                                   Path to a file containing a private key in
                                   PEM format to connect to the git repository
                                   via SSH ($GIT_SSH_PRIVATE_KEY_FROM_FILE).
      --size=SIZE                  Size of the app.
      --port=PORT                  Port the app is listening on.
      --health-probe-period-seconds=HEALTH-PROBE-PERIOD-SECONDS
                                   How often (in seconds) to perform the custom
                                   health probe.
      --health-probe-path=HEALTH-PROBE-PATH
                                   URL path on the application's HTTP server
                                   used for the custom health probe. The
                                   platform performs an HTTP GET on this path to
                                   determine health.
      --delete-health-probe        Delete existing custom health probe.
      --replicas=REPLICAS          Amount of replicas of the running app.
      --hosts=HOSTS                Host names where the application can be
                                   accessed. If empty, the application will just
                                   be accessible on a generated host name on the
                                   deploio.app domain.
      --basic-auth                 Enable/Disable basic authentication for the
                                   application.
      --change-basic-auth-password
                                   Generate a new basic auth password.
      --env=KEY=VALUE;...          Environment variables which are passed to the
                                   app at runtime.
      --sensitive-env=KEY=VALUE;...
                                   Sensitive environment variables which are
                                   passed to the app at runtime.
      --delete-env=DELETE-ENV      Runtime environment variables names which are
                                   to be deleted.
      --build-env=KEY=VALUE;...    Environment variables names which are passed
                                   to the app build process.
      --sensitive-build-env=KEY=VALUE;...
                                   Sensitive environment variables names which
                                   are passed to the app build process.
      --delete-build-env=DELETE-BUILD-ENV
                                   Build environment variables which are to be
                                   deleted.
      --deploy-job-enabled         Disables the deploy job if set to false.
      --deploy-job-command="rake db:prepare"
                                   Command to execute before a new release gets
                                   deployed. No deploy job will be executed if
                                   this is not specified.
      --deploy-job-name=release    Name of the deploy job. The deployment
                                   will only continue if the job finished
                                   successfully.
      --deploy-job-retries=3       How many times the job will be restarted on
                                   failure.
      --deploy-job-timeout=5m      Timeout of the job.
      --worker-job-name=worker-1
                                   Name of the worker job to add.
      --worker-job-command="bundle exec sidekiq"
                                   Command to execute to start the worker.
      --worker-job-size=micro      Size of the worker (defaults to "micro").
      --scheduled-job-command="bundle exec rails runner"
                                   Command to execute to start the scheduled
                                   job.
      --scheduled-job-name=scheduled-1
                                   Name of the scheduled job job to add.
      --scheduled-job-size=micro
                                   Size (resources) of the scheduled job
                                   (defaults to "micro").
-     --scheduled-job-schedule=* * * * *
+     --scheduled-job-schedule="* * * * *"
                                   Cron notation string for the scheduled job
                                   (defaults to "* * * * *").
      --scheduled-job-retries=0    How many times the job will be restarted on
                                   failure.
      --scheduled-job-timeout=5m
                                   Timeout of the job.
      --delete-worker-job=DELETE-WORKER-JOB
                                   Delete a worker job by name.
      --delete-scheduled-job=DELETE-SCHEDULED-JOB
                                   Delete a scheduled job by name.
      --retry-release              Retries release for the application.
      --retry-build                Retries build for the application if set to
                                   true.
      --pause                      Pauses the application if set to true.
                                   Stops all costs.
      --skip-repo-access-check     Skip the git repository access check.
      --debug                      Enable debug messages.
      --language=LANGUAGE          Language specifies which language your app
                                   is. If left empty, deploio will detect the
                                   language automatically. Possible values:
                                   ruby,php,python,golang,nodejs,static,
      --dockerfile-path=.          Specifies the path to the Dockerfile.
                                   If left empty a file named Dockerfile will
                                   be searched in the application code root
                                   directory.
      --dockerfile-build-context=.
                                   Defines the build context. If left empty,
                                   the application code root directory will be
                                   used as build context.
      --buildpack-stack=BUILDPACK-STACK
                                   BuildpackStack sets the stack of buildpacks
                                   to use for building the application. If left
                                   empty, the default stack (paketo) will be
                                   used. Possible values: paketo,heroku,

💡 Your command: "nctl update application": expected "<name>"
```