### PR TITLE
feat(cloudvm): add support for Debian 13, codenamed trixie

### DIFF
--- a/create/authorized_keys.go
+++ b/create/authorized_keys.go
@@ -4,9 +4,14 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"os"
+	"slices"
 	"strings"
 
+	storage "github.com/ninech/apis/storage/v1alpha1"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/ninech/nctl/internal/format"
 )
 
 // ParseAuthorizedKeys reads SSH public keys from r. Every key is expected on
@@ -37,4 +42,186 @@ func ParseAuthorizedKeys(r io.Reader) ([]string, error) {
 	}
 
 	return keys, nil
+}
+
+// ReadAuthorizedKeys returns the validated SSH public keys of values, followed
+// by the keys read from files, in that order. flag names the flag values were
+// passed to and is only used to report errors and warnings. The files are
+// closed, they are read exactly once.
+//
+// A source which holds no key at all is not an error, but it is warned about on
+// w as it is most likely not what the user intended. Values which hold nothing
+// but whitespace are not warned about, as that is how a configured list of keys
+// is cleared.
+func ReadAuthorizedKeys(w *format.Writer, flag string, values []string, files []*os.File) ([]string, error) {
+	joined := strings.Join(values, "\n")
+
+	keys, err := ParseAuthorizedKeys(strings.NewReader(joined))
+	if err != nil {
+		return nil, fmt.Errorf("error reading --%s: %w", flag, err)
+	}
+	if strings.TrimSpace(joined) != "" && len(keys) == 0 {
+		w.Warningf("no SSH public key found in --%s", flag)
+	}
+
+	for _, file := range files {
+		if file == nil {
+			continue
+		}
+
+		fileKeys, err := readAuthorizedKeysFile(file)
+		if err != nil {
+			return nil, err
+		}
+		if len(fileKeys) == 0 {
+			w.Warningf("no SSH public key found in %q", file.Name())
+		}
+		keys = append(keys, fileKeys...)
+	}
+
+	return keys, nil
+}
+
+// readAuthorizedKeysFile reads the validated SSH public keys of file and closes
+// it. It is a function of its own so that every file is closed as soon as it was
+// read instead of only when the surrounding loop is done.
+func readAuthorizedKeysFile(file *os.File) ([]string, error) {
+	defer file.Close()
+
+	keys, err := ParseAuthorizedKeys(file)
+	if err != nil {
+		return nil, fmt.Errorf("error reading public keys file %q: %w", file.Name(), err)
+	}
+
+	return keys, nil
+}
+
+// AnyFile reports whether files holds at least one file Kong decoded. A
+// repeated file flag may hold nil entries, those do not count as passed as
+// there is nothing to read from them.
+func AnyFile(files []*os.File) bool {
+	return slices.ContainsFunc(files, func(file *os.File) bool { return file != nil })
+}
+
+// SSHKeysFlags declares the --ssh-keys and --ssh-keys-from-files flags. Embed
+// it with a prefix to scope the flags to a part of a resource and set
+// ssh_keys_purpose to the clause which says what the keys are used for, it
+// completes the help of both flags:
+//
+//	SSHKeysFlags `prefix:"rescue-" set:"ssh_keys_purpose=to connect while booted into rescue"`
+//
+// The same prefix has to be passed to [SSHKeysFlags.Keys], as Kong does not
+// tell a flag which name it ended up being registered under. A mismatch between
+// the two only shows in the errors and warnings, so every command embedding the
+// flags is expected to have a test which parses real arguments through Kong and
+// asserts the flag names those messages spell out.
+type SSHKeysFlags struct {
+	// sep:"none" keeps Kong from splitting a value on commas, which would tear
+	// apart the options of an authorized_keys line. Repeat the flag or separate
+	// the keys by newlines to pass more than one.
+	SSHKeys          []string   `sep:"none" placeholder:"ssh-ed25519 AAAA..." help:"SSH public keys ${ssh_keys_purpose=to connect to the resource}. The keys are expected to be in SSH format as defined in RFC4253. Repeat the flag to pass more than one key."`
+	SSHKeysFromFiles []*os.File `placeholder:"~/.ssh/id_ed25519.pub" completion-predictor:"file" help:"Files holding SSH public keys ${ssh_keys_purpose=to connect to the resource}. Empty lines and lines prefixed with # are ignored."`
+}
+
+// Keys returns the validated SSH public keys of --<prefix>ssh-keys followed by
+// those of --<prefix>ssh-keys-from-files, in that order.
+func (f SSHKeysFlags) Keys(w *format.Writer, prefix string) ([]string, error) {
+	return ReadAuthorizedKeys(w, prefix+"ssh-keys", f.SSHKeys, f.SSHKeysFromFiles)
+}
+
+// DeprecatedKeysFlags declares the --keys and --keys-from-files flags which
+// [SSHKeysFlags] replaces. It has to be embedded with the prefix the flags were
+// registered under before the rename:
+//
+//	DeprecatedKeysFlags `prefix:"public-"`
+//
+// The flags are hidden, they only exist to keep the previous spelling working.
+// Unlike [SSHKeysFlags] they do not set sep:"none", so that values which used to
+// be split on commas keep being split the same way. The fields carry a name tag
+// so that they can be told apart from the fields of [SSHKeysFlags] wherever both
+// are embedded, the flags are still registered as --<prefix>keys and
+// --<prefix>keys-from-files.
+type DeprecatedKeysFlags struct {
+	DeprecatedKeys          []string   `name:"keys" hidden:"" help:"Deprecated, use --ssh-keys instead."`
+	DeprecatedKeysFromFiles []*os.File `name:"keys-from-files" hidden:"" completion-predictor:"file" help:"Deprecated, use --ssh-keys-from-files instead."`
+}
+
+// Set reports whether one of the deprecated flags was passed. Unlike the flags
+// of [SSHKeysFlags] they cannot be used to clear a configured list of keys.
+func (f DeprecatedKeysFlags) Set() bool {
+	return len(f.DeprecatedKeys) != 0 || AnyFile(f.DeprecatedKeysFromFiles)
+}
+
+// Keys returns the validated SSH public keys of the deprecated flags registered
+// under prefix, or nil if none of them was passed. Their use is warned about on
+// w, pointing at the flags which [SSHKeysFlags] registered under replacement.
+func (f DeprecatedKeysFlags) Keys(w *format.Writer, prefix, replacement string) ([]string, error) {
+	if !f.Set() {
+		return nil, nil
+	}
+
+	w.Warningf(
+		"--%[1]skeys and --%[1]skeys-from-files are deprecated, use --%[2]sssh-keys and --%[2]sssh-keys-from-files instead",
+		prefix, replacement,
+	)
+
+	return ReadAuthorizedKeys(w, prefix+"keys", f.DeprecatedKeys, f.DeprecatedKeysFromFiles)
+}
+
+// DatabaseSSHKeysFlags declares the SSH public key flags of the database create
+// commands, including the deprecated --ssh-keys-file which the repeatable
+// --ssh-keys-from-files replaces.
+type DatabaseSSHKeysFlags struct {
+	SSHKeysFlags
+
+	// Deprecated Flags
+	SSHKeysFile *os.File `hidden:"" completion-predictor:"file" help:"Deprecated, use --ssh-keys-from-files instead."`
+}
+
+// StorageKeys returns the validated SSH public keys of all three flags, in the
+// order --ssh-keys, --ssh-keys-from-files and --ssh-keys-file.
+func (f DatabaseSSHKeysFlags) StorageKeys(w *format.Writer) ([]storage.SSHKey, error) {
+	keys, err := f.Keys(w, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return StorageKeysWithDeprecatedFile(w, keys, f.SSHKeysFile)
+}
+
+// StorageKeysWithDeprecatedFile converts keys to the type of the storage API,
+// with the keys of the deprecated --ssh-keys-file appended. Its use is warned
+// about on w, pointing at the flag which replaces it. A nil file was not passed
+// and contributes no keys.
+//
+// It is shared by the database create and update commands, which declare the
+// same three flags but differ in how the flags they replace are declared.
+func StorageKeysWithDeprecatedFile(w *format.Writer, keys []string, deprecatedFile *os.File) ([]storage.SSHKey, error) {
+	if deprecatedFile != nil {
+		w.Warningf("--ssh-keys-file is deprecated, use --ssh-keys-from-files instead")
+
+		fileKeys, err := ReadAuthorizedKeys(w, "ssh-keys-file", nil, []*os.File{deprecatedFile})
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, fileKeys...)
+	}
+
+	return StorageSSHKeys(keys), nil
+}
+
+// StorageSSHKeys converts keys to the type of the storage API. An empty list of
+// keys converts to nil, so that callers can tell "no keys were given" from "the
+// configured keys are to be cleared" through the flags instead of the result.
+func StorageSSHKeys(keys []string) []storage.SSHKey {
+	if len(keys) == 0 {
+		return nil
+	}
+
+	sshKeys := make([]storage.SSHKey, len(keys))
+	for i, key := range keys {
+		sshKeys[i] = storage.SSHKey(key)
+	}
+
+	return sshKeys
 }

--- a/create/authorized_keys.go
+++ b/create/authorized_keys.go
@@ -1,0 +1,40 @@
+package create
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// ParseAuthorizedKeys reads SSH public keys from r. Every key is expected on
+// its own line in the SSH format defined in RFC4253, blank lines and lines
+// prefixed with # are ignored.
+//
+// The keys are validated with [ssh.ParseAuthorizedKey] but returned as they
+// were read, only stripped of surrounding whitespace, so that key comments and
+// options are preserved.
+func ParseAuthorizedKeys(r io.Reader) ([]string, error) {
+	var keys []string
+
+	scanner := bufio.NewScanner(r)
+	for line := 1; scanner.Scan(); line++ {
+		key := strings.TrimSpace(scanner.Text())
+		if key == "" || strings.HasPrefix(key, "#") {
+			continue
+		}
+
+		if _, _, _, _, err := ssh.ParseAuthorizedKey([]byte(key)); err != nil {
+			return nil, fmt.Errorf("invalid SSH public key on line %d: %w", line, err)
+		}
+
+		keys = append(keys, key)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return keys, nil
+}

--- a/create/authorized_keys_test.go
+++ b/create/authorized_keys_test.go
@@ -1,10 +1,17 @@
 package create
 
 import (
+	"bytes"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/alecthomas/kong"
+	storage "github.com/ninech/apis/storage/v1alpha1"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ninech/nctl/internal/format"
 )
 
 // Valid ed25519 public keys used across the tests of this package.
@@ -73,4 +80,129 @@ func TestParseAuthorizedKeys(t *testing.T) {
 			is.Equal(tt.want, keys)
 		})
 	}
+}
+
+// parseDatabaseSSHKeys parses args into a [DatabaseSSHKeysFlags] the same way
+// the real CLI does, so that Kong's mappers and the flag names the struct is
+// registered under are exercised.
+func parseDatabaseSSHKeys(t *testing.T, args ...string) DatabaseSSHKeysFlags {
+	t.Helper()
+
+	var cmd struct {
+		DatabaseSSHKeysFlags `set:"ssh_keys_purpose=for the tests"`
+	}
+	_, err := kong.Must(&cmd, kong.BindTo(io.Discard, (*io.Writer)(nil))).Parse(args)
+	require.NoError(t, err)
+
+	return cmd.DatabaseSSHKeysFlags
+}
+
+// TestDatabaseSSHKeysFlags asserts that the SSH key flags of the database
+// commands complement each other, including the deprecated --ssh-keys-file
+// whose keys used to replace the inline ones instead of adding to them.
+func TestDatabaseSSHKeysFlags(t *testing.T) {
+	t.Parallel()
+
+	var (
+		keyFile     = writeKeyFile(t, "id_ed25519.pub", testPublicKeyB+"\n")
+		legacyFile  = writeKeyFile(t, "authorized_keys", "# my keys\n"+testPublicKeyA+"\n")
+		invalidFile = writeKeyFile(t, "invalid.pub", "not a key\n")
+	)
+
+	const deprecationWarning = "--ssh-keys-file is deprecated, use --ssh-keys-from-files instead"
+
+	tests := map[string]struct {
+		args     []string
+		want     []storage.SSHKey
+		wantWarn string
+		wantErr  string
+	}{
+		"none": {args: nil},
+		"inline": {
+			args: []string{`--ssh-keys=` + testPublicKeyA},
+			want: []storage.SSHKey{testPublicKeyA},
+		},
+		"file": {
+			args: []string{`--ssh-keys-from-files=` + keyFile},
+			want: []storage.SSHKey{testPublicKeyB},
+		},
+		"multiple files": {
+			args: []string{`--ssh-keys-from-files=` + keyFile, `--ssh-keys-from-files=` + legacyFile},
+			want: []storage.SSHKey{testPublicKeyB, testPublicKeyA},
+		},
+		"deprecated file": {
+			args:     []string{`--ssh-keys-file=` + legacyFile},
+			want:     []storage.SSHKey{testPublicKeyA},
+			wantWarn: deprecationWarning,
+		},
+		// the deprecated file used to replace the inline keys entirely.
+		"all sources": {
+			args: []string{
+				`--ssh-keys=` + testPublicKeyA,
+				`--ssh-keys-from-files=` + keyFile,
+				`--ssh-keys-file=` + legacyFile,
+			},
+			want:     []storage.SSHKey{testPublicKeyA, testPublicKeyB, testPublicKeyA},
+			wantWarn: deprecationWarning,
+		},
+		// the keys of the deprecated file are validated just like the others.
+		"invalid key in the deprecated file": {
+			args:    []string{`--ssh-keys-file=` + invalidFile},
+			wantErr: "invalid SSH public key on line 1",
+		},
+		"invalid inline key": {
+			args:    []string{`--ssh-keys=not a key`},
+			wantErr: "error reading --ssh-keys: invalid SSH public key on line 1",
+		},
+		// commas separate the options of an authorized_keys line, they must not
+		// be mistaken for a separator between keys.
+		"inline key with options": {
+			args: []string{`--ssh-keys=restrict,pty ` + testPublicKeyA},
+			want: []storage.SSHKey{`restrict,pty ` + testPublicKeyA},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			is := require.New(t)
+
+			out := &bytes.Buffer{}
+			w := format.NewWriter(out)
+			flags := parseDatabaseSSHKeys(t, tt.args...)
+
+			keys, err := flags.StorageKeys(&w)
+			if tt.wantErr != "" {
+				is.ErrorContains(err, tt.wantErr)
+				return
+			}
+
+			is.NoError(err)
+			is.Equal(tt.want, keys)
+			if tt.wantWarn == "" {
+				is.Empty(out.String())
+			} else {
+				is.Contains(out.String(), tt.wantWarn)
+			}
+		})
+	}
+}
+
+// TestSetIgnoresNilFiles asserts that a nil entry of a repeated file flag does
+// not count as passed. It holds nothing to read, so mistaking it for a passed
+// flag would make the update commands clear the configured keys instead of
+// keeping them.
+func TestSetIgnoresNilFiles(t *testing.T) {
+	t.Parallel()
+
+	is := require.New(t)
+
+	is.False(AnyFile(nil))
+	is.False(AnyFile([]*os.File{nil, nil}))
+	is.True(AnyFile([]*os.File{nil, os.Stdin}))
+
+	is.False(DeprecatedKeysFlags{}.Set())
+	is.False(DeprecatedKeysFlags{DeprecatedKeysFromFiles: []*os.File{nil}}.Set())
+	is.True(DeprecatedKeysFlags{DeprecatedKeys: []string{testPublicKeyA}}.Set())
+	is.True(DeprecatedKeysFlags{DeprecatedKeysFromFiles: []*os.File{os.Stdin}}.Set())
 }

