### PR TITLE
fix: pass existing git auth secret to validator before constructing it

### DIFF
--- a/update/application.go
+++ b/update/application.go
@@ -177,12 +177,6 @@ func (cmd *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 			if err != nil {
 				return err
 			}
-			validator := &application.RepositoryValidator{
-				Auth:   auth,
-				Client: gitClient,
-				Debug:  cmd.Debug,
-			}
-
 			if !auth.Enabled() {
 				// if the auth was not changed but e.g. the branch changes and
 				// auth is pre-configured, we need to fetch the existing git
@@ -192,6 +186,12 @@ func (cmd *applicationCmd) Run(ctx context.Context, client *api.Client) error {
 					return fmt.Errorf("error reading preconfigured auth secret: %w", err)
 				}
 				auth = a
+			}
+
+			validator := &application.RepositoryValidator{
+				Auth:   auth,
+				Client: gitClient,
+				Debug:  cmd.Debug,
 			}
 
 			app.Spec.ForProvider.Git.GitTarget, err = validator.Validate(ctx, app.Spec.ForProvider.Git.GitTarget)

--- a/update/application_test.go
+++ b/update/application_test.go
@@ -79,6 +79,7 @@ func TestApplication(t *testing.T) {
 		cmd                           applicationCmd
 		checkApp                      func(t *testing.T, cmd applicationCmd, orig, updated *apps.Application)
 		checkSecret                   func(t *testing.T, cmd applicationCmd, authSecret *corev1.Secret)
+		verifyRequest                 func(t *testing.T, p test.GitInfoServiceParsed)
 		gitInformationServiceResponse test.GitInformationServiceResponse
 		errorExpected                 bool
 	}{
@@ -772,6 +773,46 @@ func TestApplication(t *testing.T) {
 				is.False(updated.Spec.ForProvider.Paused)
 			},
 		},
+		"existing ssh auth is used when only updating revision": {
+			orig: func() *apps.Application {
+				a := existingApp.DeepCopy()
+				a.Spec.ForProvider.Git.URL = "git@github.com:ninech/some-repo.git"
+				return a
+			}(),
+			gitAuth: &gitinfo.Auth{
+				SSHPrivateKey: &dummyRSAKey,
+			},
+			cmd: applicationCmd{
+				resourceCmd: resourceCmd{
+					Name: existingApp.Name,
+				},
+				Git: &gitConfig{
+					Revision: new("v1.2.3"),
+				},
+			},
+			gitInformationServiceResponse: test.GitInformationServiceResponse{
+				Code: 200,
+				Content: apps.GitExploreResponse{
+					RepositoryInfo: &apps.RepositoryInfo{
+						URL:      "git@github.com:ninech/some-repo.git",
+						Branches: []string{"v1.2.3"},
+						RevisionResponse: &apps.RevisionResponse{
+							RevisionRequested: "v1.2.3",
+							Found:             true,
+						},
+					},
+				},
+			},
+			checkApp: func(t *testing.T, cmd applicationCmd, orig, updated *apps.Application) {
+				is := require.New(t)
+				is.Equal("v1.2.3", updated.Spec.ForProvider.Git.Revision)
+			},
+			verifyRequest: func(t *testing.T, p test.GitInfoServiceParsed) {
+				is := require.New(t)
+				is.NotNil(p.Request.Auth, "existing SSH key should have been sent to the git info service")
+				is.NotEmpty(p.Request.Auth.PrivateKey)
+			},
+		},
 		"delete service": {
 			orig: &apps.Application{
 				ObjectMeta: metav1.ObjectMeta{
@@ -852,6 +893,12 @@ func TestApplication(t *testing.T) {
 				}
 
 				tc.checkSecret(t, tc.cmd, updatedSecret)
+			}
+
+			if tc.verifyRequest != nil {
+				req, err := gitInfoService.Request()
+				is.NoError(err)
+				tc.verifyRequest(t, req)
 			}
 		})
 	}


### PR DESCRIPTION
When updating a git field (e.g. --git-revision) without providing new auth flags, the RepositoryValidator was constructed with an empty Auth before the existing secret was fetched — leaving the git info service call unauthenticated even though a secret was already configured.