### PR TITLE
feat(application): set default replicas on create, allow unsetting on update

### DIFF
--- a/create/application.go
+++ b/create/application.go
@@ -32,6 +32,8 @@ import (
 
 const logPrintTimeout = 10 * time.Second
 
+const DefaultReplicas = 2
+
 // note: when adding/changing fields here also make sure to carry it over to
 // update/application.go.
 type applicationCmd struct {
@@ -40,7 +42,7 @@ type applicationCmd struct {
 	Size                     *string           `help:"Size of the application (defaults to \"${app_default_size}\")." placeholder:"${app_default_size}"`
 	Port                     *int32            `help:"Port the application is listening on (defaults to ${app_default_port})." placeholder:"${app_default_port}"`
 	HealthProbe              healthProbe       `embed:"" prefix:"health-probe-"`
-	Replicas                 *int32            `help:"Amount of replicas of the running application (defaults to ${app_default_replicas})." placeholder:"${app_default_replicas}"`
+	Replicas                 int32             `help:"Amount of replicas of the running application (defaults to ${app_default_replicas})." placeholder:"${app_default_replicas}" default:"${app_default_replicas}"`
 	Hosts                    []string          `help:"Host names where the application can be accessed. If empty, the application will just be accessible on a generated host name on the deploio.app domain."`
 	BasicAuth                *bool             `help:"Enable/Disable basic authentication for the application (defaults to ${app_default_basic_auth})." placeholder:"${app_default_basic_auth}"`
 	Env                      map[string]string `help:"Environment variables which are passed to the application at runtime."`
@@ -351,9 +353,7 @@ func (cmd *applicationCmd) config() apps.Config {
 	if cmd.Port != nil {
 		config.Port = cmd.Port
 	}
-	if cmd.Replicas != nil {
-		config.Replicas = cmd.Replicas
-	}
+	config.Replicas = &cmd.Replicas
 
 	cmd.HealthProbe.applyCreate(&config)
 
@@ -712,10 +712,7 @@ func ApplicationKongVars() (kong.Vars, error) {
 		return nil, errors.New("no default application port found")
 	}
 	result["app_default_port"] = strconv.Itoa(int(*apps.DefaultConfig.Port))
-	if apps.DefaultConfig.Replicas == nil {
-		return nil, errors.New("no default application replicas found")
-	}
-	result["app_default_replicas"] = strconv.Itoa(int(*apps.DefaultConfig.Replicas))
+	result["app_default_replicas"] = strconv.Itoa(DefaultReplicas)
 	if apps.DefaultConfig.EnableBasicAuth == nil {
 		return nil, errors.New("no default application basic authentication settings found")
 	}

--- a/create/application_test.go
+++ b/create/application_test.go
@@ -3,11 +3,13 @@ package create
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/alecthomas/kong"
 	runtimev1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/grafana/loki/v3/pkg/logcli/output"
@@ -88,7 +90,7 @@ func TestCreateApplication(t *testing.T) {
 				Hosts:               []string{"custom.example.org", "custom2.example.org"},
 				Port:                new(int32(1337)),
 				HealthProbe:         healthProbe{PeriodSeconds: int32(7), Path: "/he"},
-				Replicas:            new(int32(42)),
+				Replicas:            42,
 				BasicAuth:           new(false),
 				Env:                 map[string]string{"hello": "world"},
 				BuildEnv:            map[string]string{"BP_GO_TARGETS": "./cmd/web-server"},
@@ -106,7 +108,7 @@ func TestCreateApplication(t *testing.T) {
 				is.Equal(*cmd.Port, *app.Spec.ForProvider.Config.Port)
 				is.Equal(cmd.HealthProbe.PeriodSeconds, *app.Spec.ForProvider.Config.HealthProbe.PeriodSeconds)
 				is.Equal(cmd.HealthProbe.Path, app.Spec.ForProvider.Config.HealthProbe.HTTPGet.Path)
-				is.Equal(*cmd.Replicas, *app.Spec.ForProvider.Config.Replicas)
+				is.Equal(cmd.Replicas, *app.Spec.ForProvider.Config.Replicas)
 				is.Equal(*cmd.BasicAuth, *app.Spec.ForProvider.Config.EnableBasicAuth)
 				is.Equal(application.EnvVarsFromMap(cmd.Env), app.Spec.ForProvider.Config.Env)
 				is.Equal(application.EnvVarsFromMap(cmd.BuildEnv), app.Spec.ForProvider.BuildEnv)
@@ -836,4 +838,32 @@ func setResourceCondition(ctx context.Context, apiClient *api.Client, mg resourc
 
 	mg.SetConditions(condition)
 	return apiClient.Update(ctx, mg)
+}
+
+// TestApplicationFlags tests that Kong applies the default value for the
+// replicas flag when it is not explicitly provided.
+func TestApplicationFlags(t *testing.T) {
+	t.Parallel()
+
+	is := require.New(t)
+
+	vars, err := ApplicationKongVars()
+	is.NoError(err)
+
+	defaultCmd := &applicationCmd{}
+	_, err = kong.Must(defaultCmd, vars, kong.BindTo(io.Discard, (*io.Writer)(nil))).Parse([]string{
+		`test-app`,
+		`--git-url=https://github.com/ninech/doesnotexist.git`,
+	})
+	is.NoError(err)
+	is.Equal(int32(DefaultReplicas), defaultCmd.Replicas)
+
+	explicitCmd := &applicationCmd{}
+	_, err = kong.Must(explicitCmd, vars, kong.BindTo(io.Discard, (*io.Writer)(nil))).Parse([]string{
+		`test-app`,
+		`--git-url=https://github.com/ninech/doesnotexist.git`,
+		`--replicas=5`,
+	})
+	is.NoError(err)
+	is.Equal(int32(5), explicitCmd.Replicas)
 }

--- a/update/application.go
+++ b/update/application.go
@@ -32,7 +32,8 @@ type applicationCmd struct {
 	Port                    *int32            `help:"Port the app is listening on."`
 	HealthProbe             *healthProbe      `embed:"" prefix:"health-probe-"`
 	DeleteHealthProbe       *bool             `help:"Delete existing custom health probe."`
-	Replicas                *int32            `help:"Amount of replicas of the running app."`
+	Replicas                *int32            `help:"Amount of replicas of the running app." xor:"replicas"`
+	UnsetReplicas           *bool             `help:"Unset the replicas, deferring to other possible configuration layer values (.deploio.yaml, etc)." xor:"replicas"`
 	Hosts                   *[]string         `help:"Host names where the application can be accessed. If empty, the application will just be accessible on a generated host name on the deploio.app domain."`
 	BasicAuth               *bool             `help:"Enable/Disable basic authentication for the application."`
 	ChangeBasicAuthPassword *bool             `help:"Generate a new basic auth password."`
@@ -258,6 +259,9 @@ func (cmd *applicationCmd) applyUpdates(app *apps.Application) {
 	}
 	if cmd.Replicas != nil {
 		app.Spec.ForProvider.Config.Replicas = cmd.Replicas
+	}
+	if cmd.UnsetReplicas != nil && *cmd.UnsetReplicas {
+		app.Spec.ForProvider.Config.Replicas = nil
 	}
 	if cmd.Hosts != nil {
 		app.Spec.ForProvider.Hosts = *cmd.Hosts

--- a/update/application_test.go
+++ b/update/application_test.go
@@ -165,6 +165,33 @@ func TestApplication(t *testing.T) {
 				is.Nil(application.EnvVarByName(updated.Spec.ForProvider.BuildEnv, BuildTrigger))
 			},
 		},
+		"unset replicas": {
+			orig: existingApp,
+			cmd: applicationCmd{
+				resourceCmd: resourceCmd{
+					Name: existingApp.Name,
+				},
+				UnsetReplicas: new(true),
+			},
+			checkApp: func(t *testing.T, cmd applicationCmd, orig, updated *apps.Application) {
+				is := require.New(t)
+				is.NotNil(orig.Spec.ForProvider.Config.Replicas)
+				is.Nil(updated.Spec.ForProvider.Config.Replicas)
+			},
+		},
+		"replicas unchanged when unset flag is false": {
+			orig: existingApp,
+			cmd: applicationCmd{
+				resourceCmd: resourceCmd{
+					Name: existingApp.Name,
+				},
+				UnsetReplicas: new(false),
+			},
+			checkApp: func(t *testing.T, cmd applicationCmd, orig, updated *apps.Application) {
+				is := require.New(t)
+				is.Equal(orig.Spec.ForProvider.Config.Replicas, updated.Spec.ForProvider.Config.Replicas)
+			},
+		},
 		"reset custom health probe": {
 			orig: func() *apps.Application {
 				a := existingApp
@@ -861,4 +888,14 @@ func TestApplicationFlags(t *testing.T) {
 	is.NoError(err)
 	is.NotNil(noPauseFlags.Pause)
 	is.False(*noPauseFlags.Pause)
+
+	unsetReplicasFlags := &applicationCmd{}
+	_, err = kong.Must(unsetReplicasFlags, vars, kong.BindTo(t.Output(), (*io.Writer)(nil))).Parse([]string{`testname`, `--unset-replicas`})
+	is.NoError(err)
+	is.NotNil(unsetReplicasFlags.UnsetReplicas)
+	is.True(*unsetReplicasFlags.UnsetReplicas)
+
+	xorReplicasFlags := &applicationCmd{}
+	_, err = kong.Must(xorReplicasFlags, vars, kong.BindTo(t.Output(), (*io.Writer)(nil))).Parse([]string{`testname`, `--replicas=2`, `--unset-replicas`})
+	is.Error(err)
 }


### PR DESCRIPTION
When creating an application, replicas was left unset, meaning a change to the API's default replica count would silently affect existing applications. Replicas are now always set explicitly to the current recommended replicas amount at creation time.

On update, --unset-replicas (mutually exclusive with --replicas) sets the field back to null, allowing the value from .deploio.yaml or other configuration layers to take effect.