### PR TITLE
fix(update): do not error for unchanged resources

### DIFF
--- a/update/bucket_test.go
+++ b/update/bucket_test.go
@@ -343,8 +343,9 @@ func TestBucket(t *testing.T) {
 				return &p
 			}(),
 		},
+		// The flags cancel each other out, leaving the spec untouched. Flags
+		// were given, so this is a no-op update rather than a usage error.
 		"lifecycle-policy-no-op": {
-			wantErr: true,
 			flags: []string{
 				"--lifecycle-policy=prefix=tmp/;expire-after-days=7;is-live=true",
 				"--delete-lifecycle-policy=prefix=tmp/",

--- a/update/update.go
+++ b/update/update.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"reflect"
 
+	"github.com/alecthomas/kong"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	infra "github.com/ninech/apis/infrastructure/v1alpha1"
 	"github.com/ninech/nctl/api"
@@ -42,6 +43,10 @@ type Cmd struct {
 type ResourceCmd struct {
 	format.Writer `kong:"-"`
 	Name          string `arg:"" completion-predictor:"resource_name" help:"Name of the resource to update."`
+
+	// flagsProvided reports whether the invocation carried at least one flag
+	// that can change the resource. It is set by AfterApply.
+	flagsProvided bool
 }
 
 // BeforeApply initializes Writer from Kong's bound [io.Writer].
@@ -49,13 +54,41 @@ func (cmd *ResourceCmd) BeforeApply(writer io.Writer) error {
 	return cmd.Writer.BeforeApply(writer)
 }
 
+// AfterApply records whether the invocation carried any update flag, so that
+// [updater.Update] can tell "the user asked for nothing" apart from "the user
+// asked for a state the resource is already in".
+func (cmd *ResourceCmd) AfterApply(kctx *kong.Context) error {
+	// Kong descends into embedded structs when dispatching hooks, so this runs for
+	// every update sub-command embedding [ResourceCmd] without per-command code.
+	// Only the flags of the selected command are inspected: [kong.Context.Flags]
+	// accumulates the flags of every node on the path and would therefore always
+	// report the persistent flags such as --project.
+	node := kctx.Selected()
+	if node == nil {
+		return nil
+	}
+
+	for _, flag := range node.Flags {
+		// Flags carrying a default are skipped. Kong marks a value as set once it has
+		// been assigned by any mechanism, including the default itself, so a defaulted
+		// flag is indistinguishable from one the user passed.
+		if flag.Set && !flag.HasDefault {
+			cmd.flagsProvided = true
+			break
+		}
+	}
+
+	return nil
+}
+
 type updater struct {
 	format.Writer
-	mg          resource.Managed
-	client      *api.Client
-	kind        string
-	updateFunc  updateFunc
-	forceUpdate bool
+	mg            resource.Managed
+	client        *api.Client
+	kind          string
+	updateFunc    updateFunc
+	forceUpdate   bool
+	flagsProvided bool
 }
 
 type updateFunc func(current resource.Managed) error
@@ -66,7 +99,14 @@ func (cmd *ResourceCmd) newUpdater(
 	kind string,
 	f updateFunc,
 ) *updater {
-	return &updater{Writer: cmd.Writer, client: client, mg: mg, kind: kind, updateFunc: f}
+	return &updater{
+		Writer:        cmd.Writer,
+		client:        client,
+		mg:            mg,
+		kind:          kind,
+		updateFunc:    f,
+		flagsProvided: cmd.flagsProvided,
+	}
 }
 
 func (u *updater) Update(ctx context.Context) error {
@@ -88,9 +128,15 @@ func (u *updater) Update(ctx context.Context) error {
 		return err
 	}
 	if !changed && !u.forceUpdate {
-		return cli.ErrorWithContext(fmt.Errorf("no changes detected")).
-			WithExitCode(cli.ExitUsageError).
-			WithSuggestions("use --help to see available flags")
+
+		if !u.flagsProvided {
+			return cli.ErrorWithContext(fmt.Errorf("no flags provided")).
+				WithExitCode(cli.ExitUsageError).
+				WithSuggestions("use --help to see available flags")
+		}
+
+		u.Infof("", "no changes made to %s %q", u.kind, u.mg.GetName())
+		return nil
 	}
 
 	if err := u.client.Update(ctx, u.mg); err != nil {

--- a/update/update_test.go
+++ b/update/update_test.go
@@ -1,0 +1,158 @@
+package update
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"maps"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	apps "github.com/ninech/apis/apps/v1alpha1"
+	infra "github.com/ninech/apis/infrastructure/v1alpha1"
+	storage "github.com/ninech/apis/storage/v1alpha1"
+	"github.com/ninech/nctl/api"
+	"github.com/ninech/nctl/create"
+	"github.com/ninech/nctl/internal/cli"
+	"github.com/ninech/nctl/internal/test"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestUpdateWithoutChanges covers the two ways an update can end up not
+// changing anything. An invocation without any update flag expresses no
+// intent and is a usage error. An invocation whose flags describe the state
+// the resource is already in is a no-op and has to succeed, so that repeating
+// an update from a pipeline stays successful.
+func TestUpdateWithoutChanges(t *testing.T) {
+	t.Parallel()
+
+	const (
+		project     = "test-project"
+		postgres    = "test-postgres"
+		application = "test-application"
+	)
+
+	for name, tc := range map[string]struct {
+		args []string
+		// wantErr is the error the command is expected to return. An empty
+		// value expects the command to succeed.
+		wantErr string
+		// wantOutput is expected in what the command printed.
+		wantOutput string
+		// wantMachineType is the machine type the postgres instance is
+		// expected to have afterwards. An empty value skips the check.
+		wantMachineType string
+		// wantUpdate expects the resource to have been written to the API.
+		wantUpdate bool
+	}{
+		"postgres without flags": {
+			args:            []string{"postgres", postgres},
+			wantErr:         "no flags provided",
+			wantMachineType: infra.MachineTypeNineDBS.String(),
+		},
+		"postgres with a flag matching the current state": {
+			args:            []string{"postgres", postgres, "--machine-type=" + infra.MachineTypeNineDBS.String()},
+			wantOutput:      "no changes made",
+			wantMachineType: infra.MachineTypeNineDBS.String(),
+		},
+		"postgres with a flag changing the current state": {
+			args:            []string{"postgres", postgres, "--machine-type=" + infra.MachineTypeNineDBM.String()},
+			wantOutput:      "updated",
+			wantMachineType: infra.MachineTypeNineDBM.String(),
+			wantUpdate:      true,
+		},
+		// The application command declares flags carrying a default, which
+		// Kong reports as set even when the user does not pass them. They
+		// must not be mistaken for an intent to change the application.
+		"application without flags": {
+			args:    []string{"application", application},
+			wantErr: "no flags provided",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			is := require.New(t)
+
+			existingPostgres := test.Postgres(postgres, project, "nine-es34")
+			existingPostgres.Spec.ForProvider.MachineType = infra.MachineTypeNineDBS
+			existingApplication := &apps.Application{
+				ObjectMeta: metav1.ObjectMeta{Name: application, Namespace: project},
+			}
+
+			apiClient := test.SetupClient(
+				t,
+				test.WithDefaultProject(project),
+				test.WithObjects(existingPostgres, existingApplication),
+			)
+
+			out := &bytes.Buffer{}
+			err := runUpdate(t, apiClient, out, tc.args)
+
+			if tc.wantErr != "" {
+				var cliErr *cli.Error
+				is.ErrorAs(err, &cliErr)
+				// The wrapped error is compared instead of the rendered one,
+				// which carries the display formatting.
+				is.EqualError(cliErr.Err, tc.wantErr)
+				is.Equal(cli.ExitUsageError, cliErr.ExitCode())
+			} else {
+				is.NoError(err)
+			}
+
+			if tc.wantOutput != "" {
+				is.Contains(out.String(), tc.wantOutput)
+			}
+
+			if tc.wantMachineType != "" {
+				updated := &storage.Postgres{}
+				is.NoError(apiClient.Get(t.Context(), api.NamespacedName(postgres, project), updated))
+				is.Equal(tc.wantMachineType, updated.Spec.ForProvider.MachineType.String())
+
+				// The client annotates every resource it writes, which makes
+				// the annotation a reliable probe for whether the update
+				// reached the API at all.
+				if tc.wantUpdate {
+					is.Contains(updated.GetAnnotations(), cli.ManagedByAnnotation)
+				} else {
+					is.NotContains(updated.GetAnnotations(), cli.ManagedByAnnotation)
+				}
+			}
+		})
+	}
+}
+
+// runUpdate parses args and runs the resulting update command the way main
+// does, so that the Kong hooks the commands rely on are applied.
+func runUpdate(t *testing.T, client *api.Client, out io.Writer, args []string) error {
+	t.Helper()
+
+	var root struct {
+		Postgres    postgresCmd    `cmd:"" name:"postgres"`
+		Application applicationCmd `cmd:"" name:"application"`
+	}
+
+	applicationVars, err := create.ApplicationKongVars()
+	if err != nil {
+		t.Fatalf("application kong vars: %s", err)
+	}
+	vars := create.PostgresKongVars()
+	maps.Copy(vars, applicationVars)
+
+	parser := kong.Must(
+		&root,
+		kong.Name("nctl-test"),
+		vars,
+		kong.BindTo(t.Context(), (*context.Context)(nil)),
+		kong.BindTo(out, (*io.Writer)(nil)),
+	)
+
+	kctx, err := parser.Parse(args)
+	if err != nil {
+		t.Fatalf("parse %s: %s", strings.Join(args, " "), err)
+	}
+
+	return kctx.Run(client)
+}


### PR DESCRIPTION
Exit with 0 if no changes were made to a resource, only report usage errors if no flags were provided.

I think we overshot in https://github.com/ninech/nctl/pull/418 whereas we always report an error even if flags are provided but there are just no changes. This MR changes this behavior where as:

1. We do not error, but just report that there were no changes to a resource.
2. We only error if no flags were provided during an update call which doesn't make much sense.

Resolves #439 