--- a/create/authorized_keys_test.go
+++ b/create/authorized_keys_test.go
@@ -1,0 +1,76 @@
+package create
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Valid ed25519 public keys used across the tests of this package.
+const (
+	testPublicKeyA = `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJQQywLL6rNaZTvaomlhlHVvY36Tq7j1yuxJzBHark/V a@example.com`
+	testPublicKeyB = `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3bhEbFGMeJwiB7r2GTr/WLWlxrTG9CxzOTf4fM226g b@example.com`
+)
+
+func TestParseAuthorizedKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		in      string
+		want    []string
+		wantErr string
+	}{
+		"empty":            {in: ""},
+		"only comments":    {in: "# nothing to see here\n\n"},
+		"single key":       {in: testPublicKeyA, want: []string{testPublicKeyA}},
+		"trailing newline": {in: testPublicKeyA + "\n", want: []string{testPublicKeyA}},
+		"surrounding whitespace": {
+			in: "  " + testPublicKeyA + "  \n", want: []string{testPublicKeyA},
+		},
+		"multiple keys": {
+			in:   testPublicKeyA + "\n" + testPublicKeyB + "\n",
+			want: []string{testPublicKeyA, testPublicKeyB},
+		},
+		"blank and comment lines in between": {
+			in:   "# my keys\n" + testPublicKeyA + "\n\n  # another one\n" + testPublicKeyB + "\n",
+			want: []string{testPublicKeyA, testPublicKeyB},
+		},
+		"key without comment": {
+			in:   strings.TrimSuffix(testPublicKeyA, " a@example.com"),
+			want: []string{strings.TrimSuffix(testPublicKeyA, " a@example.com")},
+		},
+		"key with options": {
+			in:   `no-agent-forwarding ` + testPublicKeyA,
+			want: []string{`no-agent-forwarding ` + testPublicKeyA},
+		},
+		"garbage": {
+			in: "not a key\n", wantErr: "invalid SSH public key on line 1",
+		},
+		"private key": {
+			in:      "-----BEGIN OPENSSH PRIVATE KEY-----\n",
+			wantErr: "invalid SSH public key on line 1",
+		},
+		"reports the offending line": {
+			in:      "# my keys\n" + testPublicKeyA + "\n\nnot a key\n",
+			wantErr: "invalid SSH public key on line 4",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			is := require.New(t)
+
+			keys, err := ParseAuthorizedKeys(strings.NewReader(tt.in))
+			if tt.wantErr != "" {
+				is.ErrorContains(err, tt.wantErr)
+				is.Nil(keys)
+				return
+			}
+
+			is.NoError(err)
+			is.Equal(tt.want, keys)
+		})
+	}
+}

