### PR TITLE
fix: return empty list for -o yaml when nothing is found

### DIFF
--- a/get/get.go
+++ b/get/get.go
@@ -163,7 +163,7 @@ func (out *output) writeTabRow(project string, row ...string) {
 }
 
 func (out *output) notFound(kind, project string) error {
-	if out.Format == jsonOut {
+	if out.Format == jsonOut || out.Format == yamlOut {
 		out.Printf("[]")
 		return nil
 	}


### PR DESCRIPTION
ticket: [1670](https://gitlab.nine.ch/ninech/platform/mono-infra/-/issues/1670)