### PR TITLE
fix(exec): avoid panic when redirecting application exec output

### DIFF
--- a/exec/application.go
+++ b/exec/application.go
@@ -182,10 +182,7 @@ func executeRemoteCommand(ctx context.Context, params remoteCommandParameters) e
 	tty := setupTTY(&params)
 	var sizeQueue remotecommand.TerminalSizeQueue
 	if tty.Raw {
-		// this call spawns a goroutine to monitor/update the terminal size
-		sizeQueue = &terminalSizeQueueWrapper{
-			tsq: tty.MonitorSize(tty.GetSize()),
-		}
+		sizeQueue = newSizeQueue(tty)
 
 		// unset stderr if it was previously set because both stdout
 		// and stderr go over params.stdout when tty is
@@ -253,6 +250,16 @@ func latestAvailableReleaseForApplication(ctx context.Context, client *api.Clien
 	}
 
 	return release, nil
+}
+
+// newSizeQueue returns a [remotecommand.TerminalSizeQueue] that monitors terminal
+// size changes. It returns nil when the terminal cannot be monitored.
+func newSizeQueue(tty term.TTY) remotecommand.TerminalSizeQueue {
+	if tsq := tty.MonitorSize(tty.GetSize()); tsq != nil {
+		return &terminalSizeQueueWrapper{tsq: tsq}
+	}
+
+	return nil
 }
 
 // terminalSizeQueueWrapper implements the [remotecommand.TerminalSizeQueue] interface.

--- a/exec/application_test.go
+++ b/exec/application_test.go
@@ -1,10 +1,13 @@
 package exec
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"testing"
 	"time"
 
+	"github.com/creack/pty/v2"
 	"github.com/google/uuid"
 	apps "github.com/ninech/apis/apps/v1alpha1"
 	meta "github.com/ninech/apis/meta/v1alpha1"
@@ -18,6 +21,91 @@ import (
 const (
 	project = test.DefaultProject
 )
+
+func TestSetupTTY(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		usePTYStdin   bool
+		usePTYStdout  bool
+		tty           bool
+		enableStdin   bool
+		wantRaw       bool
+		wantTTY       bool
+		wantSizeQueue bool
+	}{
+		"stdin-disabled": {
+			tty:         true,
+			enableStdin: false,
+			wantTTY:     true,
+		},
+		"tty-disabled": {
+			enableStdin: true,
+		},
+		"non-terminal-stdin": {
+			tty:         true,
+			enableStdin: true,
+		},
+		"redirected-stdout": {
+			usePTYStdin: true,
+			tty:         true,
+			enableStdin: true,
+			wantRaw:     true,
+			wantTTY:     true,
+		},
+		"full-terminal": {
+			usePTYStdin:   true,
+			usePTYStdout:  true,
+			tty:           true,
+			enableStdin:   true,
+			wantRaw:       true,
+			wantTTY:       true,
+			wantSizeQueue: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			is := require.New(t)
+
+			var stdin io.Reader = bytes.NewReader(nil)
+			var stdout io.Writer = &bytes.Buffer{}
+
+			if tc.usePTYStdin || tc.usePTYStdout {
+				ptmx, ptty, err := pty.Open()
+				is.NoError(err)
+				t.Cleanup(func() {
+					ptmx.Close()
+					ptty.Close()
+				})
+				if tc.usePTYStdin {
+					stdin = ptty
+				}
+				if tc.usePTYStdout {
+					stdout = ptty
+				}
+			}
+
+			params := remoteCommandParameters{
+				tty:         tc.tty,
+				enableStdin: tc.enableStdin,
+				stdin:       stdin,
+				stdout:      stdout,
+			}
+
+			result := setupTTY(&params)
+
+			is.Equal(tc.wantRaw, result.Raw)
+			is.Equal(tc.wantTTY, params.tty)
+
+			sizeQueue := newSizeQueue(result)
+			if tc.wantSizeQueue {
+				is.NotNil(sizeQueue)
+			} else {
+				is.Nil(sizeQueue)
+			}
+		})
+	}
+}
 
 func TestApplicationReplicaSelection(t *testing.T) {
 	t.Parallel()

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/creack/pty/v2 v2.0.1
 	github.com/crossplane/crossplane-runtime v1.20.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/fatih/color v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,8 @@ github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/creack/pty/v2 v2.0.1 h1:RDY1VY5b+7m2mfPsugucOYPIxMp+xal5ZheSyVzUA+k=
+github.com/creack/pty/v2 v2.0.1/go.mod h1:2dSssKp3b86qYEMwA/FPwc3ff+kYpDdQI8osU8J7gxQ=
 github.com/crossplane/crossplane-runtime v1.20.0 h1:I54uipRIecqZyms+vz1J/l62yjVQ7HV5w+Nh3RMrUtc=
 github.com/crossplane/crossplane-runtime v1.20.0/go.mod h1:lfV1VJenDc9PNVLxDC80YjPoTm+JdSZ13xlS2h37Dvg=
 github.com/d4l3k/messagediff v1.2.1 h1:ZcAIMYsUg0EAp9X+tt8/enBE/Q8Yd5kzPynLyKptt9U=


### PR DESCRIPTION
MonitorSize returns nil when stdout is not a terminal, causing a nil pointer dereference in the resize goroutine spawned by remotecommand.

Resolves https://github.com/ninech/nctl/issues/403