--- a/create/cloudvm.go
+++ b/create/cloudvm.go
@@ -28,10 +28,12 @@ type cloudVMCmd struct {
 	OS                  infrastructure.OperatingSystem          `default:"" help:"Operating system to use to boot the VM. Available options: ${cloudvm_os_flavors}"`
 	BootDiskSize        *resource.Quantity                      `default:"20Gi" help:"Configures the size of the boot disk."`
 	Disks               map[string]resource.Quantity            `default:"" help:"Additional disks to mount to the machine."`
-	PublicKeys          []string                                `default:"" help:"SSH public keys to connect to the CloudVM as root. The keys are expected to be in SSH format as defined in RFC4253. Immutable after creation."`
-	PublicKeysFromFiles []*os.File                              `completion-predictor:"file" help:"SSH public key files to connect to the VM as root. The keys are expected to be in SSH format as defined in RFC4253. Immutable after creation."`
-	CloudConfig         string                                  `default:"" help:"Pass custom cloud config data (https://cloudinit.readthedocs.io/en/latest/topics/format.html#cloud-config-data) to the cloud VM. If a CloudConfig is passed, the PublicKey parameter is ignored. Immutable after creation."`
-	CloudConfigFromFile *os.File                                `completion-predictor:"file" help:"Pass custom cloud config data (https://cloudinit.readthedocs.io/en/latest/topics/format.html#cloud-config-data) from a file. Takes precedence. If a CloudConfig is passed, the PublicKey parameter is ignored. Immutable after creation."`
+	SSHKeysFlags        `set:"ssh_keys_purpose=to connect to the CloudVM as root. Immutable after creation"`
+	CloudConfig         string   `default:"" help:"Pass custom cloud config data (https://cloudinit.readthedocs.io/en/latest/topics/format.html#cloud-config-data) to the cloud VM. If a cloud config is passed, --ssh-keys and --ssh-keys-from-files are ignored. Immutable after creation."`
+	CloudConfigFromFile *os.File `completion-predictor:"file" help:"Pass custom cloud config data (https://cloudinit.readthedocs.io/en/latest/topics/format.html#cloud-config-data) from a file. Takes precedence over --cloud-config. If a cloud config is passed, --ssh-keys and --ssh-keys-from-files are ignored. Immutable after creation."`
+
+	// Deprecated Flags
+	DeprecatedKeysFlags `prefix:"public-"`
 }
 
 func (cmd *cloudVMCmd) Run(ctx context.Context, client *api.Client) error {
@@ -126,35 +128,21 @@ func (cmd *cloudVMCmd) newCloudVM(namespace string) (*infrastructure.CloudVirtua
 	return cloudVM, nil
 }
 
-// publicKeys returns the validated SSH public keys of both --public-keys and
+// publicKeys returns the validated SSH public keys of --ssh-keys and
+// --ssh-keys-from-files, followed by those of the deprecated --public-keys and
 // --public-keys-from-files, in that order.
-// A source which holds no key at all is not an error,
-// but it is warned about as it is most likely not what the user intended.
 func (cmd *cloudVMCmd) publicKeys() ([]string, error) {
-	keys, err := ParseAuthorizedKeys(strings.NewReader(strings.Join(cmd.PublicKeys, "\n")))
+	keys, err := cmd.SSHKeysFlags.Keys(&cmd.Writer, "")
 	if err != nil {
-		return nil, fmt.Errorf("error reading --public-keys: %w", err)
-	}
-	if len(cmd.PublicKeys) != 0 && len(keys) == 0 {
-		cmd.Warningf("no SSH public key found in --public-keys")
+		return nil, err
 	}
 
-	for _, file := range cmd.PublicKeysFromFiles {
-		if file == nil {
-			continue
-		}
-
-		fileKeys, err := ParseAuthorizedKeys(file)
-		if err != nil {
-			return nil, fmt.Errorf("error reading public keys file %q: %w", file.Name(), err)
-		}
-		if len(fileKeys) == 0 {
-			cmd.Warningf("no SSH public key found in %q", file.Name())
-		}
-		keys = append(keys, fileKeys...)
+	deprecated, err := cmd.DeprecatedKeysFlags.Keys(&cmd.Writer, "public-", "")
+	if err != nil {
+		return nil, err
 	}
 
-	return keys, nil
+	return append(keys, deprecated...), nil
 }
 
 // CloudVMKongVars returns all variables which are used in the application

--- a/create/cloudvm.go
+++ b/create/cloudvm.go
@@ -31,7 +31,7 @@ type cloudVMCmd struct {
 	PublicKeys          []string                                `default:"" help:"SSH public keys to connect to the CloudVM as root. The keys are expected to be in SSH format as defined in RFC4253. Immutable after creation."`
 	PublicKeysFromFiles []*os.File                              `default:"" completion-predictor:"file" help:"SSH public key files to connect to the VM as root. The keys are expected to be in SSH format as defined in RFC4253. Immutable after creation."`
 	CloudConfig         string                                  `default:"" help:"Pass custom cloud config data (https://cloudinit.readthedocs.io/en/latest/topics/format.html#cloud-config-data) to the cloud VM. If a CloudConfig is passed, the PublicKey parameter is ignored. Immutable after creation."`
-	CloudConfigFromFile *os.File                                `default:"" completion-predictor:"file" help:"Pass custom cloud config data (https://cloudinit.readthedocs.io/en/latest/topics/format.html#cloud-config-data) from a file. Takes precedence. If a CloudConfig is passed, the PublicKey parameter is ignored. Immutable after creation."`
+	CloudConfigFromFile *os.File                                `completion-predictor:"file" help:"Pass custom cloud config data (https://cloudinit.readthedocs.io/en/latest/topics/format.html#cloud-config-data) from a file. Takes precedence. If a CloudConfig is passed, the PublicKey parameter is ignored. Immutable after creation."`
 }
 
 func (cmd *cloudVMCmd) Run(ctx context.Context, client *api.Client) error {

--- a/create/cloudvm.go
+++ b/create/cloudvm.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"slices"
 	"strings"
 
 	"github.com/alecthomas/kong"
@@ -30,7 +29,7 @@ type cloudVMCmd struct {
 	BootDiskSize        *resource.Quantity                      `default:"20Gi" help:"Configures the size of the boot disk."`
 	Disks               map[string]resource.Quantity            `default:"" help:"Additional disks to mount to the machine."`
 	PublicKeys          []string                                `default:"" help:"SSH public keys to connect to the CloudVM as root. The keys are expected to be in SSH format as defined in RFC4253. Immutable after creation."`
-	PublicKeysFromFiles []*os.File                              `default:"" completion-predictor:"file" help:"SSH public key files to connect to the VM as root. The keys are expected to be in SSH format as defined in RFC4253. Immutable after creation."`
+	PublicKeysFromFiles []*os.File                              `completion-predictor:"file" help:"SSH public key files to connect to the VM as root. The keys are expected to be in SSH format as defined in RFC4253. Immutable after creation."`
 	CloudConfig         string                                  `default:"" help:"Pass custom cloud config data (https://cloudinit.readthedocs.io/en/latest/topics/format.html#cloud-config-data) to the cloud VM. If a CloudConfig is passed, the PublicKey parameter is ignored. Immutable after creation."`
 	CloudConfigFromFile *os.File                                `completion-predictor:"file" help:"Pass custom cloud config data (https://cloudinit.readthedocs.io/en/latest/topics/format.html#cloud-config-data) from a file. Takes precedence. If a CloudConfig is passed, the PublicKey parameter is ignored. Immutable after creation."`
 }
@@ -74,17 +73,9 @@ func (cmd *cloudVMCmd) Run(ctx context.Context, client *api.Client) error {
 func (cmd *cloudVMCmd) newCloudVM(namespace string) (*infrastructure.CloudVirtualMachine, error) {
 	name := getName(cmd.Name)
 
-	publicKeys := slices.Clone(cmd.PublicKeys)
-	for _, file := range cmd.PublicKeysFromFiles {
-		if file == nil {
-			continue
-		}
-
-		b, err := io.ReadAll(file)
-		if err != nil {
-			return nil, fmt.Errorf("error reading public keys file: %w", err)
-		}
-		publicKeys = append(publicKeys, string(b))
+	publicKeys, err := cmd.publicKeys()
+	if err != nil {
+		return nil, err
 	}
 
 	cloudVM := &infrastructure.CloudVirtualMachine{
@@ -133,6 +124,37 @@ func (cmd *cloudVMCmd) newCloudVM(namespace string) (*infrastructure.CloudVirtua
 	}
 
 	return cloudVM, nil
+}
+
+// publicKeys returns the validated SSH public keys of both --public-keys and
+// --public-keys-from-files, in that order.
+// A source which holds no key at all is not an error,
+// but it is warned about as it is most likely not what the user intended.
+func (cmd *cloudVMCmd) publicKeys() ([]string, error) {
+	keys, err := ParseAuthorizedKeys(strings.NewReader(strings.Join(cmd.PublicKeys, "\n")))
+	if err != nil {
+		return nil, fmt.Errorf("error reading --public-keys: %w", err)
+	}
+	if len(cmd.PublicKeys) != 0 && len(keys) == 0 {
+		cmd.Warningf("no SSH public key found in --public-keys")
+	}
+
+	for _, file := range cmd.PublicKeysFromFiles {
+		if file == nil {
+			continue
+		}
+
+		fileKeys, err := ParseAuthorizedKeys(file)
+		if err != nil {
+			return nil, fmt.Errorf("error reading public keys file %q: %w", file.Name(), err)
+		}
+		if len(fileKeys) == 0 {
+			cmd.Warningf("no SSH public key found in %q", file.Name())
+		}
+		keys = append(keys, fileKeys...)
+	}
+
+	return keys, nil
 }
 
 // CloudVMKongVars returns all variables which are used in the application

--- a/create/cloudvm.go
+++ b/create/cloudvm.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/alecthomas/kong"
@@ -61,8 +62,7 @@ func (cmd *cloudVMCmd) Run(ctx context.Context, client *api.Client) error {
 			}
 			return false, nil
 		},
-	},
-	); err != nil {
+	}); err != nil {
 		return err
 	}
 
@@ -73,6 +73,19 @@ func (cmd *cloudVMCmd) Run(ctx context.Context, client *api.Client) error {
 
 func (cmd *cloudVMCmd) newCloudVM(namespace string) (*infrastructure.CloudVirtualMachine, error) {
 	name := getName(cmd.Name)
+
+	publicKeys := slices.Clone(cmd.PublicKeys)
+	for _, file := range cmd.PublicKeysFromFiles {
+		if file == nil {
+			continue
+		}
+
+		b, err := io.ReadAll(file)
+		if err != nil {
+			return nil, fmt.Errorf("error reading public keys file: %w", err)
+		}
+		publicKeys = append(publicKeys, string(b))
+	}
 
 	cloudVM := &infrastructure.CloudVirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{
@@ -92,28 +105,11 @@ func (cmd *cloudVMCmd) newCloudVM(namespace string) (*infrastructure.CloudVirtua
 				Hostname:    cmd.Hostname,
 				PowerState:  cmd.PowerState,
 				OS:          infrastructure.CloudVirtualMachineOS(cmd.OS),
-				PublicKeys:  cmd.PublicKeys,
+				PublicKeys:  publicKeys,
 				CloudConfig: cmd.CloudConfig,
 				ReverseDNS:  cmd.ReverseDNS,
 			},
 		},
-	}
-
-	if len(cmd.PublicKeysFromFiles) != 0 {
-		cloudVM.Spec.ForProvider.PublicKeys = cmd.PublicKeys
-		var keys []string
-		for _, file := range cmd.PublicKeysFromFiles {
-			if file == nil {
-				continue
-			}
-
-			b, err := io.ReadAll(file)
-			if err != nil {
-				return nil, fmt.Errorf("error reading public keys file: %w", err)
-			}
-			keys = append(keys, string(b))
-		}
-		cloudVM.Spec.ForProvider.PublicKeys = keys
 	}
 
 	if cmd.CloudConfigFromFile != nil {

--- a/create/cloudvm_test.go
+++ b/create/cloudvm_test.go
@@ -98,6 +98,44 @@ func parseCloudVM(t *testing.T, args ...string) *cloudVMCmd {
 	return cmd
 }
 
+// TestCloudVMPublicKeys asserts that --public-keys and --public-keys-from-files
+// complement each other. Keys given via files used to replace the inline ones.
+func TestCloudVMPublicKeys(t *testing.T) {
+	t.Parallel()
+
+	const (
+		inlineKey = "ssh-ed25519 AAAAC3Nzinline inline"
+		fileKey   = "ssh-ed25519 AAAAC3Nzfile file"
+	)
+
+	keyFile := filepath.Join(t.TempDir(), "id_ed25519.pub")
+	require.NoError(t, os.WriteFile(keyFile, []byte(fileKey), 0o600))
+
+	tests := map[string]struct {
+		args []string
+		want []string
+	}{
+		"none":   {args: nil, want: nil},
+		"inline": {args: []string{`--public-keys=` + inlineKey}, want: []string{inlineKey}},
+		"file":   {args: []string{`--public-keys-from-files=` + keyFile}, want: []string{fileKey}},
+		"both": {
+			args: []string{`--public-keys=` + inlineKey, `--public-keys-from-files=` + keyFile},
+			want: []string{inlineKey, fileKey},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			is := require.New(t)
+
+			cloudVM, err := parseCloudVM(t, append([]string{`test-cloudvm`}, tt.args...)...).newCloudVM("default")
+			is.NoError(err)
+			is.Equal(tt.want, cloudVM.Spec.ForProvider.PublicKeys)
+		})
+	}
+}
+
 // TestCloudVMFileFlagsRegression is a regression test for `create cloudvm`
 // failing with "error reading cloudconfig file: read <cwd>: is a directory" on
 // every invocation that did not pass --cloud-config-from-file.

--- a/create/cloudvm_test.go
+++ b/create/cloudvm_test.go
@@ -1,6 +1,7 @@
 package create
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"github.com/alecthomas/kong"
 	infrastructure "github.com/ninech/apis/infrastructure/v1alpha1"
 	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/internal/format"
 	"github.com/ninech/nctl/internal/test"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -98,22 +100,42 @@ func parseCloudVM(t *testing.T, args ...string) *cloudVMCmd {
 	return cmd
 }
 
+// writeKeyFile writes content to a file in a fresh temporary directory and
+// returns its path.
+func writeKeyFile(t *testing.T, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
 // TestCloudVMPublicKeys asserts that --public-keys and --public-keys-from-files
 // complement each other. Keys given via files used to replace the inline ones.
+// It also covers that a file may hold more than one key and that the keys are
+// validated no matter which of the two flags they come from.
 func TestCloudVMPublicKeys(t *testing.T) {
 	t.Parallel()
 
 	const (
-		inlineKey = "ssh-ed25519 AAAAC3Nzinline inline"
-		fileKey   = "ssh-ed25519 AAAAC3Nzfile file"
+		inlineKey = testPublicKeyA
+		fileKey   = testPublicKeyB
 	)
 
-	keyFile := filepath.Join(t.TempDir(), "id_ed25519.pub")
-	require.NoError(t, os.WriteFile(keyFile, []byte(fileKey), 0o600))
+	var (
+		keyFile      = writeKeyFile(t, "id_ed25519.pub", fileKey+"\n")
+		twoKeysFile  = writeKeyFile(t, "authorized_keys", "# my keys\n"+fileKey+"\n\n"+inlineKey+"\n")
+		emptyFile    = writeKeyFile(t, "empty.pub", "# no keys in here\n")
+		invalidFile  = writeKeyFile(t, "invalid.pub", "not a key\n")
+		trailingFile = writeKeyFile(t, "trailing.pub", "  "+fileKey+"  \n\n")
+	)
 
 	tests := map[string]struct {
-		args []string
-		want []string
+		args     []string
+		want     []string
+		wantWarn string
+		wantErr  string
 	}{
 		"none":   {args: nil, want: nil},
 		"inline": {args: []string{`--public-keys=` + inlineKey}, want: []string{inlineKey}},
@@ -122,6 +144,44 @@ func TestCloudVMPublicKeys(t *testing.T) {
 			args: []string{`--public-keys=` + inlineKey, `--public-keys-from-files=` + keyFile},
 			want: []string{inlineKey, fileKey},
 		},
+		"multiple files": {
+			args: []string{`--public-keys-from-files=` + keyFile, `--public-keys-from-files=` + trailingFile},
+			want: []string{fileKey, fileKey},
+		},
+		"multiple keys in one file": {
+			args: []string{`--public-keys-from-files=` + twoKeysFile},
+			want: []string{fileKey, inlineKey},
+		},
+		"whitespace is trimmed": {
+			args: []string{`--public-keys-from-files=` + trailingFile},
+			want: []string{fileKey},
+		},
+		// a file may hold nothing but comments, that is only worth a warning as
+		// long as at least one key is configured somewhere.
+		"file without keys": {
+			args:     []string{`--public-keys=` + inlineKey, `--public-keys-from-files=` + emptyFile},
+			want:     []string{inlineKey},
+			wantWarn: `no SSH public key found in "` + emptyFile + `"`,
+		},
+		"inline without keys": {
+			args:     []string{`--public-keys=# a comment`, `--public-keys-from-files=` + keyFile},
+			want:     []string{fileKey},
+			wantWarn: "no SSH public key found in --public-keys",
+		},
+		"file with an invalid key": {
+			args: []string{`--public-keys-from-files=` + invalidFile}, wantErr: "invalid SSH public key on line 1",
+		},
+		"invalid inline key": {
+			args: []string{`--public-keys=not a key`}, wantErr: "error reading --public-keys: invalid SSH public key on line 1",
+		},
+		"multiple inline keys": {
+			args: []string{`--public-keys=` + inlineKey, `--public-keys=` + fileKey},
+			want: []string{inlineKey, fileKey},
+		},
+		"reports the offending inline key": {
+			args:    []string{`--public-keys=` + inlineKey, `--public-keys=not a key`},
+			wantErr: "error reading --public-keys: invalid SSH public key on line 2",
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -129,9 +189,23 @@ func TestCloudVMPublicKeys(t *testing.T) {
 
 			is := require.New(t)
 
-			cloudVM, err := parseCloudVM(t, append([]string{`test-cloudvm`}, tt.args...)...).newCloudVM("default")
+			out := &bytes.Buffer{}
+			cmd := parseCloudVM(t, append([]string{`test-cloudvm`}, tt.args...)...)
+			cmd.Writer = format.NewWriter(out)
+
+			cloudVM, err := cmd.newCloudVM("default")
+			if tt.wantErr != "" {
+				is.ErrorContains(err, tt.wantErr)
+				return
+			}
+
 			is.NoError(err)
 			is.Equal(tt.want, cloudVM.Spec.ForProvider.PublicKeys)
+			if tt.wantWarn == "" {
+				is.Empty(out.String())
+			} else {
+				is.Contains(out.String(), tt.wantWarn)
+			}
 		})
 	}
 }
@@ -144,6 +218,9 @@ func TestCloudVMPublicKeys(t *testing.T) {
 // the current working directory and open it, so the flag is never nil and the
 // nil checks in newCloudVM do not guard anything. The file backed flags must
 // therefore stay unset when they are not passed.
+//
+// The same `default:""` also made Kong decode every occurrence of a repeated
+// file flag after the first one to nil, silently dropping those files.
 func TestCloudVMFileFlagsRegression(t *testing.T) {
 	t.Parallel()
 
@@ -170,18 +247,21 @@ func TestCloudVMFileFlagsRegression(t *testing.T) {
 		dir := t.TempDir()
 		cloudConfig := filepath.Join(dir, "cloud-config.yaml")
 		is.NoError(os.WriteFile(cloudConfig, []byte("#cloud-config\n"), 0o600))
-		publicKey := filepath.Join(dir, "id_ed25519.pub")
-		is.NoError(os.WriteFile(publicKey, []byte("ssh-ed25519 AAAAC3Nz test\n"), 0o600))
 
 		cmd := parseCloudVM(t, `test-cloudvm`,
 			`--cloud-config-from-file=`+cloudConfig,
-			`--public-keys-from-files=`+publicKey,
+			`--public-keys-from-files=`+writeKeyFile(t, "a.pub", testPublicKeyA),
+			`--public-keys-from-files=`+writeKeyFile(t, "b.pub", testPublicKeyB),
 		)
+
+		// every repeated occurrence of the flag has to be decoded, not just
+		// the first one.
+		is.Len(cmd.PublicKeysFromFiles, 2)
+		is.NotContains(cmd.PublicKeysFromFiles, nil)
 
 		cloudVM, err := cmd.newCloudVM("default")
 		is.NoError(err)
 		is.Contains(cloudVM.Spec.ForProvider.CloudConfig, "#cloud-config")
-		is.Len(cloudVM.Spec.ForProvider.PublicKeys, 1)
-		is.Contains(cloudVM.Spec.ForProvider.PublicKeys[0], "ssh-ed25519 AAAAC3Nz test")
+		is.Equal([]string{testPublicKeyA, testPublicKeyB}, cloudVM.Spec.ForProvider.PublicKeys)
 	})
 }

--- a/create/cloudvm_test.go
+++ b/create/cloudvm_test.go
@@ -1,13 +1,18 @@
 package create
 
 import (
+	"io"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/alecthomas/kong"
 	infrastructure "github.com/ninech/apis/infrastructure/v1alpha1"
 	"github.com/ninech/nctl/api"
 	"github.com/ninech/nctl/internal/test"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -79,4 +84,66 @@ func TestCloudVM(t *testing.T) {
 			}
 		})
 	}
+}
+
+// parseCloudVM parses args into a cloudVMCmd the same way the real CLI does,
+// so that Kong's defaults and mappers are exercised.
+func parseCloudVM(t *testing.T, args ...string) *cloudVMCmd {
+	t.Helper()
+
+	cmd := &cloudVMCmd{}
+	_, err := kong.Must(cmd, CloudVMKongVars(), kong.BindTo(io.Discard, (*io.Writer)(nil))).Parse(args)
+	require.NoError(t, err)
+
+	return cmd
+}
+
+// TestCloudVMFileFlagsRegression is a regression test for `create cloudvm`
+// failing with "error reading cloudconfig file: read <cwd>: is a directory" on
+// every invocation that did not pass --cloud-config-from-file.
+//
+// Giving an *os.File flag a `default:""` makes Kong resolve the empty path to
+// the current working directory and open it, so the flag is never nil and the
+// nil checks in newCloudVM do not guard anything. The file backed flags must
+// therefore stay unset when they are not passed.
+func TestCloudVMFileFlagsRegression(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unset", func(t *testing.T) {
+		t.Parallel()
+
+		is := require.New(t)
+
+		cmd := parseCloudVM(t, `test-cloudvm`)
+		is.Nil(cmd.CloudConfigFromFile)
+		is.Empty(cmd.PublicKeysFromFiles)
+
+		cloudVM, err := cmd.newCloudVM("default")
+		is.NoError(err)
+		is.Empty(cloudVM.Spec.ForProvider.CloudConfig)
+		is.Empty(cloudVM.Spec.ForProvider.PublicKeys)
+	})
+
+	t.Run("set", func(t *testing.T) {
+		t.Parallel()
+
+		is := require.New(t)
+
+		dir := t.TempDir()
+		cloudConfig := filepath.Join(dir, "cloud-config.yaml")
+		is.NoError(os.WriteFile(cloudConfig, []byte("#cloud-config\n"), 0o600))
+		publicKey := filepath.Join(dir, "id_ed25519.pub")
+		is.NoError(os.WriteFile(publicKey, []byte("ssh-ed25519 AAAAC3Nz test\n"), 0o600))
+
+		cmd := parseCloudVM(t, `test-cloudvm`,
+			`--cloud-config-from-file=`+cloudConfig,
+			`--public-keys-from-files=`+publicKey,
+		)
+
+		cloudVM, err := cmd.newCloudVM("default")
+		is.NoError(err)
+		is.Contains(cloudVM.Spec.ForProvider.CloudConfig, "#cloud-config")
+		is.Len(cloudVM.Spec.ForProvider.PublicKeys, 1)
+		is.Contains(cloudVM.Spec.ForProvider.PublicKeys[0], "ssh-ed25519 AAAAC3Nz test")
+	})
 }

--- a/create/cloudvm_test.go
+++ b/create/cloudvm_test.go
@@ -111,10 +111,11 @@ func writeKeyFile(t *testing.T, name, content string) string {
 	return path
 }
 
-// TestCloudVMPublicKeys asserts that --public-keys and --public-keys-from-files
+// TestCloudVMPublicKeys asserts that --ssh-keys and --ssh-keys-from-files
 // complement each other. Keys given via files used to replace the inline ones.
