### PR TITLE
fix(update): support unpausing applications with --no-pause

### DIFF
--- a/update/application.go
+++ b/update/application.go
@@ -57,7 +57,7 @@ type applicationCmd struct {
 	DeleteService            []string          `help:"Service reference names to remove."`
 	RetryRelease             *bool           `help:"Retries release for the application." placeholder:"false"`
 	RetryBuild               *bool           `help:"Retries build for the application if set to true." placeholder:"false"`
-	Pause                    *bool           `help:"Pauses the application if set to true. Stops all costs." placeholder:"false"`
+	Pause                    *bool           `negatable:"" help:"Pause or unpause the application. Pausing stops all costs."`
 	GitInformationServiceURL string          `help:"URL of the git information service." default:"https://git-info.deplo.io" env:"GIT_INFORMATION_SERVICE_URL" hidden:""`
 	SkipRepoAccessCheck      bool            `help:"Skip the git repository access check." default:"false"`
 	Debug                    bool            `help:"Enable debug messages." default:"false"`
@@ -340,7 +340,7 @@ func (cmd *applicationCmd) applyUpdates(app *apps.Application) {
 		sensitiveBuildEnv,
 		delBuildEnv,
 	)
-	if cmd.Pause != nil && *cmd.Pause {
+	if cmd.Pause != nil {
 		app.Spec.ForProvider.Paused = *cmd.Pause
 	}
 

--- a/update/application_test.go
+++ b/update/application_test.go
@@ -709,6 +709,36 @@ func TestApplication(t *testing.T) {
 				is.Equal(storage.KeyValueStoreKind, updated.Spec.ForProvider.Services[0].Target.Kind)
 			},
 		},
+		"pause application": {
+			orig: existingApp,
+			cmd: applicationCmd{
+				resourceCmd: resourceCmd{
+					Name: existingApp.Name,
+				},
+				Pause: new(true),
+			},
+			checkApp: func(t *testing.T, cmd applicationCmd, orig, updated *apps.Application) {
+				is := require.New(t)
+				is.True(updated.Spec.ForProvider.Paused)
+			},
+		},
+		"unpause application": {
+			orig: func() *apps.Application {
+				a := existingApp.DeepCopy()
+				a.Spec.ForProvider.Paused = true
+				return a
+			}(),
+			cmd: applicationCmd{
+				resourceCmd: resourceCmd{
+					Name: existingApp.Name,
+				},
+				Pause: new(false),
+			},
+			checkApp: func(t *testing.T, cmd applicationCmd, orig, updated *apps.Application) {
+				is := require.New(t)
+				is.False(updated.Spec.ForProvider.Paused)
+			},
+		},
 		"delete service": {
 			orig: &apps.Application{
 				ObjectMeta: metav1.ObjectMeta{
@@ -819,4 +849,16 @@ func TestApplicationFlags(t *testing.T) {
 	is.NotNil(emptyFlags.Hosts)
 	is.NotNil(emptyFlags.Env)
 	is.NotNil(emptyFlags.BuildEnv)
+
+	pauseFlags := &applicationCmd{}
+	_, err = kong.Must(pauseFlags, vars, kong.BindTo(t.Output(), (*io.Writer)(nil))).Parse([]string{`testname`, `--pause`})
+	is.NoError(err)
+	is.NotNil(pauseFlags.Pause)
+	is.True(*pauseFlags.Pause)
+
+	noPauseFlags := &applicationCmd{}
+	_, err = kong.Must(noPauseFlags, vars, kong.BindTo(t.Output(), (*io.Writer)(nil))).Parse([]string{`testname`, `--no-pause`})
+	is.NoError(err)
+	is.NotNil(noPauseFlags.Pause)
+	is.False(*noPauseFlags.Pause)
 }


### PR DESCRIPTION
The --pause flag silently ignored false values due to an overly strict
condition, making it impossible to unpause via the CLI. Made the flag
negatable so --no-pause works, and fixed the condition to apply both
true and false.