### PR TITLE
fix: add debug symbols to avoid error message

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,6 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w
       - -X main.version={{.Version}}
       - -X main.commit={{.Commit}}
       - -X main.date={{.Date}}


### PR DESCRIPTION
This fixes this error message when installing/updating the package in Arch Linux:
```
  -> Entferne unnötige Symbole aus Binär-Dateien und Bibliotheken...
Error while writing index for `/home/dirk/git/aur/nctl-bin/pkg/nctl-bin/usr/bin/nctl': No debugging symbols
gdb-add-index: No index was created for ./usr/bin/nctl
gdb-add-index: [Was there no debuginfo? Was there already an index?]
```
The (better) alternative to this would be to fix it directly in the arch PKGBUILD file:
```
options=('!strip')
```
, but it seems this option is not implemented in goreleaser.