-// It also covers that a file may hold more than one key and that the keys are
-// validated no matter which of the two flags they come from.
+// It also covers that a file may hold more than one key, that the keys are
+// validated no matter which of the flags they come from, and that the
+// deprecated --public-keys and --public-keys-from-files still contribute.
 func TestCloudVMPublicKeys(t *testing.T) {
 	t.Parallel()
 
@@ -131,6 +132,8 @@ func TestCloudVMPublicKeys(t *testing.T) {
 		trailingFile = writeKeyFile(t, "trailing.pub", "  "+fileKey+"  \n\n")
 	)
 
+	const deprecationWarning = "--public-keys and --public-keys-from-files are deprecated, use --ssh-keys and --ssh-keys-from-files instead"
+
 	tests := map[string]struct {
 		args     []string
 		want     []string
@@ -138,49 +141,76 @@ func TestCloudVMPublicKeys(t *testing.T) {
 		wantErr  string
 	}{
 		"none":   {args: nil, want: nil},
-		"inline": {args: []string{`--public-keys=` + inlineKey}, want: []string{inlineKey}},
-		"file":   {args: []string{`--public-keys-from-files=` + keyFile}, want: []string{fileKey}},
+		"inline": {args: []string{`--ssh-keys=` + inlineKey}, want: []string{inlineKey}},
+		"file":   {args: []string{`--ssh-keys-from-files=` + keyFile}, want: []string{fileKey}},
 		"both": {
-			args: []string{`--public-keys=` + inlineKey, `--public-keys-from-files=` + keyFile},
+			args: []string{`--ssh-keys=` + inlineKey, `--ssh-keys-from-files=` + keyFile},
 			want: []string{inlineKey, fileKey},
 		},
 		"multiple files": {
-			args: []string{`--public-keys-from-files=` + keyFile, `--public-keys-from-files=` + trailingFile},
+			args: []string{`--ssh-keys-from-files=` + keyFile, `--ssh-keys-from-files=` + trailingFile},
 			want: []string{fileKey, fileKey},
 		},
 		"multiple keys in one file": {
-			args: []string{`--public-keys-from-files=` + twoKeysFile},
+			args: []string{`--ssh-keys-from-files=` + twoKeysFile},
 			want: []string{fileKey, inlineKey},
 		},
 		"whitespace is trimmed": {
-			args: []string{`--public-keys-from-files=` + trailingFile},
+			args: []string{`--ssh-keys-from-files=` + trailingFile},
 			want: []string{fileKey},
 		},
 		// a file may hold nothing but comments, that is only worth a warning as
 		// long as at least one key is configured somewhere.
 		"file without keys": {
-			args:     []string{`--public-keys=` + inlineKey, `--public-keys-from-files=` + emptyFile},
+			args:     []string{`--ssh-keys=` + inlineKey, `--ssh-keys-from-files=` + emptyFile},
 			want:     []string{inlineKey},
 			wantWarn: `no SSH public key found in "` + emptyFile + `"`,
 		},
 		"inline without keys": {
-			args:     []string{`--public-keys=# a comment`, `--public-keys-from-files=` + keyFile},
+			args:     []string{`--ssh-keys=# a comment`, `--ssh-keys-from-files=` + keyFile},
 			want:     []string{fileKey},
-			wantWarn: "no SSH public key found in --public-keys",
+			wantWarn: "no SSH public key found in --ssh-keys",
 		},
 		"file with an invalid key": {
-			args: []string{`--public-keys-from-files=` + invalidFile}, wantErr: "invalid SSH public key on line 1",
+			args: []string{`--ssh-keys-from-files=` + invalidFile}, wantErr: "invalid SSH public key on line 1",
 		},
 		"invalid inline key": {
-			args: []string{`--public-keys=not a key`}, wantErr: "error reading --public-keys: invalid SSH public key on line 1",
+			args: []string{`--ssh-keys=not a key`}, wantErr: "error reading --ssh-keys: invalid SSH public key on line 1",
 		},
 		"multiple inline keys": {
-			args: []string{`--public-keys=` + inlineKey, `--public-keys=` + fileKey},
+			args: []string{`--ssh-keys=` + inlineKey, `--ssh-keys=` + fileKey},
 			want: []string{inlineKey, fileKey},
 		},
+		// commas separate the options of an authorized_keys line, they must not
+		// be mistaken for a separator between keys.
+		"inline key with options": {
+			args: []string{`--ssh-keys=restrict,pty ` + inlineKey},
+			want: []string{`restrict,pty ` + inlineKey},
+		},
 		"reports the offending inline key": {
-			args:    []string{`--public-keys=` + inlineKey, `--public-keys=not a key`},
-			wantErr: "error reading --public-keys: invalid SSH public key on line 2",
+			args:    []string{`--ssh-keys=` + inlineKey, `--ssh-keys=not a key`},
+			wantErr: "error reading --ssh-keys: invalid SSH public key on line 2",
+		},
+		// the deprecated flags keep working, they are merged after the keys of
+		// the flags which replace them.
+		"deprecated inline": {
+			args:     []string{`--public-keys=` + inlineKey},
+			want:     []string{inlineKey},
+			wantWarn: deprecationWarning,
+		},
+		"deprecated file": {
+			args:     []string{`--public-keys-from-files=` + keyFile},
+			want:     []string{fileKey},
+			wantWarn: deprecationWarning,
+		},
+		"deprecated and current": {
+			args:     []string{`--public-keys=` + fileKey, `--ssh-keys=` + inlineKey},
+			want:     []string{inlineKey, fileKey},
+			wantWarn: deprecationWarning,
+		},
+		"invalid deprecated inline key": {
+			args:    []string{`--public-keys=not a key`},
+			wantErr: "error reading --public-keys: invalid SSH public key on line 1",
 		},
 	}
 	for name, tt := range tests {
@@ -231,7 +261,7 @@ func TestCloudVMFileFlagsRegression(t *testing.T) {
 
 		cmd := parseCloudVM(t, `test-cloudvm`)
 		is.Nil(cmd.CloudConfigFromFile)
-		is.Empty(cmd.PublicKeysFromFiles)
+		is.Empty(cmd.SSHKeysFromFiles)
 
 		cloudVM, err := cmd.newCloudVM("default")
 		is.NoError(err)
@@ -250,14 +280,14 @@ func TestCloudVMFileFlagsRegression(t *testing.T) {
 
 		cmd := parseCloudVM(t, `test-cloudvm`,
 			`--cloud-config-from-file=`+cloudConfig,
-			`--public-keys-from-files=`+writeKeyFile(t, "a.pub", testPublicKeyA),
-			`--public-keys-from-files=`+writeKeyFile(t, "b.pub", testPublicKeyB),
+			`--ssh-keys-from-files=`+writeKeyFile(t, "a.pub", testPublicKeyA),
+			`--ssh-keys-from-files=`+writeKeyFile(t, "b.pub", testPublicKeyB),
 		)
 
 		// every repeated occurrence of the flag has to be decoded, not just
 		// the first one.
-		is.Len(cmd.PublicKeysFromFiles, 2)
-		is.NotContains(cmd.PublicKeysFromFiles, nil)
+		is.Len(cmd.SSHKeysFromFiles, 2)
+		is.NotContains(cmd.SSHKeysFromFiles, nil)
 
 		cloudVM, err := cmd.newCloudVM("default")
 		is.NoError(err)

--- a/create/mysql.go
+++ b/create/mysql.go
@@ -1,10 +1,8 @@
 package create
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,11 +19,10 @@ import (
 
 type mySQLCmd struct {
 	ResourceCmd
-	Location              meta.LocationName                      `placeholder:"${mysql_location_default}" help:"Where the MySQL instance is created. Available locations are: ${mysql_location_options}"`
-	MachineType           string                                 `placeholder:"${mysql_machine_default}" help:"Sizing for a particular MySQL instance. Available types: ${mysql_machine_types}"`
-	AllowedCidrs          []meta.IPv4CIDR                        `placeholder:"203.0.113.1/32" help:"IP addresses allowed to connect to the instance."`
-	SSHKeys               []storage.SSHKey                       `help:"SSH public keys allowed to connect to the database server in order to up-/download and directly restore database backups."`
-	SSHKeysFile           *os.File                               `completion-predictor:"file" help:"Path to a file containing a list of SSH public keys (see above), separated by newlines. Lines prefixed with # are ignored."`
+	Location              meta.LocationName `placeholder:"${mysql_location_default}" help:"Where the MySQL instance is created. Available locations are: ${mysql_location_options}"`
+	MachineType           string            `placeholder:"${mysql_machine_default}" help:"Sizing for a particular MySQL instance. Available types: ${mysql_machine_types}"`
+	AllowedCidrs          []meta.IPv4CIDR   `placeholder:"203.0.113.1/32" help:"IP addresses allowed to connect to the instance."`
+	DatabaseSSHKeysFlags  `set:"ssh_keys_purpose=allowed to connect to the database server in order to up-/download and directly restore database backups"`
 	SQLMode               *[]storage.MySQLMode                   `placeholder:"\"MODE1, MODE2, ...\"" help:"Configures the sql_mode setting. Modes affect the SQL syntax MySQL supports and the data validation checks it performs. Defaults to: ${mysql_mode}"`
 	CharacterSetName      string                                 `placeholder:"${mysql_charset}" help:"Configures the character_set_server variable."`
 	CharacterSetCollation string                                 `placeholder:"${mysql_collation}" help:"Configures the collation_server variable."`
@@ -36,17 +33,10 @@ type mySQLCmd struct {
 }
 
 func (cmd *mySQLCmd) Run(ctx context.Context, client *api.Client) error {
-	if cmd.SSHKeysFile != nil {
-		defer cmd.SSHKeysFile.Close()
-
-		keys, err := ParseSSHKeys(cmd.SSHKeysFile)
-		if err != nil {
-			return err
-		}
-		cmd.SSHKeys = keys
+	mysql, err := cmd.newMySQL(client.Project)
+	if err != nil {
+		return err
 	}
-
-	mysql := cmd.newMySQL(client.Project)
 
 	c := cmd.newCreator(client, mysql, storage.MySQLKind)
 	ctx, cancel := context.WithTimeout(ctx, cmd.WaitTimeout)
@@ -72,8 +62,13 @@ func (cmd *mySQLCmd) Run(ctx context.Context, client *api.Client) error {
 	})
 }
 
-func (cmd *mySQLCmd) newMySQL(namespace string) *storage.MySQL {
+func (cmd *mySQLCmd) newMySQL(namespace string) (*storage.MySQL, error) {
 	name := getName(cmd.Name)
+
+	sshKeys, err := cmd.StorageKeys(&cmd.Writer)
+	if err != nil {
+		return nil, err
+	}
 
 	mySQL := &storage.MySQL{
 		ObjectMeta: metav1.ObjectMeta{
@@ -90,8 +85,8 @@ func (cmd *mySQLCmd) newMySQL(namespace string) *storage.MySQL {
 			ForProvider: storage.MySQLParameters{
 				Location:     cmd.Location,
 				MachineType:  infra.NewMachineType(cmd.MachineType),
-				AllowedCIDRs: []meta.IPv4CIDR{},  // avoid missing parameter error
-				SSHKeys:      []storage.SSHKey{}, // avoid missing parameter error
+				AllowedCIDRs: []meta.IPv4CIDR{}, // avoid missing parameter error
+				SSHKeys:      sshKeys,
 				SQLMode:      cmd.SQLMode,
 				CharacterSet: storage.MySQLCharacterSet{
 					Name:      cmd.CharacterSetName,
@@ -108,11 +103,8 @@ func (cmd *mySQLCmd) newMySQL(namespace string) *storage.MySQL {
 	if cmd.AllowedCidrs != nil {
 		mySQL.Spec.ForProvider.AllowedCIDRs = cmd.AllowedCidrs
 	}
-	if cmd.SSHKeys != nil {
-		mySQL.Spec.ForProvider.SSHKeys = cmd.SSHKeys
-	}
 
-	return mySQL
+	return mySQL, nil
 }
 
 // MySQLKongVars returns all variables which are used in the MySQL
@@ -132,25 +124,4 @@ func MySQLKongVars() kong.Vars {
 	result["mysql_transaction_isolation"] = string(storage.MySQLTransactionIsolationDefault)
 	result["mysql_backup_retention_days"] = fmt.Sprintf("%d", storage.MySQLBackupRetentionDaysDefault)
 	return result
-}
-
-// ParseSSHKeys parses the SSH keys from the given file.
-func ParseSSHKeys(file *os.File) ([]storage.SSHKey, error) {
-	keys := []storage.SSHKey{}
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-
-		keys = append(keys, storage.SSHKey(scanner.Text()))
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error reading SSH keys file: %w", err)
-	}
-
-	return keys, nil
 }

--- a/create/mysql_test.go
+++ b/create/mysql_test.go
@@ -48,9 +48,11 @@ func TestMySQL(t *testing.T) {
 			want:   storage.MySQLParameters{MachineType: storage.MySQLMachineTypeDefault},
 		},
 		{
-			name:   "sshKeys",
-			create: mySQLCmd{SSHKeys: []storage.SSHKey{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJGG5/nnivrW4zLD4ANLclVT3y68GAg6NOA3HpzFLo5e test@test"}},
-			want:   storage.MySQLParameters{SSHKeys: []storage.SSHKey{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJGG5/nnivrW4zLD4ANLclVT3y68GAg6NOA3HpzFLo5e test@test"}},
+			name: "sshKeys",
+			create: mySQLCmd{DatabaseSSHKeysFlags: DatabaseSSHKeysFlags{
+				SSHKeysFlags: SSHKeysFlags{SSHKeys: []string{testPublicKeyA}},
+			}},
+			want: storage.MySQLParameters{SSHKeys: []storage.SSHKey{testPublicKeyA}},
 		},
 		{
 			name:   "sqlMode",

--- a/create/postgres.go
+++ b/create/postgres.go
@@ -3,7 +3,6 @@ package create
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,27 +19,19 @@ import (
 
 type postgresCmd struct {
 	ResourceCmd
-	Location         meta.LocationName       `placeholder:"${postgres_location_default}" help:"Where the PostgreSQL instance is created. Available locations are: ${postgres_location_options}"`
-	MachineType      string                  `placeholder:"${postgres_machine_default}" help:"Defines the sizing for a particular PostgreSQL instance. Available types: ${postgres_machine_types}"`
-	AllowedCidrs     []meta.IPv4CIDR         `placeholder:"203.0.113.1/32" help:"IP addresses allowed to connect to the instance."`
-	SSHKeys          []storage.SSHKey        `help:"SSH public keys allowed to connect to the database server in order to up-/download and directly restore database backups."`
-	SSHKeysFile      *os.File                `completion-predictor:"file" help:"Path to a file containing a list of SSH public keys (see above), separated by newlines. Lines prefixed with # are ignored."`
-	PostgresVersion  storage.PostgresVersion `placeholder:"${postgres_version_default}" help:"Release version with which the PostgreSQL instance is created. Available versions: ${postgres_versions}"`
-	KeepDailyBackups *int                    `placeholder:"${postgres_backup_retention_days}" help:"Number of daily database backups to keep. Note that setting this to 0, backup will be disabled and existing dumps deleted immediately."`
+	Location             meta.LocationName `placeholder:"${postgres_location_default}" help:"Where the PostgreSQL instance is created. Available locations are: ${postgres_location_options}"`
+	MachineType          string            `placeholder:"${postgres_machine_default}" help:"Defines the sizing for a particular PostgreSQL instance. Available types: ${postgres_machine_types}"`
+	AllowedCidrs         []meta.IPv4CIDR   `placeholder:"203.0.113.1/32" help:"IP addresses allowed to connect to the instance."`
+	DatabaseSSHKeysFlags `set:"ssh_keys_purpose=allowed to connect to the database server in order to up-/download and directly restore database backups"`
+	PostgresVersion      storage.PostgresVersion `placeholder:"${postgres_version_default}" help:"Release version with which the PostgreSQL instance is created. Available versions: ${postgres_versions}"`
+	KeepDailyBackups     *int                    `placeholder:"${postgres_backup_retention_days}" help:"Number of daily database backups to keep. Note that setting this to 0, backup will be disabled and existing dumps deleted immediately."`
 }
 
 func (cmd *postgresCmd) Run(ctx context.Context, client *api.Client) error {
-	if cmd.SSHKeysFile != nil {
-		defer cmd.SSHKeysFile.Close()
-
-		keys, err := ParseSSHKeys(cmd.SSHKeysFile)
-		if err != nil {
-			return err
-		}
-		cmd.SSHKeys = keys
+	postgres, err := cmd.newPostgres(client.Project)
+	if err != nil {
+		return err
 	}
-
-	postgres := cmd.newPostgres(client.Project)
 
 	c := cmd.newCreator(client, postgres, storage.PostgresKind)
 	ctx, cancel := context.WithTimeout(ctx, cmd.WaitTimeout)
@@ -66,8 +57,13 @@ func (cmd *postgresCmd) Run(ctx context.Context, client *api.Client) error {
 	})
 }
 
-func (cmd *postgresCmd) newPostgres(namespace string) *storage.Postgres {
+func (cmd *postgresCmd) newPostgres(namespace string) (*storage.Postgres, error) {
 	name := getName(cmd.Name)
+
+	sshKeys, err := cmd.StorageKeys(&cmd.Writer)
+	if err != nil {
+		return nil, err
+	}
 
 	postgres := &storage.Postgres{
 		ObjectMeta: metav1.ObjectMeta{
@@ -84,8 +80,8 @@ func (cmd *postgresCmd) newPostgres(namespace string) *storage.Postgres {
 			ForProvider: storage.PostgresParameters{
 				Location:         cmd.Location,
 				MachineType:      infra.NewMachineType(cmd.MachineType),
-				AllowedCIDRs:     []meta.IPv4CIDR{},  // avoid missing parameter error
-				SSHKeys:          []storage.SSHKey{}, // avoid missing parameter error
+				AllowedCIDRs:     []meta.IPv4CIDR{}, // avoid missing parameter error
+				SSHKeys:          sshKeys,
 				Version:          cmd.PostgresVersion,
 				KeepDailyBackups: cmd.KeepDailyBackups,
 			},
@@ -95,11 +91,8 @@ func (cmd *postgresCmd) newPostgres(namespace string) *storage.Postgres {
 	if cmd.AllowedCidrs != nil {
 		postgres.Spec.ForProvider.AllowedCIDRs = cmd.AllowedCidrs
 	}
-	if cmd.SSHKeys != nil {
-		postgres.Spec.ForProvider.SSHKeys = cmd.SSHKeys
-	}
 
-	return postgres
+	return postgres, nil
 }
 
 // PostgresKongVars returns all variables which are used in the Postgres

--- a/create/postgres_test.go
+++ b/create/postgres_test.go
@@ -48,9 +48,11 @@ func TestPostgres(t *testing.T) {
 			want:   storage.PostgresParameters{MachineType: storage.PostgresMachineTypeDefault},
 		},
 		{
-			name:   "sshKeys",
-			create: postgresCmd{SSHKeys: []storage.SSHKey{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJGG5/nnivrW4zLD4ANLclVT3y68GAg6NOA3HpzFLo5e test@test"}},
-			want:   storage.PostgresParameters{SSHKeys: []storage.SSHKey{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJGG5/nnivrW4zLD4ANLclVT3y68GAg6NOA3HpzFLo5e test@test"}},
+			name: "sshKeys",
+			create: postgresCmd{DatabaseSSHKeysFlags: DatabaseSSHKeysFlags{
+				SSHKeysFlags: SSHKeysFlags{SSHKeys: []string{testPublicKeyA}},
+			}},
+			want: storage.PostgresParameters{SSHKeys: []storage.SSHKey{testPublicKeyA}},
 		},
 		{
 			name:   "allowedCIDRs",

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/mattn/go-isatty v0.0.24
 	github.com/moby/moby v28.5.2+incompatible
 	github.com/moby/term v0.5.2
-	github.com/ninech/apis v0.0.0-20260724082511-e7728fc766fd
+	github.com/ninech/apis v0.0.0-20260806095343-87013cd33259
 	github.com/posener/complete v1.2.3
 	github.com/prometheus/common v0.70.1
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -585,8 +585,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/ninech/apis v0.0.0-20260724082511-e7728fc766fd h1:dJ43vAV/DUsN93YcIfheZiUE5tUY0j+TokCuv6u2Bms=
-github.com/ninech/apis v0.0.0-20260724082511-e7728fc766fd/go.mod h1:fZmFev7Udt8Gu+755TVSjZSNkKwUHcbA4huDoUqrmZA=
+github.com/ninech/apis v0.0.0-20260806095343-87013cd33259 h1:QjBU0u4Y2hBdLpx497Ioi41QlCJRUlv9K9+lgfs1/Pk=
+github.com/ninech/apis v0.0.0-20260806095343-87013cd33259/go.mod h1:fZmFev7Udt8Gu+755TVSjZSNkKwUHcbA4huDoUqrmZA=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=

--- a/update/authorized_keys.go
+++ b/update/authorized_keys.go
@@ -1,0 +1,64 @@
+package update
+
+import (
+	"os"
+
+	storage "github.com/ninech/apis/storage/v1alpha1"
+
+	"github.com/ninech/nctl/create"
+	"github.com/ninech/nctl/internal/format"
+)
+
+// OptionalSSHKeysFlags is [create.SSHKeysFlags] for the update commands, where
+// a flag which was not passed has to be told apart from one which was passed an
+// empty value in order to clear the configured keys. It is embedded and
+// described just like [create.SSHKeysFlags].
+type OptionalSSHKeysFlags struct {
+	// sep:"none" keeps Kong from splitting a value on commas, which would tear
+	// apart the options of an authorized_keys line. Repeat the flag or separate
+	// the keys by newlines to pass more than one.
+	SSHKeys          []string   `sep:"none" placeholder:"ssh-ed25519 AAAA..." help:"SSH public keys ${ssh_keys_purpose=to connect to the resource}. The keys are expected to be in SSH format as defined in RFC4253. Repeat the flag to pass more than one key, pass it an empty value to remove all configured keys."`
+	SSHKeysFromFiles []*os.File `placeholder:"~/.ssh/id_ed25519.pub" completion-predictor:"file" help:"Files holding SSH public keys ${ssh_keys_purpose=to connect to the resource}. Empty lines and lines prefixed with # are ignored."`
+}
+
+// SSHKeysSet reports whether one of the flags was passed at all. If it is false
+// the keys which are already configured have to be kept, while SSHKeysSet
+// together with no keys asks for the configured keys to be removed, which is
+// what passing --ssh-keys= does: sep:"none" makes Kong decode the empty value
+// into a single empty entry, telling the flag apart from one which was never
+// passed.
+func (f OptionalSSHKeysFlags) SSHKeysSet() bool {
+	return len(f.SSHKeys) != 0 || create.AnyFile(f.SSHKeysFromFiles)
+}
+
+// Keys returns the validated SSH public keys of --<prefix>ssh-keys followed by
+// those of --<prefix>ssh-keys-from-files, in that order.
+func (f OptionalSSHKeysFlags) Keys(w *format.Writer, prefix string) ([]string, error) {
+	return create.ReadAuthorizedKeys(w, prefix+"ssh-keys", f.SSHKeys, f.SSHKeysFromFiles)
+}
+
+// DatabaseSSHKeysFlags declares the SSH public key flags of the database update
+// commands, including the deprecated --ssh-keys-file which the repeatable
+// --ssh-keys-from-files replaces.
+type DatabaseSSHKeysFlags struct {
+	OptionalSSHKeysFlags
+
+	// Deprecated Flags
+	SSHKeysFile *os.File `hidden:"" completion-predictor:"file" help:"Deprecated, use --ssh-keys-from-files instead."`
+}
+
+// SSHKeysSet reports whether one of the flags was passed at all.
+func (f DatabaseSSHKeysFlags) SSHKeysSet() bool {
+	return f.OptionalSSHKeysFlags.SSHKeysSet() || f.SSHKeysFile != nil
+}
+
+// StorageKeys returns the validated SSH public keys of all three flags, in the
+// order --ssh-keys, --ssh-keys-from-files and --ssh-keys-file.
+func (f DatabaseSSHKeysFlags) StorageKeys(w *format.Writer) ([]storage.SSHKey, error) {
+	keys, err := f.Keys(w, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return create.StorageKeysWithDeprecatedFile(w, keys, f.SSHKeysFile)
+}

--- a/update/authorized_keys_test.go
+++ b/update/authorized_keys_test.go
@@ -1,0 +1,128 @@
+package update
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	infrastructure "github.com/ninech/apis/infrastructure/v1alpha1"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ninech/nctl/internal/format"
+)
+
+// TestOptionalSSHKeysFlagsSet asserts how the flags report whether they were
+// passed, which is what tells "keep the configured keys" apart from "clear
+// them". A nil entry of a repeated file flag holds nothing to read, so it must
+// not count as passed.
+func TestOptionalSSHKeysFlagsSet(t *testing.T) {
+	t.Parallel()
+
+	is := require.New(t)
+
+	is.False(OptionalSSHKeysFlags{}.SSHKeysSet())
+	is.False(OptionalSSHKeysFlags{SSHKeysFromFiles: []*os.File{nil}}.SSHKeysSet())
+	is.True(OptionalSSHKeysFlags{SSHKeysFromFiles: []*os.File{os.Stdin}}.SSHKeysSet())
+	// the flag passed an empty value, which is how the keys are cleared.
+	is.True(OptionalSSHKeysFlags{SSHKeys: []string{""}}.SSHKeysSet())
+	is.True(OptionalSSHKeysFlags{SSHKeys: []string{testPublicKeyA}}.SSHKeysSet())
+
+	is.False(DatabaseSSHKeysFlags{}.SSHKeysSet())
+	is.False(DatabaseSSHKeysFlags{
+		OptionalSSHKeysFlags: OptionalSSHKeysFlags{SSHKeysFromFiles: []*os.File{nil}},
+	}.SSHKeysSet())
+	is.True(DatabaseSSHKeysFlags{SSHKeysFile: os.Stdin}.SSHKeysSet())
+}
+
+// TestOptionalSSHKeysFlagsDecoding pins how Kong decodes --ssh-keys, which is
+// what [OptionalSSHKeysFlags.Set] relies on to tell "keep the configured keys"
+// apart from "clear them".
+//
+// A repeated flag has to accumulate. The flag used to be declared as a
+// *[]string, where Kong decodes every occurrence into a freshly allocated slice
+// which replaces the previous one, silently dropping all but the last key.
+func TestOptionalSSHKeysFlagsDecoding(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		args     []string
+		wantSet  bool
+		wantKeys []string
+	}{
+		"unset": {},
+		"one key": {
+			args:     []string{`--ssh-keys=` + testPublicKeyA},
+			wantSet:  true,
+			wantKeys: []string{testPublicKeyA},
+		},
+		"repeated": {
+			args:     []string{`--ssh-keys=` + testPublicKeyA, `--ssh-keys=` + testPublicKeyB},
+			wantSet:  true,
+			wantKeys: []string{testPublicKeyA, testPublicKeyB},
+		},
+		"newline separated": {
+			args:     []string{`--ssh-keys=` + testPublicKeyA + "\n" + testPublicKeyB},
+			wantSet:  true,
+			wantKeys: []string{testPublicKeyA, testPublicKeyB},
+		},
+		// an empty value decodes into a single empty entry rather than into no
+		// entry at all, which is what makes it tell itself apart from a flag
+		// which was never passed.
+		"empty value": {
+			args:    []string{`--ssh-keys=`},
+			wantSet: true,
+		},
+		"repeated after an empty value": {
+			args:     []string{`--ssh-keys=`, `--ssh-keys=` + testPublicKeyA},
+			wantSet:  true,
+			wantKeys: []string{testPublicKeyA},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			is := require.New(t)
+
+			flags := &struct{ OptionalSSHKeysFlags }{}
+			_, err := kong.Must(flags).Parse(tt.args)
+			is.NoError(err)
+
+			is.Equal(tt.wantSet, flags.SSHKeysSet())
+
+			w := format.NewWriter(io.Discard)
+			keys, err := flags.Keys(&w, "")
+			is.NoError(err)
+			is.Equal(tt.wantKeys, keys)
+		})
+	}
+}
+
+// TestCloudVMRescueNilKeyFileKeepsKeys asserts that a nil entry of
+// --rescue-ssh-keys-from-files keeps the configured keys. There is nothing to
+// read from it, so treating it as a passed flag would clear them instead.
+func TestCloudVMRescueNilKeyFileKeepsKeys(t *testing.T) {
+	t.Parallel()
+
+	is := require.New(t)
+
+	cloudVM := &infrastructure.CloudVirtualMachine{}
+	cloudVM.Spec.ForProvider.Rescue = &infrastructure.CloudVirtualMachineRescue{
+		Enabled:    true,
+		PublicKeys: []string{testPublicKeyA},
+	}
+
+	out := &bytes.Buffer{}
+	cmd := cloudVMCmd{}
+	cmd.Writer = format.NewWriter(out)
+	cmd.SSHKeysFromFiles = []*os.File{nil}
+
+	is.NoError(cmd.applyUpdates(cloudVM))
+	is.Equal(
+		&infrastructure.CloudVirtualMachineRescue{Enabled: true, PublicKeys: []string{testPublicKeyA}},
+		cloudVM.Spec.ForProvider.Rescue,
+	)
+	is.Empty(out.String())
+}

--- a/update/cloudvm.go
+++ b/update/cloudvm.go
@@ -3,8 +3,6 @@ package update
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	infrastructure "github.com/ninech/apis/infrastructure/v1alpha1"
@@ -17,18 +15,20 @@ import (
 
 type cloudVMCmd struct {
 	ResourceCmd
-	MachineType               string            `placeholder:"nine-standard-1" help:"Defines the sizing for a particular CloudVM."`
-	Hostname                  string            `placeholder:"" help:"Configures the hostname explicitly. If unset, the name of the resource will be used as the hostname. This does not affect the DNS name."`
-	ReverseDNS                string            `placeholder:"" help:"Allows to set the reverse DNS of the CloudVM."`
-	OS                        string            `placeholder:"ubuntu22.04" help:"OS which should be used to boot the VM."`
-	BootDiskSize              string            `placeholder:"20Gi" help:"Configures the size of the boot disk."`
-	Disks                     map[string]string `placeholder:"{}" help:"Additional disks to mount to the machine."`
-	On                        *bool             `help:"Turns the CloudVM on."`
-	Off                       *bool             `help:"Turns the CloudVM off immediately."`
-	Shutdown                  *bool             `help:"Shuts down the CloudVM via ACPI."`
-	BootRescue                *bool             `help:"Boot CloudVM into a live rescue environment."`
-	RescuePublicKeys          *[]string         `placeholder:"ssh-ed25519" help:"SSH public keys that can be used to connect to the CloudVM while booted into rescue. The keys are expected to be in SSH format as defined in RFC4253. Pass the flag without a value to remove all configured keys."`
-	RescuePublicKeysFromFiles []*os.File        `placeholder:"~/.ssh/id_ed25519.pub" completion-predictor:"file" help:"SSH public key files that can be used to connect to the CloudVM while booted into rescue. The keys are expected to be in SSH format as defined in RFC4253."`
+	MachineType          string            `placeholder:"nine-standard-1" help:"Defines the sizing for a particular CloudVM."`
+	Hostname             string            `placeholder:"" help:"Configures the hostname explicitly. If unset, the name of the resource will be used as the hostname. This does not affect the DNS name."`
+	ReverseDNS           string            `placeholder:"" help:"Allows to set the reverse DNS of the CloudVM."`
+	OS                   string            `placeholder:"ubuntu22.04" help:"OS which should be used to boot the VM."`
+	BootDiskSize         string            `placeholder:"20Gi" help:"Configures the size of the boot disk."`
+	Disks                map[string]string `placeholder:"{}" help:"Additional disks to mount to the machine."`
+	On                   *bool             `help:"Turns the CloudVM on."`
+	Off                  *bool             `help:"Turns the CloudVM off immediately."`
+	Shutdown             *bool             `help:"Shuts down the CloudVM via ACPI."`
+	BootRescue           *bool             `help:"Boot CloudVM into a live rescue environment."`
+	OptionalSSHKeysFlags `prefix:"rescue-" set:"ssh_keys_purpose=that can be used to connect to the CloudVM while booted into rescue"`
+
+	// Deprecated Flags
+	create.DeprecatedKeysFlags `prefix:"rescue-public-"`
 }
 
 func (cmd *cloudVMCmd) Run(ctx context.Context, client *api.Client) error {
@@ -130,47 +130,26 @@ func (cmd *cloudVMCmd) applyUpdates(cloudVM *infrastructure.CloudVirtualMachine)
 	return nil
 }
 
-// rescuePublicKeys returns the validated SSH public keys of both
+// rescuePublicKeys returns the validated SSH public keys of --rescue-ssh-keys
+// and --rescue-ssh-keys-from-files, followed by those of the deprecated
 // --rescue-public-keys and --rescue-public-keys-from-files, in that order.
 //
 // set reports whether one of the flags was passed at all. If it is false the
 // keys which are already configured have to be kept, while no keys and set
 // asks for the configured keys to be removed, which is what passing
-// --rescue-public-keys without a value does.
-//
-// A source which holds no key at all is not an error, but it is warned about as
-// it is most likely not what the user intended.
+// --rescue-ssh-keys an empty value does.
 func (cmd *cloudVMCmd) rescuePublicKeys() (keys []string, set bool, err error) {
-	if cmd.RescuePublicKeys != nil {
-		set = true
-
-		inline, err := create.ParseAuthorizedKeys(strings.NewReader(strings.Join(*cmd.RescuePublicKeys, "\n")))
-		if err != nil {
-			return nil, false, fmt.Errorf("error reading --rescue-public-keys: %w", err)
-		}
-		// an empty value is how the keys are removed, only a value which holds
-		// nothing but comments is worth warning about.
-		if len(*cmd.RescuePublicKeys) != 0 && len(inline) == 0 {
-			cmd.Warningf("no SSH public key found in --rescue-public-keys")
-		}
-		keys = append(keys, inline...)
+	keys, err = cmd.OptionalSSHKeysFlags.Keys(&cmd.Writer, "rescue-")
+	if err != nil {
+		return nil, false, err
 	}
 
-	for _, file := range cmd.RescuePublicKeysFromFiles {
-		if file == nil {
-			continue
-		}
-		set = true
-
-		fileKeys, err := create.ParseAuthorizedKeys(file)
-		if err != nil {
-			return nil, false, fmt.Errorf("error reading public keys file %q: %w", file.Name(), err)
-		}
-		if len(fileKeys) == 0 {
-			cmd.Warningf("no SSH public key found in %q", file.Name())
-		}
-		keys = append(keys, fileKeys...)
+	deprecated, err := cmd.DeprecatedKeysFlags.Keys(&cmd.Writer, "rescue-public-", "rescue-")
+	if err != nil {
+		return nil, false, err
 	}
 
-	return keys, set, nil
+	set = cmd.SSHKeysSet() || cmd.Set()
+
+	return append(keys, deprecated...), set, nil
 }

--- a/update/cloudvm.go
+++ b/update/cloudvm.go
@@ -27,7 +27,7 @@ type cloudVMCmd struct {
 	Off                       *bool             `help:"Turns the CloudVM off immediately."`
 	Shutdown                  *bool             `help:"Shuts down the CloudVM via ACPI."`
 	BootRescue                *bool             `help:"Boot CloudVM into a live rescue environment."`
-	RescuePublicKeys          []string          `placeholder:"ssh-ed25519" help:"SSH public keys that can be used to connect to the CloudVM while booted into rescue. The keys are expected to be in SSH format as defined in RFC4253."`
+	RescuePublicKeys          *[]string         `placeholder:"ssh-ed25519" help:"SSH public keys that can be used to connect to the CloudVM while booted into rescue. The keys are expected to be in SSH format as defined in RFC4253. Pass the flag without a value to remove all configured keys."`
 	RescuePublicKeysFromFiles []*os.File        `placeholder:"~/.ssh/id_ed25519.pub" completion-predictor:"file" help:"SSH public key files that can be used to connect to the CloudVM while booted into rescue. The keys are expected to be in SSH format as defined in RFC4253."`
 }
 
@@ -110,11 +110,13 @@ func (cmd *cloudVMCmd) applyUpdates(cloudVM *infrastructure.CloudVirtualMachine)
 		}
 	}
 
-	rescuePublicKeys, err := cmd.rescuePublicKeys()
+	rescuePublicKeys, setRescuePublicKeys, err := cmd.rescuePublicKeys()
 	if err != nil {
 		return err
 	}
-	if len(rescuePublicKeys) != 0 {
+	// there is nothing to remove as long as rescue was never configured, only
+	// allocate it if there are keys to set.
+	if setRescuePublicKeys && (cloudVM.Spec.ForProvider.Rescue != nil || len(rescuePublicKeys) != 0) {
 		if cloudVM.Spec.ForProvider.Rescue == nil {
 			cloudVM.Spec.ForProvider.Rescue = &infrastructure.CloudVirtualMachineRescue{}
 		}
@@ -130,25 +132,39 @@ func (cmd *cloudVMCmd) applyUpdates(cloudVM *infrastructure.CloudVirtualMachine)
 
 // rescuePublicKeys returns the validated SSH public keys of both
 // --rescue-public-keys and --rescue-public-keys-from-files, in that order.
-// A source which holds no key at all is not an error,
-// but it is warned about as it is most likely not what the user intended.
-func (cmd *cloudVMCmd) rescuePublicKeys() ([]string, error) {
-	keys, err := create.ParseAuthorizedKeys(strings.NewReader(strings.Join(cmd.RescuePublicKeys, "\n")))
-	if err != nil {
-		return nil, fmt.Errorf("error reading --rescue-public-keys: %w", err)
-	}
-	if len(cmd.RescuePublicKeys) != 0 && len(keys) == 0 {
-		cmd.Warningf("no SSH public key found in --rescue-public-keys")
+//
+// set reports whether one of the flags was passed at all. If it is false the
+// keys which are already configured have to be kept, while no keys and set
+// asks for the configured keys to be removed, which is what passing
+// --rescue-public-keys without a value does.
+//
+// A source which holds no key at all is not an error, but it is warned about as
+// it is most likely not what the user intended.
+func (cmd *cloudVMCmd) rescuePublicKeys() (keys []string, set bool, err error) {
+	if cmd.RescuePublicKeys != nil {
+		set = true
+
+		inline, err := create.ParseAuthorizedKeys(strings.NewReader(strings.Join(*cmd.RescuePublicKeys, "\n")))
+		if err != nil {
+			return nil, false, fmt.Errorf("error reading --rescue-public-keys: %w", err)
+		}
+		// an empty value is how the keys are removed, only a value which holds
+		// nothing but comments is worth warning about.
+		if len(*cmd.RescuePublicKeys) != 0 && len(inline) == 0 {
+			cmd.Warningf("no SSH public key found in --rescue-public-keys")
+		}
+		keys = append(keys, inline...)
 	}
 
 	for _, file := range cmd.RescuePublicKeysFromFiles {
 		if file == nil {
 			continue
 		}
+		set = true
 
 		fileKeys, err := create.ParseAuthorizedKeys(file)
 		if err != nil {
-			return nil, fmt.Errorf("error reading public keys file %q: %w", file.Name(), err)
+			return nil, false, fmt.Errorf("error reading public keys file %q: %w", file.Name(), err)
 		}
 		if len(fileKeys) == 0 {
 			cmd.Warningf("no SSH public key found in %q", file.Name())
@@ -156,5 +172,5 @@ func (cmd *cloudVMCmd) rescuePublicKeys() ([]string, error) {
 		keys = append(keys, fileKeys...)
 	}
 
-	return keys, nil
+	return keys, set, nil
 }

--- a/update/cloudvm.go
+++ b/update/cloudvm.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	infrastructure "github.com/ninech/apis/infrastructure/v1alpha1"
 	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/create"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	res "k8s.io/apimachinery/pkg/api/resource"
@@ -26,7 +28,7 @@ type cloudVMCmd struct {
 	Shutdown                  *bool             `help:"Shuts down the CloudVM via ACPI."`
 	BootRescue                *bool             `help:"Boot CloudVM into a live rescue environment."`
 	RescuePublicKeys          []string          `placeholder:"ssh-ed25519" help:"SSH public keys that can be used to connect to the CloudVM while booted into rescue. The keys are expected to be in SSH format as defined in RFC4253."`
-	RescuePublicKeysFromFiles []string          `placeholder:"~/.ssh/id_ed25519.pub" completion-predictor:"file" help:"SSH public key files that can be used to connect to the CloudVM while booted into rescue. The keys are expected to be in SSH format as defined in RFC4253."`
+	RescuePublicKeysFromFiles []*os.File        `placeholder:"~/.ssh/id_ed25519.pub" completion-predictor:"file" help:"SSH public key files that can be used to connect to the CloudVM while booted into rescue. The keys are expected to be in SSH format as defined in RFC4253."`
 }
 
 func (cmd *cloudVMCmd) Run(ctx context.Context, client *api.Client) error {
@@ -108,20 +110,15 @@ func (cmd *cloudVMCmd) applyUpdates(cloudVM *infrastructure.CloudVirtualMachine)
 		}
 	}
 
-	if len(cmd.RescuePublicKeysFromFiles) != 0 {
-		var keys []string
-		for _, file := range cmd.RescuePublicKeysFromFiles {
-			b, err := os.ReadFile(file)
-			if err != nil {
-				return fmt.Errorf("error reading public key file %q: %w", cmd.RescuePublicKeysFromFiles, err)
-			}
-			keys = append(keys, string(b))
-		}
+	rescuePublicKeys, err := cmd.rescuePublicKeys()
+	if err != nil {
+		return err
+	}
+	if len(rescuePublicKeys) != 0 {
 		if cloudVM.Spec.ForProvider.Rescue == nil {
-			cloudVM.Spec.ForProvider.Rescue = &infrastructure.CloudVirtualMachineRescue{PublicKeys: keys}
-		} else {
-			cloudVM.Spec.ForProvider.Rescue.PublicKeys = keys
+			cloudVM.Spec.ForProvider.Rescue = &infrastructure.CloudVirtualMachineRescue{}
 		}
+		cloudVM.Spec.ForProvider.Rescue.PublicKeys = rescuePublicKeys
 	}
 
 	if cmd.ReverseDNS != "" {
@@ -129,4 +126,35 @@ func (cmd *cloudVMCmd) applyUpdates(cloudVM *infrastructure.CloudVirtualMachine)
 	}
 
 	return nil
+}
+
+// rescuePublicKeys returns the validated SSH public keys of both
+// --rescue-public-keys and --rescue-public-keys-from-files, in that order.
+// A source which holds no key at all is not an error,
+// but it is warned about as it is most likely not what the user intended.
+func (cmd *cloudVMCmd) rescuePublicKeys() ([]string, error) {
+	keys, err := create.ParseAuthorizedKeys(strings.NewReader(strings.Join(cmd.RescuePublicKeys, "\n")))
+	if err != nil {
+		return nil, fmt.Errorf("error reading --rescue-public-keys: %w", err)
+	}
+	if len(cmd.RescuePublicKeys) != 0 && len(keys) == 0 {
+		cmd.Warningf("no SSH public key found in --rescue-public-keys")
+	}
+
+	for _, file := range cmd.RescuePublicKeysFromFiles {
+		if file == nil {
+			continue
+		}
+
+		fileKeys, err := create.ParseAuthorizedKeys(file)
+		if err != nil {
+			return nil, fmt.Errorf("error reading public keys file %q: %w", file.Name(), err)
+		}
+		if len(fileKeys) == 0 {
+			cmd.Warningf("no SSH public key found in %q", file.Name())
+		}
+		keys = append(keys, fileKeys...)
+	}
+
+	return keys, nil
 }

--- a/update/cloudvm_test.go
+++ b/update/cloudvm_test.go
@@ -130,10 +130,11 @@ func writeKeyFile(t *testing.T, name, content string) string {
 	return path
 }
 
-// TestCloudVMRescuePublicKeys asserts that --rescue-public-keys and
-// --rescue-public-keys-from-files complement each other and that the keys are
-// validated no matter which of the two flags they come from. Inline keys used
-// to be ignored entirely.
+// TestCloudVMRescuePublicKeys asserts that --rescue-ssh-keys and
+// --rescue-ssh-keys-from-files complement each other and that the keys are
+// validated no matter which of the flags they come from. Inline keys used to be
+// ignored entirely. It also covers that the deprecated --rescue-public-keys and
+// --rescue-public-keys-from-files still contribute.
 func TestCloudVMRescuePublicKeys(t *testing.T) {
 	t.Parallel()
 
@@ -145,6 +146,8 @@ func TestCloudVMRescuePublicKeys(t *testing.T) {
 		trailingFile = writeKeyFile(t, "trailing.pub", "  "+testPublicKeyB+"  \n\n")
 	)
 
+	const deprecationWarning = "--rescue-public-keys and --rescue-public-keys-from-files are deprecated, use --rescue-ssh-keys and --rescue-ssh-keys-from-files instead"
+
 	tests := map[string]struct {
 		args     []string
 		rescue   *infrastructure.CloudVirtualMachineRescue
@@ -154,29 +157,33 @@ func TestCloudVMRescuePublicKeys(t *testing.T) {
 	}{
 		"none": {args: nil},
 		"inline": {
-			args: []string{`--rescue-public-keys=` + testPublicKeyA},
+			args: []string{`--rescue-ssh-keys=` + testPublicKeyA},
 			want: &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{testPublicKeyA}},
 		},
 		"file": {
-			args: []string{`--rescue-public-keys-from-files=` + keyFile},
+			args: []string{`--rescue-ssh-keys-from-files=` + keyFile},
 			want: &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{testPublicKeyB}},
 		},
 		"both": {
-			args: []string{`--rescue-public-keys=` + testPublicKeyA, `--rescue-public-keys-from-files=` + keyFile},
+			args: []string{`--rescue-ssh-keys=` + testPublicKeyA, `--rescue-ssh-keys-from-files=` + keyFile},
+			want: &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{testPublicKeyA, testPublicKeyB}},
+		},
+		"multiple inline keys": {
+			args: []string{`--rescue-ssh-keys=` + testPublicKeyA, `--rescue-ssh-keys=` + testPublicKeyB},
 			want: &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{testPublicKeyA, testPublicKeyB}},
 		},
 		"multiple files": {
-			args: []string{`--rescue-public-keys-from-files=` + keyFile, `--rescue-public-keys-from-files=` + trailingFile},
+			args: []string{`--rescue-ssh-keys-from-files=` + keyFile, `--rescue-ssh-keys-from-files=` + trailingFile},
 			want: &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{testPublicKeyB, testPublicKeyB}},
 		},
 		"multiple keys in one file": {
-			args: []string{`--rescue-public-keys-from-files=` + twoKeysFile},
+			args: []string{`--rescue-ssh-keys-from-files=` + twoKeysFile},
 			want: &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{testPublicKeyB, testPublicKeyA}},
 		},
 		// the keys replace the ones which are already set, while everything
 		// else about the rescue configuration is kept.
 		"replaces existing keys": {
-			args:   []string{`--rescue-public-keys=` + testPublicKeyA},
+			args:   []string{`--rescue-ssh-keys=` + testPublicKeyA},
 			rescue: &infrastructure.CloudVirtualMachineRescue{Enabled: true, PublicKeys: []string{testPublicKeyB}},
 			want:   &infrastructure.CloudVirtualMachineRescue{Enabled: true, PublicKeys: []string{testPublicKeyA}},
 		},
@@ -188,39 +195,73 @@ func TestCloudVMRescuePublicKeys(t *testing.T) {
 		// passing the flag without a value is how the keys are removed, the
 		// rest of the rescue configuration is kept.
 		"clears existing keys": {
-			args:   []string{`--rescue-public-keys=`},
+			args:   []string{`--rescue-ssh-keys=`},
 			rescue: &infrastructure.CloudVirtualMachineRescue{Enabled: true, PublicKeys: []string{testPublicKeyB}},
 			want:   &infrastructure.CloudVirtualMachineRescue{Enabled: true},
 		},
 		// nothing to remove, the rescue configuration must not be allocated
 		// just to hold no keys.
 		"clears keys of an unconfigured rescue": {
-			args: []string{`--rescue-public-keys=`},
+			args: []string{`--rescue-ssh-keys=`},
 			want: nil,
 		},
 		"clears before adding": {
-			args:   []string{`--rescue-public-keys=`, `--rescue-public-keys-from-files=` + keyFile},
+			args:   []string{`--rescue-ssh-keys=`, `--rescue-ssh-keys-from-files=` + keyFile},
 			rescue: &infrastructure.CloudVirtualMachineRescue{Enabled: true, PublicKeys: []string{testPublicKeyA}},
 			want:   &infrastructure.CloudVirtualMachineRescue{Enabled: true, PublicKeys: []string{testPublicKeyB}},
 		},
 		// a source may hold nothing but comments, that is only worth a warning.
 		"file without keys": {
-			args:     []string{`--rescue-public-keys=` + testPublicKeyA, `--rescue-public-keys-from-files=` + emptyFile},
+			args:     []string{`--rescue-ssh-keys=` + testPublicKeyA, `--rescue-ssh-keys-from-files=` + emptyFile},
 			want:     &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{testPublicKeyA}},
 			wantWarn: `no SSH public key found in "` + emptyFile + `"`,
 		},
 		"inline without keys": {
-			args:     []string{`--rescue-public-keys=# a comment`, `--rescue-public-keys-from-files=` + keyFile},
+			args:     []string{`--rescue-ssh-keys=# a comment`, `--rescue-ssh-keys-from-files=` + keyFile},
 			want:     &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{testPublicKeyB}},
-			wantWarn: "no SSH public key found in --rescue-public-keys",
+			wantWarn: "no SSH public key found in --rescue-ssh-keys",
 		},
 		"invalid inline key": {
+			args:    []string{`--rescue-ssh-keys=not a key`},
+			wantErr: "error reading --rescue-ssh-keys: invalid SSH public key on line 1",
+		},
+		"file with an invalid key": {
+			args:    []string{`--rescue-ssh-keys-from-files=` + invalidFile},
+			wantErr: "invalid SSH public key on line 1",
+		},
+		// the deprecated flags keep working, they are merged after the keys of
+		// the flags which replace them.
+		"deprecated inline": {
+			args:     []string{`--rescue-public-keys=` + testPublicKeyA},
+			want:     &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{testPublicKeyA}},
+			wantWarn: deprecationWarning,
+		},
+		"deprecated file": {
+			args:     []string{`--rescue-public-keys-from-files=` + keyFile},
+			want:     &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{testPublicKeyB}},
+			wantWarn: deprecationWarning,
+		},
+		"deprecated and current": {
+			args:     []string{`--rescue-public-keys=` + testPublicKeyB, `--rescue-ssh-keys=` + testPublicKeyA},
+			want:     &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{testPublicKeyA, testPublicKeyB}},
+			wantWarn: deprecationWarning,
+		},
+		// the deprecated flags never gained the ability to clear the keys,
+		// passing one without a value keeps what is configured.
+		"deprecated inline without a value keeps existing keys": {
+			args:   []string{`--rescue-public-keys=`},
+			rescue: &infrastructure.CloudVirtualMachineRescue{Enabled: true, PublicKeys: []string{testPublicKeyB}},
+			want:   &infrastructure.CloudVirtualMachineRescue{Enabled: true, PublicKeys: []string{testPublicKeyB}},
+		},
+		"invalid deprecated inline key": {
 			args:    []string{`--rescue-public-keys=not a key`},
 			wantErr: "error reading --rescue-public-keys: invalid SSH public key on line 1",
 		},
-		"file with an invalid key": {
-			args:    []string{`--rescue-public-keys-from-files=` + invalidFile},
-			wantErr: "invalid SSH public key on line 1",
+		// commas separate the options of an authorized_keys line, they must not
+		// be mistaken for a separator between keys.
+		"inline key with options": {
+			args: []string{`--rescue-ssh-keys=restrict,pty ` + testPublicKeyA},
+			want: &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{`restrict,pty ` + testPublicKeyA}},
 		},
 	}
 	for name, tt := range tests {

--- a/update/cloudvm_test.go
+++ b/update/cloudvm_test.go
@@ -185,6 +185,24 @@ func TestCloudVMRescuePublicKeys(t *testing.T) {
 			rescue: &infrastructure.CloudVirtualMachineRescue{Enabled: true, PublicKeys: []string{testPublicKeyB}},
 			want:   &infrastructure.CloudVirtualMachineRescue{Enabled: true, PublicKeys: []string{testPublicKeyB}},
 		},
+		// passing the flag without a value is how the keys are removed, the
+		// rest of the rescue configuration is kept.
+		"clears existing keys": {
+			args:   []string{`--rescue-public-keys=`},
+			rescue: &infrastructure.CloudVirtualMachineRescue{Enabled: true, PublicKeys: []string{testPublicKeyB}},
+			want:   &infrastructure.CloudVirtualMachineRescue{Enabled: true},
+		},
+		// nothing to remove, the rescue configuration must not be allocated
+		// just to hold no keys.
+		"clears keys of an unconfigured rescue": {
+			args: []string{`--rescue-public-keys=`},
+			want: nil,
+		},
+		"clears before adding": {
+			args:   []string{`--rescue-public-keys=`, `--rescue-public-keys-from-files=` + keyFile},
+			rescue: &infrastructure.CloudVirtualMachineRescue{Enabled: true, PublicKeys: []string{testPublicKeyA}},
+			want:   &infrastructure.CloudVirtualMachineRescue{Enabled: true, PublicKeys: []string{testPublicKeyB}},
+		},
 		// a source may hold nothing but comments, that is only worth a warning.
 		"file without keys": {
 			args:     []string{`--rescue-public-keys=` + testPublicKeyA, `--rescue-public-keys-from-files=` + emptyFile},

--- a/update/cloudvm_test.go
+++ b/update/cloudvm_test.go
@@ -2,15 +2,26 @@ package update
 
 import (
 	"bytes"
+	"io"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/alecthomas/kong"
 	infrastructure "github.com/ninech/apis/infrastructure/v1alpha1"
 	"github.com/ninech/nctl/api"
 	"github.com/ninech/nctl/internal/format"
 	"github.com/ninech/nctl/internal/test"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Valid ed25519 public keys used across the tests of this package.
+const (
+	testPublicKeyA = `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJQQywLL6rNaZTvaomlhlHVvY36Tq7j1yuxJzBHark/V a@example.com`
+	testPublicKeyB = `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3bhEbFGMeJwiB7r2GTr/WLWlxrTG9CxzOTf4fM226g b@example.com`
 )
 
 func TestCloudVM(t *testing.T) {
@@ -91,6 +102,134 @@ func TestCloudVM(t *testing.T) {
 				if !strings.Contains(out.String(), tt.update.Name) {
 					t.Errorf("expected output to contain %q, got: %s", tt.update.Name, out.String())
 				}
+			}
+		})
+	}
+}
+
+// parseCloudVM parses args into a cloudVMCmd the same way the real CLI does,
+// so that Kong's defaults and mappers are exercised.
+func parseCloudVM(t *testing.T, args ...string) *cloudVMCmd {
+	t.Helper()
+
+	cmd := &cloudVMCmd{}
+	_, err := kong.Must(cmd, kong.BindTo(io.Discard, (*io.Writer)(nil))).Parse(args)
+	require.NoError(t, err)
+
+	return cmd
+}
+
+// writeKeyFile writes content to a file in a fresh temporary directory and
+// returns its path.
+func writeKeyFile(t *testing.T, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
+// TestCloudVMRescuePublicKeys asserts that --rescue-public-keys and
+// --rescue-public-keys-from-files complement each other and that the keys are
+// validated no matter which of the two flags they come from. Inline keys used
+// to be ignored entirely.
+func TestCloudVMRescuePublicKeys(t *testing.T) {
+	t.Parallel()
+
+	var (
+		keyFile      = writeKeyFile(t, "id_ed25519.pub", testPublicKeyB+"\n")
+		twoKeysFile  = writeKeyFile(t, "authorized_keys", "# my keys\n"+testPublicKeyB+"\n\n"+testPublicKeyA+"\n")
+		emptyFile    = writeKeyFile(t, "empty.pub", "# no keys in here\n")
+		invalidFile  = writeKeyFile(t, "invalid.pub", "not a key\n")
+		trailingFile = writeKeyFile(t, "trailing.pub", "  "+testPublicKeyB+"  \n\n")
+	)
+
+	tests := map[string]struct {
+		args     []string
+		rescue   *infrastructure.CloudVirtualMachineRescue
+		want     *infrastructure.CloudVirtualMachineRescue
+		wantWarn string
+		wantErr  string
+	}{
+		"none": {args: nil},
+		"inline": {
+			args: []string{`--rescue-public-keys=` + testPublicKeyA},
+			want: &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{testPublicKeyA}},
+		},
+		"file": {
+			args: []string{`--rescue-public-keys-from-files=` + keyFile},
+			want: &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{testPublicKeyB}},
+		},
+		"both": {
+			args: []string{`--rescue-public-keys=` + testPublicKeyA, `--rescue-public-keys-from-files=` + keyFile},
+			want: &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{testPublicKeyA, testPublicKeyB}},
+		},
+		"multiple files": {
+			args: []string{`--rescue-public-keys-from-files=` + keyFile, `--rescue-public-keys-from-files=` + trailingFile},
+			want: &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{testPublicKeyB, testPublicKeyB}},
+		},
+		"multiple keys in one file": {
+			args: []string{`--rescue-public-keys-from-files=` + twoKeysFile},
+			want: &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{testPublicKeyB, testPublicKeyA}},
+		},
+		// the keys replace the ones which are already set, while everything
+		// else about the rescue configuration is kept.
+		"replaces existing keys": {
+			args:   []string{`--rescue-public-keys=` + testPublicKeyA},
+			rescue: &infrastructure.CloudVirtualMachineRescue{Enabled: true, PublicKeys: []string{testPublicKeyB}},
+			want:   &infrastructure.CloudVirtualMachineRescue{Enabled: true, PublicKeys: []string{testPublicKeyA}},
+		},
+		"keeps existing keys when unset": {
+			args:   nil,
+			rescue: &infrastructure.CloudVirtualMachineRescue{Enabled: true, PublicKeys: []string{testPublicKeyB}},
+			want:   &infrastructure.CloudVirtualMachineRescue{Enabled: true, PublicKeys: []string{testPublicKeyB}},
+		},
+		// a source may hold nothing but comments, that is only worth a warning.
+		"file without keys": {
+			args:     []string{`--rescue-public-keys=` + testPublicKeyA, `--rescue-public-keys-from-files=` + emptyFile},
+			want:     &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{testPublicKeyA}},
+			wantWarn: `no SSH public key found in "` + emptyFile + `"`,
+		},
+		"inline without keys": {
+			args:     []string{`--rescue-public-keys=# a comment`, `--rescue-public-keys-from-files=` + keyFile},
+			want:     &infrastructure.CloudVirtualMachineRescue{PublicKeys: []string{testPublicKeyB}},
+			wantWarn: "no SSH public key found in --rescue-public-keys",
+		},
+		"invalid inline key": {
+			args:    []string{`--rescue-public-keys=not a key`},
+			wantErr: "error reading --rescue-public-keys: invalid SSH public key on line 1",
+		},
+		"file with an invalid key": {
+			args:    []string{`--rescue-public-keys-from-files=` + invalidFile},
+			wantErr: "invalid SSH public key on line 1",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			is := require.New(t)
+
+			cloudVM := &infrastructure.CloudVirtualMachine{}
+			cloudVM.Spec.ForProvider.Rescue = tt.rescue
+
+			out := &bytes.Buffer{}
+			cmd := parseCloudVM(t, append([]string{`test-cloudvm`}, tt.args...)...)
+			cmd.Writer = format.NewWriter(out)
+
+			err := cmd.applyUpdates(cloudVM)
+			if tt.wantErr != "" {
+				is.ErrorContains(err, tt.wantErr)
+				return
+			}
+
+			is.NoError(err)
+			is.Equal(tt.want, cloudVM.Spec.ForProvider.Rescue)
+			if tt.wantWarn == "" {
+				is.Empty(out.String())
+			} else {
+				is.Contains(out.String(), tt.wantWarn)
 			}
 		})
 	}

--- a/update/mysql.go
+++ b/update/mysql.go
@@ -3,23 +3,20 @@ package update
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	infra "github.com/ninech/apis/infrastructure/v1alpha1"
 	meta "github.com/ninech/apis/meta/v1alpha1"
 	storage "github.com/ninech/apis/storage/v1alpha1"
 	"github.com/ninech/nctl/api"
-	"github.com/ninech/nctl/create"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type mySQLCmd struct {
 	ResourceCmd
-	MachineType           *string                                 `placeholder:"${mysql_machine_default}" help:"Defines the sizing for a particular MySQL instance. Available types: ${mysql_machine_types}"`
-	AllowedCidrs          *[]meta.IPv4CIDR                        `placeholder:"203.0.113.1/32" help:"Specifies the IP addresses allowed to connect to the instance."`
-	SSHKeys               []storage.SSHKey                        `help:"SSH public keys allowed to connect to the database server in order to up-/download and directly restore database backups."`
-	SSHKeysFile           *os.File                                `completion-predictor:"file" help:"Path to a file containing a list of SSH public keys (see above), separated by newlines. Lines prefixed with # are ignored."`
+	MachineType           *string          `placeholder:"${mysql_machine_default}" help:"Defines the sizing for a particular MySQL instance. Available types: ${mysql_machine_types}"`
+	AllowedCidrs          *[]meta.IPv4CIDR `placeholder:"203.0.113.1/32" help:"Specifies the IP addresses allowed to connect to the instance."`
+	DatabaseSSHKeysFlags  `set:"ssh_keys_purpose=allowed to connect to the database server in order to up-/download and directly restore database backups"`
 	SQLMode               *[]storage.MySQLMode                    `placeholder:"\"MODE1, MODE2, ...\"" help:"Configures the sql_mode setting. Modes affect the SQL syntax MySQL supports and the data validation checks it performs. Defaults to: ${mysql_mode}"`
 	CharacterSetName      *string                                 `placeholder:"${mysql_charset}" help:"Configures the character_set_server variable."`
 	CharacterSetCollation *string                                 `placeholder:"${mysql_collation}" help:"Configures the collation_server variable."`
@@ -43,32 +40,25 @@ func (cmd *mySQLCmd) Run(ctx context.Context, client *api.Client) error {
 			return fmt.Errorf("resource is of type %T, expected %T", current, storage.MySQL{})
 		}
 
-		if cmd.SSHKeysFile != nil {
-			defer cmd.SSHKeysFile.Close()
-
-			keys, err := create.ParseSSHKeys(cmd.SSHKeysFile)
-			if err != nil {
-				return err
-			}
-			cmd.SSHKeys = keys
-		}
-
-		cmd.applyUpdates(mysql)
-		return nil
+		return cmd.applyUpdates(mysql)
 	})
 
 	return upd.Update(ctx)
 }
 
-func (cmd *mySQLCmd) applyUpdates(mysql *storage.MySQL) {
+func (cmd *mySQLCmd) applyUpdates(mysql *storage.MySQL) error {
 	if cmd.MachineType != nil {
 		mysql.Spec.ForProvider.MachineType = infra.NewMachineType(*cmd.MachineType)
 	}
 	if cmd.AllowedCidrs != nil {
 		mysql.Spec.ForProvider.AllowedCIDRs = *cmd.AllowedCidrs
 	}
-	if cmd.SSHKeys != nil {
-		mysql.Spec.ForProvider.SSHKeys = cmd.SSHKeys
+	if cmd.SSHKeysSet() {
+		sshKeys, err := cmd.StorageKeys(&cmd.Writer)
+		if err != nil {
+			return err
+		}
+		mysql.Spec.ForProvider.SSHKeys = sshKeys
 	}
 	if cmd.SQLMode != nil {
 		mysql.Spec.ForProvider.SQLMode = cmd.SQLMode
@@ -91,4 +81,6 @@ func (cmd *mySQLCmd) applyUpdates(mysql *storage.MySQL) {
 	if cmd.KeepDailyBackups != nil {
 		mysql.Spec.ForProvider.KeepDailyBackups = cmd.KeepDailyBackups
 	}
+
+	return nil
 }

--- a/update/mysql_test.go
+++ b/update/mysql_test.go
@@ -55,9 +55,11 @@ func TestMySQL(t *testing.T) {
 			want:   storage.MySQLParameters{SQLMode: &[]storage.MySQLMode{"ALLOW_INVALID_DATES", "STRICT_TRANS_TABLES"}},
 		},
 		{
-			name:   "sshKeys",
-			update: mySQLCmd{SSHKeys: []storage.SSHKey{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJGG5/nnivrW4zLD4ANLclVT3y68GAg6NOA3HpzFLo5e test@test"}},
-			want:   storage.MySQLParameters{SSHKeys: []storage.SSHKey{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJGG5/nnivrW4zLD4ANLclVT3y68GAg6NOA3HpzFLo5e test@test"}},
+			name: "sshKeys",
+			update: mySQLCmd{DatabaseSSHKeysFlags: DatabaseSSHKeysFlags{
+				OptionalSSHKeysFlags: OptionalSSHKeysFlags{SSHKeys: []string{testPublicKeyA}},
+			}},
+			want: storage.MySQLParameters{SSHKeys: []storage.SSHKey{testPublicKeyA}},
 		},
 		{
 			name:   "characterSet",

--- a/update/postgres.go
+++ b/update/postgres.go
@@ -3,24 +3,21 @@ package update
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	infra "github.com/ninech/apis/infrastructure/v1alpha1"
 	meta "github.com/ninech/apis/meta/v1alpha1"
 	storage "github.com/ninech/apis/storage/v1alpha1"
 	"github.com/ninech/nctl/api"
-	"github.com/ninech/nctl/create"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type postgresCmd struct {
 	ResourceCmd
-	MachineType      *string          `placeholder:"${postgres_machine_default}" help:"Defines the sizing for a particular PostgreSQL instance. Available types: ${postgres_machine_types}"`
-	AllowedCidrs     *[]meta.IPv4CIDR `placeholder:"203.0.113.1/32" help:"Specifies the IP addresses allowed to connect to the instance."`
-	SSHKeys          []storage.SSHKey `help:"SSH public keys allowed to connect to the database server in order to up-/download and directly restore database backups."`
-	SSHKeysFile      *os.File         `completion-predictor:"file" help:"Path to a file containing a list of SSH public keys (see above), separated by newlines. Lines prefixed with # are ignored."`
-	KeepDailyBackups *int             `placeholder:"${postgres_backup_retention_days}" help:"Number of daily database backups to keep. Note that setting this to 0, backup will be disabled and existing dumps deleted immediately."`
+	MachineType          *string          `placeholder:"${postgres_machine_default}" help:"Defines the sizing for a particular PostgreSQL instance. Available types: ${postgres_machine_types}"`
+	AllowedCidrs         *[]meta.IPv4CIDR `placeholder:"203.0.113.1/32" help:"Specifies the IP addresses allowed to connect to the instance."`
+	DatabaseSSHKeysFlags `set:"ssh_keys_purpose=allowed to connect to the database server in order to up-/download and directly restore database backups"`
+	KeepDailyBackups     *int `placeholder:"${postgres_backup_retention_days}" help:"Number of daily database backups to keep. Note that setting this to 0, backup will be disabled and existing dumps deleted immediately."`
 }
 
 func (cmd *postgresCmd) Run(ctx context.Context, client *api.Client) error {
@@ -37,34 +34,29 @@ func (cmd *postgresCmd) Run(ctx context.Context, client *api.Client) error {
 			return fmt.Errorf("resource is of type %T, expected %T", current, storage.Postgres{})
 		}
 
-		if cmd.SSHKeysFile != nil {
-			defer cmd.SSHKeysFile.Close()
-
-			keys, err := create.ParseSSHKeys(cmd.SSHKeysFile)
-			if err != nil {
-				return err
-			}
-			cmd.SSHKeys = keys
-		}
-
-		cmd.applyUpdates(postgres)
-		return nil
+		return cmd.applyUpdates(postgres)
 	})
 
 	return upd.Update(ctx)
 }
 
-func (cmd *postgresCmd) applyUpdates(postgres *storage.Postgres) {
+func (cmd *postgresCmd) applyUpdates(postgres *storage.Postgres) error {
 	if cmd.MachineType != nil {
 		postgres.Spec.ForProvider.MachineType = infra.NewMachineType(*cmd.MachineType)
 	}
 	if cmd.AllowedCidrs != nil {
 		postgres.Spec.ForProvider.AllowedCIDRs = *cmd.AllowedCidrs
 	}
-	if cmd.SSHKeys != nil {
-		postgres.Spec.ForProvider.SSHKeys = cmd.SSHKeys
+	if cmd.SSHKeysSet() {
+		sshKeys, err := cmd.StorageKeys(&cmd.Writer)
+		if err != nil {
+			return err
+		}
+		postgres.Spec.ForProvider.SSHKeys = sshKeys
 	}
 	if cmd.KeepDailyBackups != nil {
 		postgres.Spec.ForProvider.KeepDailyBackups = cmd.KeepDailyBackups
 	}
+
+	return nil
 }

--- a/update/postgres_test.go
+++ b/update/postgres_test.go
@@ -38,15 +38,28 @@ func TestPostgres(t *testing.T) {
 		},
 		{
 			name: "sshKeys",
-			update: postgresCmd{
-				SSHKeys: []storage.SSHKey{
-					"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJGG5/nnivrW4zLD4ANLclVT3y68GAg6NOA3HpzFLo5e test@test",
-				},
-			},
+			update: postgresCmd{DatabaseSSHKeysFlags: DatabaseSSHKeysFlags{
+				OptionalSSHKeysFlags: OptionalSSHKeysFlags{SSHKeys: []string{testPublicKeyA}},
+			}},
+			want: storage.PostgresParameters{SSHKeys: []storage.SSHKey{testPublicKeyA}},
+		},
+		{
+			// passing the flag an empty value removes the configured keys, that
+			// is the single empty entry Kong decodes --ssh-keys= into.
+			name:   "sshKeys-cleared",
+			create: storage.PostgresParameters{SSHKeys: []storage.SSHKey{testPublicKeyA}},
+			update: postgresCmd{DatabaseSSHKeysFlags: DatabaseSSHKeysFlags{
+				OptionalSSHKeysFlags: OptionalSSHKeysFlags{SSHKeys: []string{""}},
+			}},
+			want: storage.PostgresParameters{},
+		},
+		{
+			name:   "sshKeys-kept-when-unset",
+			create: storage.PostgresParameters{SSHKeys: []storage.SSHKey{testPublicKeyA}},
+			update: postgresCmd{KeepDailyBackups: new(5)},
 			want: storage.PostgresParameters{
-				SSHKeys: []storage.SSHKey{
-					"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJGG5/nnivrW4zLD4ANLclVT3y68GAg6NOA3HpzFLo5e test@test",
-				},
+				SSHKeys:          []storage.SSHKey{testPublicKeyA},
+				KeepDailyBackups: new(5),
 			},
 		},
 		{


### PR DESCRIPTION
The main customer facing change in this MR is Debian 13 support. It also includes some fixes and improvements:

1. Fixing errors when no key or cloud config file was supplied.
2. Allowing keys from flags and files to be combined.
3. Adding basic key validation.
4. Allowing to clear rescue keys.
5. Aligning SSH key flag names over databases and VMs. Old flag names continue to work.