### PR TITLE
fix: reject -f flag combined with a resource kind on create

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -2,14 +2,6 @@
 // allowing users to apply resources from files.
 package apply
 
-import (
-	"os"
-
-	"github.com/ninech/nctl/internal/format"
-)
-
 type Cmd struct {
-	format.Writer `hidden:""`
-	Filename      *os.File `short:"f" completion-predictor:"file"`
-	FromFile      fromFile `cmd:"" default:"1" name:"-f <file>" help:"Apply any resource from a yaml or json file."`
+	FromFile fromFile `cmd:"" default:"withargs" name:"-f <file>" help:"Apply any resource from a yaml or json file."`
 }

--- a/apply/file.go
+++ b/apply/file.go
@@ -15,10 +15,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type fromFile struct{}
+type fromFile struct {
+	format.Writer `hidden:""`
+	Filename      *os.File `short:"f" completion-predictor:"file"`
+}
 
-func (cmd *Cmd) Run(ctx context.Context, client *api.Client, apply *Cmd) error {
-	return File(ctx, cmd.Writer, client, apply.Filename, UpdateOnExists())
+func (cmd *fromFile) Run(ctx context.Context, client *api.Client) error {
+	return File(ctx, cmd.Writer, client, cmd.Filename, UpdateOnExists())
 }
 
 type Option func(*config)

--- a/create/create.go
+++ b/create/create.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
-	"os"
 	"time"
 
 	runtimev1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
@@ -24,8 +23,7 @@ import (
 )
 
 type Cmd struct {
-	Filename            *os.File             `short:"f" help:"Create any resource from a yaml or json file." completion-predictor:"file"`
-	FromFile            fromFile             `cmd:"" group:"create-general" default:"1" name:"-f <file>" help:"Create any resource from a yaml or json file."`
+	FromFile            fromFile             `cmd:"" group:"create-general" default:"withargs" name:"-f <file>" help:"Create any resource from a yaml or json file."`
 	VCluster            vclusterCmd          `cmd:"" group:"create-infra" name:"vcluster" help:"Create a new vcluster."`
 	APIServiceAccount   apiServiceAccountCmd `cmd:"" group:"create-access" name:"apiserviceaccount" aliases:"asa" help:"Create a new API Service Account."`
 	Project             projectCmd           `cmd:"" group:"create-access" name:"project" help:"Create a new project."`

--- a/create/file.go
+++ b/create/file.go
@@ -2,6 +2,7 @@ package create
 
 import (
 	"context"
+	"os"
 
 	"github.com/ninech/nctl/api"
 	"github.com/ninech/nctl/apply"
@@ -10,8 +11,9 @@ import (
 
 type fromFile struct {
 	format.Writer
+	Filename *os.File `short:"f" help:"Create any resource from a yaml or json file." completion-predictor:"file"`
 }
 
-func (cmd *fromFile) Run(ctx context.Context, client *api.Client, create *Cmd) error {
-	return apply.File(ctx, cmd.Writer, client, create.Filename)
+func (cmd *fromFile) Run(ctx context.Context, client *api.Client) error {
+	return apply.File(ctx, cmd.Writer, client, cmd.Filename)
 }

--- a/delete/delete.go
+++ b/delete/delete.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"time"
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -16,8 +15,7 @@ import (
 )
 
 type Cmd struct {
-	Filename            *os.File             `short:"f" completion-predictor:"file"`
-	FromFile            fromFile             `cmd:"" group:"delete-general" default:"1" name:"-f <file>" help:"Delete any resource from a yaml or json file."`
+	FromFile            fromFile             `cmd:"" group:"delete-general" default:"withargs" name:"-f <file>" help:"Delete any resource from a yaml or json file."`
 	VCluster            vclusterCmd          `cmd:"" group:"delete-infra" name:"vcluster" help:"Delete a vcluster."`
 	APIServiceAccount   apiServiceAccountCmd `cmd:"" group:"delete-access" name:"apiserviceaccount" aliases:"asa" help:"Delete an API Service Account."`
 	Project             projectCmd           `cmd:"" group:"delete-access" name:"project" aliases:"proj" help:"Delete a Project."`

--- a/delete/file.go
+++ b/delete/file.go
@@ -2,6 +2,7 @@ package delete
 
 import (
 	"context"
+	"os"
 
 	"github.com/ninech/nctl/api"
 	"github.com/ninech/nctl/apply"
@@ -10,8 +11,9 @@ import (
 
 type fromFile struct {
 	format.Writer
+	Filename *os.File `short:"f" completion-predictor:"file"`
 }
 
-func (cmd *fromFile) Run(ctx context.Context, client *api.Client, delete *Cmd) error {
-	return apply.File(ctx, cmd.Writer, client, delete.Filename, apply.Delete())
+func (cmd *fromFile) Run(ctx context.Context, client *api.Client) error {
+	return apply.File(ctx, cmd.Writer, client, cmd.Filename, apply.Delete())
 }


### PR DESCRIPTION
`-f` is now only allowed when doing `nctl create -f` as `nctl create <type> -f`doesn't make any sense. A file already contains the types of its resources.