### PR TITLE
fix: skip authentication for non-interactive commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"os/signal"
 	"reflect"
 	"runtime/debug"
-	"slices"
 	"strings"
 	"syscall"
 
@@ -142,10 +141,9 @@ func main() {
 		kong.BindTo(reader, (*io.Reader)(nil)),
 	)
 
-	apiClientRequired := !noAPIClientRequired(strings.Join(os.Args[1:], " "))
 	predictors := append([]completion.Option{
 		completion.WithPredictor("file", complete.PredictFiles("*")),
-	}, clientPredictors(ctx, apiClientRequired)...)
+	}, clientPredictors(ctx)...)
 	completion.Register(parser, predictors...)
 
 	kongCtx, err := parser.Parse(os.Args[1:])
@@ -173,7 +171,9 @@ func main() {
 		kong.BindTo(writer, (*io.Writer)(nil)),
 		kong.BindTo(reader, (*io.Reader)(nil)),
 	}
-	if apiClientRequired {
+	// Kong exits during Parse for --help and --version, so those cases
+	// never reach here. Only auth and completions commands remain.
+	if !noAPIClientRequired(kongCtx.Command()) {
 		client, err := api.New(
 			ctx,
 			cmd.APICluster,
@@ -218,7 +218,7 @@ func main() {
 	}
 }
 
-func clientPredictors(ctx context.Context, apiClientRequired bool) []completion.Option {
+func clientPredictors(ctx context.Context) []completion.Option {
 	// complete needs all used predictors to be defined, so we just use
 	// [complete.PredictNothing] for those that would require an API client.
 	nothing := []completion.Option{
@@ -228,7 +228,10 @@ func clientPredictors(ctx context.Context, apiClientRequired bool) []completion.
 		completion.WithPredictor("mysql_databases", complete.PredictNothing),
 	}
 
-	if !apiClientRequired || os.Getenv("COMP_LINE") == "" {
+	// During completion for commands that don't need an API client (auth,
+	// completions), this still attempts a kubeconfig read. The cost is
+	// negligible and the predictors are never invoked for those commands.
+	if os.Getenv("COMP_LINE") == "" {
 		return nothing
 	}
 
@@ -248,25 +251,14 @@ func clientPredictors(ctx context.Context, apiClientRequired bool) []completion.
 }
 
 // noAPIClientRequired returns true if the command does not need to (or can't)
-// require an API client.
+// require an API client. The command parameter is the resolved command path
+// from [kong.Context.Command].
 func noAPIClientRequired(command string) bool {
-	return containsFlag(command, "--help", "-h", "--version") ||
-		matchCommand(command, auth.CmdName, format.LoginCommand) ||
+	return matchCommand(command, auth.CmdName, format.LoginCommand) ||
 		matchCommand(command, auth.CmdName, format.LogoutCommand) ||
 		matchCommand(command, auth.CmdName, auth.OIDCCmdName) ||
 		matchCommand(command, auth.CmdName, auth.ClientCredentialsCmdName) ||
 		matchCommand(command, "completions")
-}
-
-// containsFlag reports whether any whitespace-delimited token in command
-// equals one of the given flags.
-func containsFlag(command string, flags ...string) bool {
-	for arg := range strings.SplitSeq(command, " ") {
-		if slices.Contains(flags, arg) {
-			return true
-		}
-	}
-	return false
 }
 
 func matchCommand(command string, parts ...string) bool {

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"reflect"
 	"runtime/debug"
+	"slices"
 	"strings"
 	"syscall"
 
@@ -227,7 +228,7 @@ func clientPredictors(ctx context.Context, apiClientRequired bool) []completion.
 		completion.WithPredictor("mysql_databases", complete.PredictNothing),
 	}
 
-	if !apiClientRequired {
+	if !apiClientRequired || os.Getenv("COMP_LINE") == "" {
 		return nothing
 	}
 
@@ -249,11 +250,23 @@ func clientPredictors(ctx context.Context, apiClientRequired bool) []completion.
 // noAPIClientRequired returns true if the command does not need to (or can't)
 // require an API client.
 func noAPIClientRequired(command string) bool {
-	return matchCommand(command, auth.CmdName, format.LoginCommand) ||
+	return containsFlag(command, "--help", "-h", "--version") ||
+		matchCommand(command, auth.CmdName, format.LoginCommand) ||
 		matchCommand(command, auth.CmdName, format.LogoutCommand) ||
 		matchCommand(command, auth.CmdName, auth.OIDCCmdName) ||
 		matchCommand(command, auth.CmdName, auth.ClientCredentialsCmdName) ||
 		matchCommand(command, "completions")
+}
+
+// containsFlag reports whether any whitespace-delimited token in command
+// equals one of the given flags.
+func containsFlag(command string, flags ...string) bool {
+	for arg := range strings.SplitSeq(command, " ") {
+		if slices.Contains(flags, arg) {
+			return true
+		}
+	}
+	return false
 }
 
 func matchCommand(command string, parts ...string) bool {

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,4 +16,31 @@ func TestKongVars(t *testing.T) {
 	vars, err := kongVariables()
 	is.NoError(err)
 	is.NotEmpty(vars)
+}
+
+func TestNoAPIClientRequired(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	tests := []struct {
+		command  string
+		expected bool
+	}{
+		{"--help", true},
+		{"-h", true},
+		{"--version", true},
+		{"get --help", true},
+		{"get application --help", true},
+		{"get -h", true},
+		{"auth login", true},
+		{"auth logout", true},
+		{"completions", true},
+		{"get", false},
+		{"get application", false},
+		{"create application", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		is.Equal(tt.expected, noAPIClientRequired(tt.command), "command: %q", tt.command)
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -22,22 +22,25 @@ func TestNoAPIClientRequired(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
+	// Commands use the resolved format from kong.Context.Command().
+	// --help and --version are not tested here because Kong exits
+	// during Parse before noAPIClientRequired is called.
 	tests := []struct {
 		command  string
 		expected bool
 	}{
-		{"--help", true},
-		{"-h", true},
-		{"--version", true},
-		{"get --help", true},
-		{"get application --help", true},
-		{"get -h", true},
 		{"auth login", true},
+		{"auth login <organization>", true},
 		{"auth logout", true},
+		{"auth oidc", true},
+		{"auth client-credentials", true},
 		{"completions", true},
+		{"completions bash", true},
 		{"get", false},
 		{"get application", false},
-		{"create application", false},
+		{"get application <name>", false},
+		{"create application <name>", false},
+		{"exec application <name>", false},
 		{"", false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
`nctl --help` and `nctl --version` unnecessarily triggered API authentication.

The predictor client for shell completion was created eagerly on every invocation, even when completions weren't being requested. Additionally, `--help`/`--version` flags weren't recognized as commands that don't need an API client.

**Changes**

- Gate predictor client creation on `COMP_LINE`: The API client is only created when the shell is actually requesting completions.
- Skip API client for `--help`, `-h`, and `--version` flags anywhere in the args.